### PR TITLE
fix(messaging): replace React use() with useParams() in conversation page

### DIFF
--- a/app/dashboard/messages/[conversationId]/page.tsx
+++ b/app/dashboard/messages/[conversationId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useEffect, use } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
 import { useAuth } from '@/lib/context/AuthContext';
 import { ProtectedRoute } from '@/lib/auth/protected-route';
 import { MessageThread } from '@/components/messaging/MessageThread';
@@ -11,12 +11,9 @@ import { ArrowLeft, Loader2, User } from 'lucide-react';
 import Link from 'next/link';
 import type { ConversationDetail } from '@/lib/types/api';
 
-interface PageProps {
-  params: Promise<{ conversationId: string }>;
-}
-
-export default function ConversationPage({ params }: PageProps) {
-  const { conversationId } = use(params);
+export default function ConversationPage() {
+  const params = useParams<{ conversationId: string }>();
+  const conversationId = params.conversationId;
   const { user, isCustomer } = useAuth();
   const router = useRouter();
   const [conversation, setConversation] = useState<ConversationDetail | null>(null);


### PR DESCRIPTION
## Summary
- `react@18.2.0` does not export `use`. Calling `use(params)` in `app/dashboard/messages/[conversationId]/page.tsx` threw `TypeError: use is not a function` at render time, which the `app/dashboard/error.tsx` boundary surfaced as "Dashboard error: An unexpected error occurred. Please try again or contact support."
- Customers' POST to `/api/messages` was succeeding (conversation + message rows were written, trigger fired correctly), but they were bounced to the error UI instead of the conversation thread.
- Swap `use(params)` for `useParams()` from `next/navigation` to match every other client-side dynamic page in this codebase (e.g. `app/review/[bookingId]/page.tsx`).

## Test plan
- [ ] Sign in as customer (willpowermc@gmail.com)
- [ ] Open Magic Clean's profile, click Send Message, send a short test message
- [ ] Confirm redirect to `/dashboard/messages/<id>` renders the thread (no dashboard error boundary)
- [ ] Confirm the previously-stuck message from 16:42 UTC today is visible in the thread

## Notes
- API route, RLS, and schema untouched.
- No dependency bumps.
- Existing conversation `d0d7b9fa-7eed-46c2-9065-86b1de22559e` will be reused on next send (existing-conversation branch in the API route handles append).

🤖 Generated with [Claude Code](https://claude.com/claude-code)