### PR TITLE
feat(quote): remove customer PII from quote form, API, and pro view

### DIFF
--- a/app/dashboard/pro/quote-requests/actions.ts
+++ b/app/dashboard/pro/quote-requests/actions.ts
@@ -18,9 +18,12 @@ export interface MarketplaceQuote {
   service_date: string | null;
   frequency: string | null;
   status: string;
-  contact_name: string | null;
-  contact_email: string | null;
-  contact_phone: string | null;
+  /**
+   * Customer's first name only — derived from users.full_name at read time.
+   * Last name, email, phone, and street address are NEVER returned to a pro
+   * pre-acceptance. Per BOC_MARKETPLACE_ARCHITECTURE_v1.1 §4 (Customer Journey).
+   */
+  customer_first_name: string | null;
   cleaner_id: string | null;
   quoted_price: number | null;
   response_message: string | null;
@@ -61,9 +64,41 @@ export async function getMarketplaceQuotes(): Promise<{
       return { success: false, error: 'Your account must be approved to view leads' };
     }
 
-    // Fetch marketplace quotes (RLS now allows this) + own claimed quotes
-    // Using two separate queries to handle both cases
-    const selectCols = 'id, service_type, property_type, property_size, zip_code, city, description, service_date, frequency, status, contact_name, cleaner_id, quoted_price, response_message, responded_at, created_at';
+    // Fetch marketplace quotes (RLS now allows this) + own claimed quotes.
+    // PII (last name, email, phone, street) is NEVER selected here — pro is pre-acceptance.
+    // Customer's first name is derived from users.full_name via JOIN at read time.
+    const selectCols = 'id, service_type, property_type, property_size, zip_code, city, description, service_date, frequency, status, cleaner_id, quoted_price, response_message, responded_at, created_at, customer:users!quote_requests_customer_id_fkey(full_name)';
+
+    type RawRow = {
+      id: string;
+      service_type: string;
+      property_type: string | null;
+      property_size: string | null;
+      zip_code: string;
+      city: string;
+      description: string | null;
+      service_date: string | null;
+      frequency: string | null;
+      status: string;
+      cleaner_id: string | null;
+      quoted_price: number | null;
+      response_message: string | null;
+      responded_at: string | null;
+      created_at: string;
+      customer?: { full_name: string | null } | { full_name: string | null }[] | null;
+    };
+
+    const toFirstName = (row: RawRow): string | null => {
+      const c = Array.isArray(row.customer) ? row.customer[0] : row.customer;
+      const fullName = c?.full_name?.trim();
+      if (!fullName) return null;
+      return fullName.split(/\s+/)[0] || null;
+    };
+
+    const stripCustomer = (row: RawRow): MarketplaceQuote => {
+      const { customer: _customer, ...rest } = row;
+      return { ...rest, customer_first_name: toFirstName(row) };
+    };
 
     // 1. Pending marketplace quotes (cleaner_id IS NULL)
     const { data: marketplaceQuotes, error: mqError } = await supabase
@@ -72,19 +107,21 @@ export async function getMarketplaceQuotes(): Promise<{
       .is('cleaner_id', null)
       .eq('status', 'pending')
       .order('created_at', { ascending: false })
-      .limit(50);
+      .limit(50)
+      .returns<RawRow[]>();
 
     if (mqError) {
       logger.error('Error fetching marketplace quotes', { function: 'getMarketplaceQuotes' }, mqError);
     }
 
-    // 2. Quotes this pro has already claimed/responded to (include contact info)
+    // 2. Quotes this pro has already claimed/responded to (still pre-acceptance — no PII)
     const { data: myQuotes, error: myError } = await supabase
       .from('quote_requests')
-      .select(selectCols + ', contact_email, contact_phone')
+      .select(selectCols)
       .eq('cleaner_id', cleaner.id)
       .order('created_at', { ascending: false })
-      .limit(50);
+      .limit(50)
+      .returns<RawRow[]>();
 
     if (myError) {
       logger.error('Error fetching my quotes', { function: 'getMarketplaceQuotes' }, myError);
@@ -92,9 +129,9 @@ export async function getMarketplaceQuotes(): Promise<{
 
     // Merge (deduplicate by id, my quotes first)
     const myIds = new Set((myQuotes || []).map(q => q.id));
-    const merged = [
-      ...(myQuotes || []),
-      ...(marketplaceQuotes || []).filter(q => !myIds.has(q.id)),
+    const merged: MarketplaceQuote[] = [
+      ...(myQuotes || []).map(stripCustomer),
+      ...(marketplaceQuotes || []).filter(q => !myIds.has(q.id)).map(stripCustomer),
     ];
 
     return { success: true, quotes: merged, cleanerId: cleaner.id };
@@ -141,10 +178,12 @@ export async function respondToQuote(
       return { success: false, error: 'Please include a message with your quote' };
     }
 
-    // Verify the quote is still available (pending, unclaimed)
+    // Verify the quote is still available (pending, unclaimed).
+    // Customer email/name pulled from users table via JOIN at read time —
+    // never read from the contact_* columns on the quote row.
     const { data: quote, error: fetchError } = await supabase
       .from('quote_requests')
-      .select('id, status, cleaner_id, contact_name, contact_email')
+      .select('id, status, cleaner_id, customer_id, customer:users!quote_requests_customer_id_fkey(full_name, email)')
       .eq('id', quoteId)
       .single();
 
@@ -178,14 +217,20 @@ export async function respondToQuote(
       return { success: false, error: 'Failed to submit your quote' };
     }
 
+    // Resolve customer info from the JOIN (legacy rows with no customer_id will be null)
+    const customerJoin = Array.isArray(quote.customer) ? quote.customer[0] : quote.customer;
+    const customerEmail = customerJoin?.email || null;
+    const customerFullName = customerJoin?.full_name || null;
+    const customerFirstName = customerFullName ? customerFullName.split(/\s+/)[0] : null;
+
     // Create notification for the customer (if they have a user account)
     const adminSupabase = createServiceRoleClient();
 
     // Notify customer via email (fire-and-forget)
-    if (quote.contact_email) {
+    if (customerEmail) {
       sendQuoteResponseEmail({
-        to: quote.contact_email,
-        customerName: quote.contact_name || 'Customer',
+        to: customerEmail,
+        customerName: customerFullName || 'Customer',
         businessName: cleaner.business_name,
         quoteAmount: price,
         availabilityDate: availabilityDate || null,
@@ -196,7 +241,7 @@ export async function respondToQuote(
       );
     }
 
-    // Create in-app notification for admin
+    // Create in-app notification for admin (uses first name only, never last name)
     try {
       const { data: adminUsers } = await adminSupabase
         .from('users')
@@ -210,7 +255,7 @@ export async function respondToQuote(
             user_id: admin.id,
             type: 'quote_response',
             title: 'Pro Responded to Quote',
-            message: `${cleaner.business_name} quoted $${price} for ${quote.contact_name || 'a customer'}'s request.`,
+            message: `${cleaner.business_name} quoted $${price} for ${customerFirstName || 'a customer'}'s request.`,
             action_url: '/dashboard/admin',
           });
         }

--- a/app/dashboard/pro/quote-requests/page.tsx
+++ b/app/dashboard/pro/quote-requests/page.tsx
@@ -129,7 +129,7 @@ export default function QuoteRequestsPage() {
       (q.city || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
       (q.zip_code || '').includes(searchTerm) ||
       (q.service_type || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
-      (q.contact_name || '').toLowerCase().includes(searchTerm.toLowerCase());
+      (q.customer_first_name || '').toLowerCase().includes(searchTerm.toLowerCase());
     return matchesFilter && matchesSearch;
   });
 
@@ -299,9 +299,9 @@ export default function QuoteRequestsPage() {
                             )}
                           </div>
 
-                          {/* Customer name */}
+                          {/* Customer first name only — last name, email, phone, and street stay private until acceptance */}
                           <p className="text-lg font-semibold text-gray-900 mb-2">
-                            {quote.contact_name || 'Customer Request'}
+                            {quote.customer_first_name || 'Customer Request'}
                           </p>
 
                           {/* Details grid */}
@@ -339,20 +339,7 @@ export default function QuoteRequestsPage() {
                             </div>
                           )}
 
-                          {/* Contact info (only visible for claimed quotes) */}
-                          {isMine && quote.contact_email && (
-                            <div className="mt-3 p-3 bg-blue-50 rounded-md space-y-1">
-                              <p className="text-sm font-medium text-blue-900">Contact Info</p>
-                              <p className="text-sm text-blue-700">
-                                Email: <a href={`mailto:${quote.contact_email}`} className="underline">{quote.contact_email}</a>
-                              </p>
-                              {quote.contact_phone && (
-                                <p className="text-sm text-blue-700">
-                                  Phone: <a href={`tel:${quote.contact_phone}`} className="underline">{quote.contact_phone}</a>
-                                </p>
-                              )}
-                            </div>
-                          )}
+                          {/* Contact info is hidden pre-acceptance — pro sees email/phone only after the customer accepts the quote (Phase B) */}
 
                           {/* Your response (if already responded) */}
                           {isMine && quote.quoted_price && (

--- a/app/quote-request/actions.ts
+++ b/app/quote-request/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { headers } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
 import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import { sendQuoteConfirmationEmail, sendNewLeadEmail } from '@/lib/email/notifications';
 import { checkRateLimit, RATE_LIMITS } from '@/lib/middleware/rate-limit';
@@ -18,9 +19,6 @@ export interface QuoteRequestData {
   city?: string;
   preferred_date?: string;
   flexibility?: 'exact' | 'flexible' | 'asap';
-  contact_name: string;
-  contact_email: string;
-  contact_phone?: string;
   notes?: string;
   tcpa_user_agent?: string;
 }
@@ -33,11 +31,12 @@ export interface QuoteRequestResult {
 }
 
 /**
- * Submit a public quote request (no auth required).
- * 1. Inserts into quote_requests (marketplace lead, cleaner_id = NULL)
- * 2. Finds approved pros who serve that zip code
+ * Submit an authenticated marketplace quote request.
+ * Customer identity is resolved from the session — contact info is NEVER trusted from the body.
+ * 1. Inserts into quote_requests with customer_id (cleaner_id = NULL, no contact_* PII denormalized)
+ * 2. Finds approved pros who serve that zip code (service-role for cross-customer match)
  * 3. Sends email + in-app notification to each matched pro
- * 4. Sends confirmation email to the customer
+ * 4. Sends confirmation email to the customer (email pulled from users row at send time)
  */
 export async function submitQuoteRequest(
   data: QuoteRequestData
@@ -54,19 +53,36 @@ export async function submitQuoteRequest(
     };
   }
 
-  // Use service-role client to bypass RLS (this is a public form, no auth)
-  const supabase = createServiceRoleClient();
+  // Auth-scoped client (cookie-based) — required so RLS binds to the customer
+  const supabase = await createClient();
+
+  // Service-role client for cross-customer reads (matching pros to a zip code).
+  // Never used to write customer-identifying data.
+  const adminSupabase = createServiceRoleClient();
 
   try {
-    // Validate required fields
-    if (!data.service_type || !data.zip_code || !data.contact_name || !data.contact_email || !data.contact_phone) {
-      return { success: false, error: 'Missing required fields' };
+    // Resolve the customer from the session — never trust the request body for PII
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be signed in to request a quote.' };
     }
 
-    // Validate email format
-    const emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
-    if (!emailRegex.test(data.contact_email)) {
-      return { success: false, error: 'Invalid email format' };
+    // Pull canonical contact info from the users table (read-time JOIN target,
+    // never denormalized into the quote row)
+    const { data: customer, error: customerError } = await supabase
+      .from('users')
+      .select('id, full_name, email')
+      .eq('id', user.id)
+      .single();
+
+    if (customerError || !customer?.email) {
+      logger.error('Failed to resolve customer for quote request', { function: 'submitQuoteRequest', userId: user.id }, customerError);
+      return { success: false, error: 'Could not resolve your account info. Please refresh and try again.' };
+    }
+
+    // Validate required fields (no contact_* required — those come from the session)
+    if (!data.service_type || !data.zip_code) {
+      return { success: false, error: 'Missing required fields' };
     }
 
     // Validate zip code format
@@ -92,12 +108,14 @@ export async function submitQuoteRequest(
     const description = descriptionParts.length > 0 ? descriptionParts.join(' | ') : null;
 
     // ============================================
-    // STEP 1: Insert marketplace lead (cleaner_id = NULL)
+    // STEP 1: Insert marketplace lead (cleaner_id = NULL, no contact_* PII)
     // ============================================
+    // RLS policy quote_requests_customers_insert_own enforces customer_id = auth.uid().
     const now = new Date().toISOString();
     const { data: quote, error: insertError } = await supabase
       .from('quote_requests')
       .insert({
+        customer_id: user.id,
         service_type: data.service_type,
         property_type: data.property_type || 'home',
         property_size: propertySize,
@@ -106,9 +124,6 @@ export async function submitQuoteRequest(
         description,
         service_date: data.preferred_date || null,
         address: '',
-        contact_name: data.contact_name,
-        contact_email: data.contact_email,
-        contact_phone: data.contact_phone || null,
         status: 'pending',
         tcpa_consent_at: now,
         tcpa_consent_ip: ip,
@@ -132,8 +147,8 @@ export async function submitQuoteRequest(
     let matchedPros: { cleaner_id: string; user_id: string; email: string; business_name: string }[] = [];
 
     try {
-      // Primary match: service_areas table
-      const { data: areaMatches } = await supabase
+      // Primary match: service_areas table (service-role: cross-customer read)
+      const { data: areaMatches } = await adminSupabase
         .from('service_areas')
         .select('cleaner_id, cleaner:cleaners!inner(id, business_name, user_id, approval_status, user:users!inner(email))')
         .eq('zip_code', data.zip_code);
@@ -159,7 +174,7 @@ export async function submitQuoteRequest(
       // Fallback: if no service_areas match, find all approved cleaners
       // (early stage — not many pros have set up service areas yet)
       if (matchedPros.length === 0) {
-        const { data: allApproved } = await supabase
+        const { data: allApproved } = await adminSupabase
           .from('cleaners')
           .select('id, business_name, user_id, user:users!inner(email)')
           .eq('approval_status', 'approved');
@@ -193,9 +208,9 @@ export async function submitQuoteRequest(
     const location = data.city ? `${data.city}, ${data.zip_code}` : data.zip_code;
 
     for (const pro of matchedPros) {
-      // In-app notification
+      // In-app notification (service-role: writing to a different user's notifications row)
       try {
-        await supabase.from('notifications').insert({
+        await adminSupabase.from('notifications').insert({
           user_id: pro.user_id,
           type: 'new_lead',
           title: 'New Quote Request!',
@@ -220,11 +235,11 @@ export async function submitQuoteRequest(
     }
 
     // ============================================
-    // STEP 4: Send confirmation email to customer
+    // STEP 4: Send confirmation email to customer (info pulled from session, not body)
     // ============================================
     sendQuoteConfirmationEmail({
-      to: data.contact_email,
-      customerName: data.contact_name,
+      to: customer.email,
+      customerName: customer.full_name || 'Customer',
       quoteId: quote.id,
       matchCount: matchedPros.length,
     }).catch((err) =>

--- a/app/quote-request/page.tsx
+++ b/app/quote-request/page.tsx
@@ -9,9 +9,6 @@ import {
   ArrowLeft,
   Home,
   Sparkles,
-  Phone,
-  Mail,
-  User,
   Square,
   Bath,
   Bed,
@@ -74,9 +71,6 @@ export default function QuoteRequestPage() {
     city: '',
     preferred_date: '',
     flexibility: 'flexible',
-    contact_name: '',
-    contact_email: '',
-    contact_phone: '',
     notes: '',
   });
 
@@ -103,18 +97,6 @@ export default function QuoteRequestPage() {
       case 2:
         return true; // Property details are optional
       case 3:
-        if (!formData.contact_name) {
-          setError('Please enter your name');
-          return false;
-        }
-        if (!formData.contact_email || !/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(formData.contact_email)) {
-          setError('Please enter a valid email address');
-          return false;
-        }
-        if (!formData.contact_phone) {
-          setError('Phone number is required');
-          return false;
-        }
         if (!tcpaConsented) {
           setError('You must agree to the contact consent to submit');
           return false;
@@ -261,7 +243,7 @@ export default function QuoteRequestPage() {
           <div className="flex justify-between text-xs text-gray-600">
             <span>Service</span>
             <span>Property</span>
-            <span>Contact</span>
+            <span>Review</span>
           </div>
         </div>
 
@@ -495,84 +477,15 @@ export default function QuoteRequestPage() {
               </div>
             )}
 
-            {/* Step 3: Contact Information */}
+            {/* Step 3: Review & Consent */}
             {step === 3 && (
               <div className="space-y-6">
                 <div>
                   <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                    How can cleaners reach you?
+                    Review &amp; submit
                   </h2>
 
-                  <div className="space-y-4">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Your Name *
-                      </label>
-                      <div className="relative">
-                        <User className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                        <input
-                          type="text"
-                          value={formData.contact_name}
-                          onChange={(e) => handleInputChange('contact_name', e.target.value)}
-                          placeholder="John Smith"
-                          className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        />
-                      </div>
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Email Address *
-                      </label>
-                      <div className="relative">
-                        <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                        <input
-                          type="email"
-                          value={formData.contact_email}
-                          onChange={(e) => handleInputChange('contact_email', e.target.value)}
-                          placeholder="john@example.com"
-                          className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        />
-                      </div>
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Phone Number *
-                      </label>
-                      <div className="relative">
-                        <Phone className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                        <input
-                          type="tel"
-                          value={formData.contact_phone}
-                          onChange={(e) => handleInputChange('contact_phone', e.target.value)}
-                          placeholder="(555) 123-4567"
-                          required
-                          className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        />
-                      </div>
-                    </div>
-
-                    {/* TCPA 2025 one-to-one consent */}
-                    <div className="flex items-start gap-3 pt-2">
-                      <input
-                        id="quote-tcpa-consent"
-                        type="checkbox"
-                        checked={tcpaConsented}
-                        onChange={(e) => setTcpaConsented(e.target.checked)}
-                        className="mt-1 h-4 w-4 shrink-0 rounded border-gray-300 accent-blue-600"
-                        required
-                      />
-                      <label htmlFor="quote-tcpa-consent" className="text-xs text-gray-600 leading-snug">
-                        I agree to be contacted by the independent service professional(s) who respond to this quote, via phone call, text, and email at the information provided. I understand Boss of Clean will share my contact info with those professionals only. Consent is not a condition of purchase. Msg &amp; data rates may apply. Reply STOP to opt out. See{' '}
-                        <a href="/privacy" className="underline hover:text-gray-900">Privacy Policy</a>
-                        {' '}and{' '}
-                        <a href="/terms" className="underline hover:text-gray-900">Terms</a>.
-                      </label>
-                    </div>
-                  </div>
-
-                  <div className="mt-6 bg-gray-50 border border-gray-200 rounded-lg p-4">
+                  <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
                     <h4 className="font-medium text-gray-900 mb-2">Your Quote Request Summary</h4>
                     <dl className="text-sm space-y-1">
                       <div className="flex justify-between">
@@ -604,9 +517,27 @@ export default function QuoteRequestPage() {
                     </dl>
                   </div>
 
-                  <p className="text-xs text-gray-500 mt-4">
-                    Your contact info is only shared with home service professionals who respond to your quote request.
-                  </p>
+                  <div className="mt-4 bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-900">
+                    Your name, email, phone, and street address stay private. They are only shared with a pro after you accept that pro&apos;s quote.
+                  </div>
+
+                  {/* TCPA 2025 one-to-one consent */}
+                  <div className="flex items-start gap-3 pt-4">
+                    <input
+                      id="quote-tcpa-consent"
+                      type="checkbox"
+                      checked={tcpaConsented}
+                      onChange={(e) => setTcpaConsented(e.target.checked)}
+                      className="mt-1 h-4 w-4 shrink-0 rounded border-gray-300 accent-blue-600"
+                      required
+                    />
+                    <label htmlFor="quote-tcpa-consent" className="text-xs text-gray-600 leading-snug">
+                      I agree that, after I accept a pro&apos;s quote, that pro may contact me via phone call, text, and email using the contact info on my Boss of Clean account. Consent is not a condition of purchase. Msg &amp; data rates may apply. Reply STOP to opt out. See{' '}
+                      <a href="/privacy" className="underline hover:text-gray-900">Privacy Policy</a>
+                      {' '}and{' '}
+                      <a href="/terms" className="underline hover:text-gray-900">Terms</a>.
+                    </label>
+                  </div>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
Pay-on-Acceptance requires customer PII (last name, email, phone, street) stay private until the customer accepts a pro's quote. The quote flow was leaking it three places — UI form, server-action insert, and pro listing. Closed end-to-end in one commit.

### Customer form (`app/quote-request/page.tsx`)
- Drop Name / Email / Phone inputs + their validation. Step 3 is Review + TCPA consent only.
- Updated copy: contact info shared only after the customer accepts a quote.

### Server action (`app/quote-request/actions.ts`)
- Auth required. `customer_id` resolved from `auth.getUser()` (cookie-bound `createClient` with `await`).
- Insert with `customer_id`; **stops writing** `contact_name` / `contact_email` / `contact_phone`. RLS policy `quote_requests_customers_insert_own` enforces `customer_id = auth.uid()`.
- Customer email + name pulled from `public.users` at send time (read-time JOIN, not denormalized).
- Service-role client retained only for cross-customer reads (matching pros to a zip, writing pro notifications).

### Pro view (`app/dashboard/pro/quote-requests/{actions,page}.tsx`)
- Stops selecting `contact_name` / `contact_email` / `contact_phone`.
- JOINs `users` via `customer_id` and derives `customer_first_name` (whitespace split, first token only).
- Drops the email/phone display block on claimed-but-pre-acceptance quotes.
- `respondToQuote` pulls customer email/full_name via JOIN, not from `contact_*`. Admin notification uses first name only.

### Schema
DB columns `contact_name` / `contact_email` / `contact_phone` remain (3 legacy rows). Scheduled to be dropped in a follow-up migration.

## Test plan
- [ ] Sign in as customer (willpowermc@gmail.com)
- [ ] Click Get Free Quotes
- [ ] Confirm form does NOT ask for name, email, or phone
- [ ] Submit a quote request
- [ ] Sign in as pro (Magic Clean)
- [ ] Open the new lead — pro can see first name, ZIP, project details, photos
- [ ] Pro CANNOT see last name, email, phone, street address

## Notes
- No RLS, Stripe, or messaging changes.
- No DB column drops in this commit.
- `getQuoteStatus` (legacy lookup) left untouched — still falls back to `contact_email` for the 3 legacy rows; new rows have `customer_id` set and the customer is signed in anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)