### PR TITLE
fix(messages): close PII filter bypass on organic conversations

### DIFF
--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -5,7 +5,7 @@ import { sendNewMessageEmail } from '@/lib/email/new-message';
 import { rateLimitRoute, RATE_LIMITS } from '@/lib/middleware/rate-limit';
 import { createLogger } from '@/lib/utils/logger';
 import { notifyProNewMessage, notifyCustomerQuoteReceived, sendSMSIfEnabled } from '@/lib/sms/notifications';
-import { filterPII, hashContent } from '@/lib/pii-filter';
+import { filterPII } from '@/lib/pii-filter';
 
 const logger = createLogger({ file: 'api/messages/route' });
 
@@ -261,12 +261,18 @@ export async function POST(request: NextRequest) {
   }
 
   // PII filter — check before inserting
+  //
+  // Gating rule:
+  //   - Customers are NEVER unlocked. Their messages always go through the filter.
+  //   - Pros are unlocked ONLY when the conversation has a quote_request_id AND
+  //     this pro has a paid lead_unlock for that quote.
+  //   - Default is "filtered" — organic direct conversations (quote_request_id IS NULL)
+  //     stay filtered for both sides, which closes the lead-bypass channel.
   {
-    // Determine if this conversation's lead has been unlocked (paid)
-    let isUnlocked = true // default ON (customers are never gated)
+    let isUnlocked = false
 
     if (!isCustomer && actualConversationId) {
-      // Fetch conversation's quote_request_id + cleaner_id
+      // Pro path: only an organic-paid lead unlocks the filter for this pro.
       const { data: conv } = await supabase
         .from('conversations')
         .select('quote_request_id, cleaner_id')
@@ -274,7 +280,6 @@ export async function POST(request: NextRequest) {
         .single()
 
       if (conv?.quote_request_id) {
-        // Conversation originated from a lead — check unlock status
         const { data: unlock } = await supabase
           .from('lead_unlocks')
           .select('id')
@@ -286,24 +291,29 @@ export async function POST(request: NextRequest) {
 
         isUnlocked = !!unlock
       }
-      // If quote_request_id is NULL: organic direct conversation → filter off
+      // If quote_request_id is NULL: organic conversation → stays filtered.
     }
+    // Customers fall through with isUnlocked = false (no exceptions).
 
     const piiResult = filterPII(content.trim(), isUnlocked)
 
     if (piiResult.blocked) {
-      // Log the attempt (non-blocking, service-role to bypass RLS)
-      const srClient = createServiceRoleClient()
-      hashContent(content.trim()).then(hash => {
-        srClient.from('pii_filter_log').insert({
+      // Audit log (service-role to bypass RLS).
+      // Failure must NOT block the 422 response, but it MUST be visible in logs.
+      try {
+        const srClient = createServiceRoleClient()
+        const { error: logError } = await srClient.from('pii_filter_log').insert({
           conversation_id: actualConversationId,
           sender_id: user.id,
-          sender_role: isCustomer ? 'customer' : 'cleaner',
-          content_hash: hash,
-          pattern_hit: piiResult.patternHit!,
-          is_unlocked: isUnlocked,
-        }).catch(() => {}) // fire-and-forget
-      })
+          blocked_content: content.trim(),
+          matched_pattern: piiResult.patternHit!,
+        })
+        if (logError) {
+          console.error('[pii-filter] Failed to write audit log entry:', logError.message)
+        }
+      } catch (err) {
+        console.error('[pii-filter] Audit log insert threw:', err)
+      }
 
       return NextResponse.json(
         { error: piiResult.message ?? 'To share contact info, unlock this lead first.' },

--- a/lib/pii-filter.ts
+++ b/lib/pii-filter.ts
@@ -81,6 +81,33 @@ export function filterPII(content: string, isUnlocked: boolean): PiiFilterResult
 }
 
 /**
+ * Scrub-only helper: replaces every PII match in `content` with a redaction
+ * marker and returns the rewritten string plus the patterns that hit.
+ *
+ * Used for back-filling pre-existing messages that were saved before the
+ * server-side filter was active. Does NOT make a block/allow decision —
+ * unlike filterPII, this is purely a transformation.
+ */
+export function scrubText(content: string): { scrubbed: string; matches: string[] } {
+  const matches: string[] = []
+  let scrubbed = content
+
+  for (const { name, re } of PII_PATTERNS) {
+    // PII_PATTERNS are non-global; build a global twin for replaceAll-style behavior.
+    const globalRe = new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g')
+    if (globalRe.test(scrubbed)) {
+      matches.push(name)
+      scrubbed = scrubbed.replace(
+        new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g'),
+        '[redacted]'
+      )
+    }
+  }
+
+  return { scrubbed, matches }
+}
+
+/**
  * Simple hex SHA-256 of content (for log — no plain text stored).
  * Uses Web Crypto available in Node 18+ / Edge runtime.
  */

--- a/scripts/scrub-leaked-pii.js
+++ b/scripts/scrub-leaked-pii.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * One-shot cleanup: scrub PII from messages on a single conversation.
+ *
+ * Why this exists: the server-side PII filter (lib/pii-filter.ts) had a
+ * gating bug that let pro→customer messages through on conversations with
+ * quote_request_id IS NULL. This pre-fix backfill scrubs a single known
+ * conversation's history before the new gating goes live.
+ *
+ * The regex patterns below MIRROR lib/pii-filter.ts PII_PATTERNS exactly.
+ * If you change one, change both.
+ *
+ * Run once:
+ *   node --env-file=.env.local scripts/scrub-leaked-pii.js
+ *
+ * Required env: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ */
+
+const { createClient } = require('@supabase/supabase-js');
+
+const TARGET_CONVERSATION = 'd0d7b9fa-7eed-46c2-9065-86b1de22559e';
+
+// Mirror of lib/pii-filter.ts PII_PATTERNS — same order, same expressions.
+const PII_PATTERNS = [
+  { name: 'phone_number',   re: /(\+?1[\s.-]?)?\(?\d{3}\)?[\s.\-]?\d{3}[\s.\-]?\d{4}/ },
+  { name: 'email_address',  re: /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/ },
+  { name: 'zelle',          re: /\bzelle\b/i },
+  { name: 'venmo',          re: /\bvenmo\b/i },
+  { name: 'cash_app',       re: /\bcash\s*app\b|\$[a-zA-Z][a-zA-Z0-9_]{1,19}/i },
+  { name: 'paypal',         re: /\bpaypal\b/i },
+  { name: 'contact_phrase', re: /\b(call me at|text me at|my number is|reach me at|contact me at|my phone is|my cell is)\b/i },
+  { name: 'whatsapp',       re: /\bwhatsapp\b|\bwa\.me\b/i },
+];
+
+function scrubText(content) {
+  const matches = [];
+  let scrubbed = content;
+  for (const { name, re } of PII_PATTERNS) {
+    const flags = re.flags.includes('g') ? re.flags : re.flags + 'g';
+    const globalRe = new RegExp(re.source, flags);
+    if (globalRe.test(scrubbed)) {
+      matches.push(name);
+      scrubbed = scrubbed.replace(new RegExp(re.source, flags), '[redacted]');
+    }
+  }
+  return { scrubbed, matches };
+}
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+
+  const supabase = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+  const { data, error } = await supabase
+    .from('messages')
+    .select('id, sender_role, content, created_at')
+    .eq('conversation_id', TARGET_CONVERSATION)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error('Failed to load messages:', error.message);
+    process.exit(1);
+  }
+
+  const rows = data || [];
+  console.log(`Loaded ${rows.length} message(s) for conversation ${TARGET_CONVERSATION}\n`);
+
+  let scrubbed = 0;
+  let clean = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    const result = scrubText(row.content);
+    if (result.scrubbed === row.content) {
+      console.log(`[clean] ${row.id} (${row.sender_role}): "${row.content}"`);
+      clean++;
+      continue;
+    }
+
+    console.log(`[scrub] ${row.id} (${row.sender_role})`);
+    console.log(`  patterns: ${result.matches.join(', ')}`);
+    console.log(`  before:   ${row.content}`);
+    console.log(`  after:    ${result.scrubbed}`);
+
+    const { error: updateError } = await supabase
+      .from('messages')
+      .update({ content: result.scrubbed })
+      .eq('id', row.id);
+
+    if (updateError) {
+      console.error(`  FAILED:   ${updateError.message}`);
+      failed++;
+    } else {
+      scrubbed++;
+    }
+  }
+
+  console.log(`\nDone. clean=${clean}  scrubbed=${scrubbed}  failed=${failed}`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
A pro could open a conversation from the cleaner profile (no `quote_request_id`) and freely send contact info — the filter defaulted `isUnlocked = true` on organic chats and exempted customers entirely. This PR flips the default and fixes the silently-failing audit log.

## Gating change (`app/api/messages/route.ts`)
- Default `isUnlocked = false`. Filter runs on every conversation by default.
- **Customers**: never unlocked, no exceptions.
- **Pros**: unlocked only when `quote_request_id IS NOT NULL` AND that pro has a `paid` `lead_unlocks` row for that quote. Organic chats stay filtered.

## Audit-log fix (`app/api/messages/route.ts`)
- Was inserting columns that don't exist (`sender_role`, `content_hash`, `pattern_hit`, `is_unlocked`) and swallowing failure with `.catch(() => {})`.
- Switched to the real columns (`conversation_id`, `sender_id`, `blocked_content`, `matched_pattern`), wrapped in try/catch, and any failure now hits `console.error` (visible in Netlify logs). Failure still doesn't block the 422 rejection.
- Removed unused `hashContent` import.

## Scrub-only helper (`lib/pii-filter.ts`)
- Added `scrubText(content)` for back-fill. Distinct from `filterPII` (which makes a block/allow decision).

## One-shot cleanup (`scripts/scrub-leaked-pii.js`)
- Already executed against production. Cleaner message containing email + phone in conversation `d0d7b9fa-…` is now `[redacted]` in the DB. Two customer messages were already clean and untouched.

## Test plan
- [ ] Sign in as customer (willpowermc@gmail.com), open the existing Magic Clean conversation. Confirm previously-leaked pro PII shows `[redacted]`.
- [ ] Customer sends `Call me at 555-123-4567` → 422, message NOT saved.
- [ ] Customer sends `I have 3 bedrooms, 1500 sq ft, $200 budget` → sends.
- [ ] Sign in as pro (Magic Clean). Send `My number is 407-555-1234` → 422, NOT saved.
- [ ] Pro sends `Available next Saturday morning, $245 for 3-4 hr deep clean` → sends.
- [ ] `SELECT count(*) FROM pii_filter_log WHERE created_at > now() - interval '5 minutes'` returns > 0 after the blocked attempts.

## Notes
- No DB schema, RLS, payment, or UI changes.
- Frontend yellow-banner block deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)