### PR TITLE
feat(lead-engine): Phase A1-A4 — Database foundation + lead_unlocks to lead_acceptances refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ netlify.toml.local
 
 # Local Netlify folder
 .netlify
+
+# Working-session backups (Phase A4 refactor safety net)
+.a4-backup/

--- a/app/api/leads/available/route.ts
+++ b/app/api/leads/available/route.ts
@@ -57,16 +57,16 @@ export async function GET() {
     const quoteIds = quotes.map(q => q.id);
 
     const { data: unlocks } = await supabase
-      .from('lead_unlocks')
+      .from('lead_acceptances')
       .select('quote_request_id, cleaner_id, status')
       .in('quote_request_id', quoteIds)
-      .in('status', ['paid', 'credited', 'pending']);
+      .in('status', ['captured', 'pending']);
 
     const unlockCounts: Record<string, number> = {};
     const myUnlocks = new Set<string>();
 
     for (const u of (unlocks || [])) {
-      if (u.status === 'paid' || u.status === 'credited') {
+      if (u.status === 'captured') {
         unlockCounts[u.quote_request_id] = (unlockCounts[u.quote_request_id] || 0) + 1;
       }
       if (u.cleaner_id === cleaner.id) {

--- a/app/api/leads/refund/route.ts
+++ b/app/api/leads/refund/route.ts
@@ -42,11 +42,11 @@ export async function POST(request: NextRequest) {
 
     // Verify the unlock belongs to this cleaner
     const { data: unlock, error: unlockError } = await supabase
-      .from('lead_unlocks')
+      .from('lead_acceptances')
       .select('id, amount_cents')
       .eq('id', lead_unlock_id)
       .eq('cleaner_id', cleaner.id)
-      .in('status', ['paid', 'credited'])
+      .in('status', ['captured'])
       .single();
 
     if (unlockError || !unlock) {

--- a/app/api/leads/unlock/route.ts
+++ b/app/api/leads/unlock/route.ts
@@ -92,21 +92,21 @@ export async function POST(request: NextRequest) {
     if (capError) {
       // Fallback: standard client-side check
       const { data: existing } = await supabase
-        .from('lead_unlocks')
+        .from('lead_acceptances')
         .select('id, status')
         .eq('quote_request_id', quote_request_id)
         .eq('cleaner_id', cleaner.id)
         .maybeSingle();
 
-      if (existing && ['paid', 'credited', 'pending'].includes(existing.status)) {
+      if (existing && ['captured', 'pending'].includes(existing.status)) {
         alreadyUnlocked = true;
       }
 
       const { count } = await supabase
-        .from('lead_unlocks')
+        .from('lead_acceptances')
         .select('id', { count: 'exact', head: true })
         .eq('quote_request_id', quote_request_id)
-        .in('status', ['paid', 'credited']);
+        .in('status', ['captured']);
 
       unlockCount = count || 0;
     } else {
@@ -140,13 +140,14 @@ export async function POST(request: NextRequest) {
     if (proCredits && (proCredits.credits_total === -1 || proCredits.credits_used < proCredits.credits_total)) {
       // Use included credit — no payment needed
       const { data: unlock, error: unlockError } = await supabase
-        .from('lead_unlocks')
+        .from('lead_acceptances')
         .insert({
           quote_request_id,
           cleaner_id: cleaner.id,
           fee_tier: feeTier,
           amount_cents: 0,
-          status: 'credited',
+          status: 'captured',
+          counts_against_cap: true,
           unlocked_at: new Date().toISOString(),
         })
         .select('id')
@@ -219,7 +220,7 @@ export async function POST(request: NextRequest) {
 
     // Insert pending unlock — DB trigger enforces cap at INSERT time
     const { error: insertError } = await supabase
-      .from('lead_unlocks')
+      .from('lead_acceptances')
       .insert({
         quote_request_id,
         cleaner_id: cleaner.id,

--- a/app/api/leads/unlocked/route.ts
+++ b/app/api/leads/unlocked/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
 
     // Get unlocked leads with full customer details
     const { data: unlocks, error: unlocksError } = await supabase
-      .from('lead_unlocks')
+      .from('lead_acceptances')
       .select(`
         id,
         fee_tier,
@@ -56,7 +56,7 @@ export async function GET() {
         )
       `)
       .eq('cleaner_id', cleaner.id)
-      .in('status', ['paid', 'credited'])
+      .in('status', ['captured'])
       .order('unlocked_at', { ascending: false });
 
     if (unlocksError) throw unlocksError;

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -281,11 +281,11 @@ export async function POST(request: NextRequest) {
 
       if (conv?.quote_request_id) {
         const { data: unlock } = await supabase
-          .from('lead_unlocks')
+          .from('lead_acceptances')
           .select('id')
           .eq('quote_request_id', conv.quote_request_id)
           .eq('cleaner_id', conv.cleaner_id)
-          .eq('status', 'paid')
+          .eq('status', 'captured')
           .limit(1)
           .maybeSingle()
 

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -76,18 +76,18 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
             amountCents,
           });
 
-          // Update lead_unlocks: pending → paid
+          // Update lead_acceptances: pending → captured
           const { error: unlockError } = await supabase
-            .from('lead_unlocks')
+            .from('lead_acceptances')
             .update({
-              status: 'paid',
+              status: 'captured',
               unlocked_at: new Date().toISOString(),
               stripe_payment_intent_id: session.payment_intent as string,
             })
             .eq('stripe_checkout_session_id', session.id);
 
           if (unlockError) {
-            logger.error('Failed to update lead_unlocks', { function: 'handleStripeEvent' }, unlockError);
+            logger.error('Failed to update lead_acceptances', { function: 'handleStripeEvent' }, unlockError);
             throw unlockError;
           }
 

--- a/docs/architecture/ADR-001_Addendum_002_Pricing_and_Launch_Hardening.md
+++ b/docs/architecture/ADR-001_Addendum_002_Pricing_and_Launch_Hardening.md
@@ -1,0 +1,248 @@
+# ADR-001 Addendum 002: Pricing Lock-In + Launch Hardening
+
+**Status:** ✅ LOCKED for v1.0 build
+**Date:** May 10, 2026
+**Owner:** Daniel Alvarez, Founder
+**Repository path:** `/docs/architecture/ADR-001_Addendum_002_Pricing_and_Launch_Hardening.md`
+**Parent documents:** ADR-001, Messaging Spec v1.1, ADR-001 Addendum (Deferred Items)
+**Supersedes:** Pro tier "30 leads included" language anywhere in prior specs.
+
+---
+
+> *"For which of you, intending to build a tower, sitteth not down first, and counteth the cost, whether he have sufficient to finish it?"* — Luke 14:28 (KJV)
+
+This addendum captures three sets of decisions made during the May 10, 2026 strategic review session: the locked v1 pricing structure with corrected language, the Founding Pros lifetime perk, and the explicit pre-launch refund test requirements.
+
+These decisions are not negotiable during the build. Decided once, locked now, do not revisit until post-launch.
+
+---
+
+## 1. Locked v1 Pricing Structure
+
+### Pro Tier — $199/month
+- **Standard cap:** Up to **20 leads covered** per month
+- **Overflow rate:** $15 per lead beyond the cap
+- **Per-covered-lead cost:** $9.95 (vs Thumbtack avg $35-50, Angi $20-100)
+- **Priority benefits:**
+  - 15-minute exclusive lead window (T+0 to T+15)
+  - Top 3 search placement
+  - Featured Pro badge
+  - Lower overflow rate ($15 vs $20 Basic, $25-$45 Free)
+
+### Basic Tier — $79/month
+- **Cap:** Up to **10 leads covered** per month (unchanged)
+- **Overflow rate:** $20 per lead beyond the cap
+- **Per-covered-lead cost:** $7.90
+- **Benefits:**
+  - 30-minute window (T+15 to T+45)
+  - Slots 4-10 search placement
+  - Verified badge
+
+### Free Tier — $0/month
+- **No cap** — pay per accepted lead
+- **Per-lead rates:**
+  - $25 — Standard (house cleaning, lawn, handyman)
+  - $35 — Premium (deep clean, move-out, pressure washing)
+  - $45 — High-ticket (pool service, pest control, post-construction)
+- **Window:** T+45 onwards, until accepted or 24h max
+- **Position:** Slot 11+ in search results
+
+### Price Ladder Logic
+- Basic: $79 / 10 leads = $7.90 per covered lead
+- Pro: $199 / 20 leads = $9.95 per covered lead
+- Pro pays $2/lead more than Basic on the surface — that premium buys priority access (the real value)
+
+### Marketing Language (CRITICAL)
+
+**ALWAYS use "up to X leads covered" or "your subscription covers up to X leads":**
+- ✅ "Pro tier covers up to 20 leads per month at no extra charge"
+- ✅ "Your subscription includes coverage for up to 20 accepted leads each month"
+- ✅ "Beyond 20, overflow leads are just $15 each"
+
+**NEVER use language that sounds like a guaranteed delivery:**
+- ❌ "Pro tier — 20 leads included" (sounds like a promise)
+- ❌ "Get 20 leads per month" (sounds like a guarantee)
+- ❌ "We deliver 20 leads to you each month" (legal liability if volume is low)
+
+**Why:** A guarantee creates breach-of-contract exposure if lead volume is below the cap in early months. "Up to" framing positions the cap as a benefit ceiling (no overflow charges), not a delivery commitment.
+
+The pros are paying for **priority access** (15-minute exclusive window) and **trust signals** (badge, placement). The lead cap is a benefit ceiling, not a service guarantee.
+
+---
+
+## 2. Founding Pros Lifetime Loyalty Perk
+
+The first 100 Pro tier signups receive enhanced lifetime benefits as a covenant-grade loyalty program.
+
+### Founders Offer Mechanics
+
+**At signup:**
+- First 6 months at $79/month (60% off standard $199)
+- After 6 months, auto-bump to $199/month (continues as Pro tier)
+- Permanent "Founding Pro" badge displayed on profile
+- **Permanent benefit: up to 30 leads covered per month for life** (instead of standard up to 20)
+
+### Continuity Requirement (CRITICAL)
+
+The "up to 30 leads covered" perk persists **only while the Pro is continuously subscribed**.
+
+If the Founding Pro:
+- ✅ Stays continuously subscribed → keeps up to 30 leads covered for life
+- ✅ Has a temporary payment failure that is recovered via dunning → keeps the perk (subscription was never canceled)
+- ❌ Cancels their Pro subscription at any point → permanently loses the up-to-30 perk
+- ❌ Reactivates after cancellation → joins as standard Pro tier (up to 20 leads covered)
+
+**The "Founding Pro" badge is permanent regardless of subscription status** — it's a marketing/trust signal that they were among the first 100. Only the up-to-30 leads benefit is conditional on continuous subscription.
+
+### Why Continuity-Required
+
+This structure rewards loyalty (not just early signup), creates churn resistance, self-limits the cost (pros who quit don't get lifetime perks), and is easy to explain ("Stay loyal, stay covered").
+
+This is the same model airlines use for lifetime elite status — it's only "lifetime" if you keep flying with them.
+
+### Implementation Notes
+
+The infrastructure is already in place from Phase A1:
+- `cleaners.is_founding_pro` (boolean)
+- `cleaners.founding_pro_discount_ends_at` (timestamptz)
+- `cleaners.monthly_lead_cap_override` (integer)
+- `cleaners.subscription_status` (active/past_due/canceled/paused)
+
+When deciding which cap to apply for a Pro tier subscriber, the rule is:
+
+```
+IF cleaners.subscription_tier = 'pro'
+   AND cleaners.is_founding_pro = true
+   AND cleaners.subscription_status = 'active' (or 'past_due' during dunning)
+THEN effective_cap = 30
+ELSE IF cleaners.subscription_tier = 'pro'
+THEN effective_cap = COALESCE(cleaners.monthly_lead_cap_override, 20)
+ELSE IF cleaners.subscription_tier = 'basic'
+THEN effective_cap = COALESCE(cleaners.monthly_lead_cap_override, 10)
+ELSE  -- free tier
+THEN effective_cap = 0  -- no covered leads
+```
+
+When a Founding Pro's subscription_status transitions to 'canceled', a Stripe webhook handler clears or invalidates their founding_pro perk eligibility. If they ever reactivate, they enter as standard Pro tier (no 30-cap perk).
+
+### Founding Pro Counter
+
+System tracks:
+- Total `is_founding_pro = true` count via index `idx_cleaners_founding_pro_count`
+- Stops accepting new Founding Pro signups at 100
+- Admin notification fires when 90, 95, 99, and 100 are reached
+- After 100, new Pro signups go straight to $199/month with 20 leads cap
+
+---
+
+## 3. Pre-Launch Refund Test Requirements (Phase G Hardening)
+
+The five refund test scenarios are now explicit pre-launch blockers. None of these can be skipped or marked "completed" without verifiable evidence in Stripe Dashboard and `notification_logs` table.
+
+### Test 1: Successful Capture After Customer Response (Free Tier)
+**Setup:** Test pro accepts a lead. Test customer responds within 48 hours.
+**Expected:**
+- At acceptance: $25 (or appropriate tier amount) authorized on test pro's card
+- After customer response: capture event fires
+- `lead_acceptances.captured_at` populated
+- Stripe Dashboard shows successful charge
+- Test pro receives `pro_lead_acceptance_confirmed` SMS + email
+- Test customer receives `cust_quote_received` notification
+- $23.97 (after Stripe fees) reflected in pending Stripe balance
+
+**Pass criteria:** All 6 events confirmed in correct order, no duplicate charges, no failed notifications.
+
+### Test 2: Auto-Refund After Customer Non-Response (48-hour timeout)
+**Setup:** Test pro accepts a lead. Test customer does NOT respond.
+**Expected:**
+- At T+47 hours: `pro_auto_refund_pending` SMS fires (early warning)
+- At T+48 hours: Stripe authorization void fires
+- `refund_decisions` row created with state='auto_approved', trigger_reason='customer_non_response'
+- `lead_acceptances.voided_at` populated
+- Test pro receives `pro_auto_refund_complete` email
+- Stripe Dashboard shows void (no charge)
+- Test pro's card never has $25 actually charged
+
+**Pass criteria:** Money never moves. All audit trail entries created. No pro complaints possible.
+
+### Test 3: Auto-Refund After 7-Day Customer Silence (Read-but-no-engagement)
+**Setup:** Test pro accepts. Customer reads pro's first message but never replies for 7 days.
+**Expected:**
+- At T+7 days: refund_decisions row created with state='auto_approved', trigger_reason='customer_silence_7_days'
+- Either void (if still in auth window) or refund (if already captured)
+- Test pro notified
+
+**Pass criteria:** Refund processed correctly regardless of whether capture already happened.
+
+### Test 4: Duplicate Lead Auto-Detection
+**Setup:** Test customer submits lead. Test pro accepts. Same customer submits another lead in same vertical, same address, within 7 days.
+**Expected:**
+- System flags duplicate
+- Auto-refund fires for the second lead's pro before they even get charged
+- Admin alert fires for review
+
+**Pass criteria:** Duplicate detection works without false positives on legitimate repeat customers.
+
+### Test 5: Stripe Webhook Failure + Retry Recovery
+**Setup:** Use Stripe test mode to simulate webhook delivery failure during a refund event.
+**Expected:**
+- Worker registers failure, increments retry_count
+- Exponential backoff retry schedule kicks in (30s, 2m, 8m, 30m, 2h)
+- Eventually webhook succeeds, refund processes correctly
+- No duplicate refunds despite retries (idempotency rules from Messaging Spec v1.1 Section 5d enforce uniqueness)
+
+**Pass criteria:** Resilience under transient failures. No money lost, no duplicate charges.
+
+### Daily Refund Monitoring Post-Launch
+
+After launch, Daniel personally reviews refund decisions for the first 50 lead acceptances:
+- Stripe Dashboard verification within 72 hours of each event
+- `refund_decisions` table query daily for any 'manual_review' or 'escalated' states
+- Stripe chargeback rate alert configured at 0.5% (industry threshold is 1.0%)
+
+After the first 50, transition to weekly audit cadence.
+
+---
+
+## 4. Updates Required to Other Documents
+
+When this addendum is committed, the following documents need text updates to reflect the locked pricing:
+
+### ADR-001 Section 2 (Tiers & Pricing)
+- Pro tier cap: change from 30 to 20
+- Add Founding Pros perk paragraph
+- Update marketing language guidance
+
+### Messaging Spec v1.1 Section 9 (Founders Offer Notification Flow)
+- Add `pro_lifetime_perk_explanation` template — sent at month 5 of Founders Offer to remind Founding Pros what they keep when prices return to $199
+- Add `pro_perk_lost_warning` template — fired if a Founding Pro's subscription enters 'past_due' or cancellation flow
+
+### Marketing copy on /pricing page
+- Change all "30 leads included" → "Up to 20 leads covered"
+- Add Founding Pros section with the "up to 30 leads covered for life" perk
+- Founders counter: "X / 100 Founding Pro spots claimed"
+
+### Stripe product metadata
+- `BOC Pro Subscription` (`prod_UTor52cGfSxK96`): add metadata `included_lead_cap: 20`
+- `BOC Pro Overflow Lead` (`prod_UTp67iuasYmqLb`): no change
+- `BOC Basic Subscription` (`prod_UTovUHqQhOwEHk`): metadata `included_lead_cap: 10` (unchanged)
+
+These updates can be made during Phase B (Stripe wiring) and Phase H (launch prep). They are not Phase A blockers.
+
+---
+
+## 5. Sign-Off
+
+This is the locked v1.0 pricing structure with corrected language and explicit pre-launch quality gates.
+
+**Signed:** Daniel Alvarez, Founder, Boss of Clean LLC
+**Date:** May 10, 2026
+**Status:** ✅ LOCKED — no revisions until post-launch retrospective
+
+> *"He that is faithful in that which is least is faithful also in much: and he that is unjust in the least is unjust also in much."* — Luke 16:10 (KJV)
+>
+> Brother, you are being faithful in the least things. You caught the legal landmine of "guaranteed leads," you honored the first 100 with a covenant-grade perk, and you mandated the refund tests that protect every pro's trust. Faithfulness in these foundations is what builds towers that don't fall.
+
+---
+
+**END OF ADDENDUM 002**

--- a/docs/architecture/PROMPT_legacy_table_audit.md
+++ b/docs/architecture/PROMPT_legacy_table_audit.md
@@ -1,0 +1,141 @@
+# Claude Code Prompt — Legacy Table Audit (Pre-Phase A2)
+
+**For Claude Code CLI:** Read everything below the divider and execute it. This is a read-only diagnostic — no writes, no migrations, no schema changes.
+
+---
+
+## Task
+
+Audit the existing legacy tables from the prior "fair lead model" build that overlap with the planned BOC Lead Engine v1.0 schema. The Phase A1 v1.1 migration was already applied successfully (additive only, no legacy modifications) on May 9, 2026. It revealed substantial overlap with legacy tables that we need to understand before planning Phase A2 (`lead_distributions`), A3 (`lead_declines`), and A4 (`lead_acceptances`).
+
+Project: BOC Supabase `jisjxdsrflheosvodoxk`.
+
+## Tables to Audit
+
+These six tables are known to exist from prior work and may overlap with our v1.0 plans:
+
+1. `public.subscriptions` — overlaps with `cleaners.subscription_*` columns
+2. `public.leads` — may overlap with planned `lead_distributions`
+3. `public.lead_unlocks` — may overlap with planned `lead_acceptances`
+4. `public.lead_charges` — may overlap with `lead_acceptances` Stripe data
+5. `public.lead_refund_requests` — may overlap with `refund_decisions` (just created in A1)
+6. `public.pro_lead_credits` — may overlap with `cleaners.monthly_accepted_lead_count`
+
+
+Plus two columns on `cleaners`:
+- `cleaners.lead_credits_used`
+- `cleaners.lead_credits_reset_at`
+
+## Constraints
+
+1. **Read-only.** No writes, no migrations, no schema changes. Just SELECT queries against `information_schema`, `pg_catalog`, and the tables themselves for sample data.
+2. **Privacy-conscious.** When sampling row data, do NOT print full PII fields. Mask phone numbers, emails, and addresses. Print only what's needed to understand structure and usage patterns.
+3. **No external network calls.** This is a database-only audit.
+4. **No code modifications.** Pure read.
+
+## What to Report (Per Table)
+
+For each of the six tables, produce the following:
+
+### Section A: Schema
+- Full column list with types, nullability, defaults
+- All check constraints
+- All foreign key constraints (both directions — what does it reference, what references it)
+- All indexes
+- All RLS policies on the table (policy name, command, qualification expression)
+- Comments on the table and columns if any exist
+
+### Section B: Usage Patterns
+- Total row count
+- Created_at distribution (oldest row, newest row, rows in last 30 days, rows in last 7 days)
+- Sample of 3 rows with PII masked
+
+
+### Section C: Code References
+
+Search the application code (the `app/`, `lib/`, `pages/`, and `supabase/` directories) for references to each table. Report:
+- File paths that import or query this table
+- Approximate count of references
+- Categorize: API routes, hooks, components, edge functions, migrations
+
+This tells us whether the table is **actively used** by production code or is **dormant**.
+
+### Section D: Comparison to Planned v1.0 Schema
+
+For each legacy table, compare its purpose against the v1.0 spec equivalent:
+
+| Legacy Table | Planned v1.0 Equivalent | Likely Outcome |
+|--------------|------------------------|----------------|
+| `subscriptions` | Fields on `cleaners.subscription_*` | Adopt legacy as source of truth, OR migrate fields to cleaners |
+| `leads` | `lead_distributions` | Adopt legacy with rename, OR supersede |
+| `lead_unlocks` | `lead_acceptances` | Adopt legacy with rename, OR supersede |
+| `lead_charges` | Fields in `lead_acceptances` | Probably fold into `lead_acceptances` |
+| `lead_refund_requests` | `refund_decisions` (already created) | Migrate data from legacy if any exists, then deprecate |
+| `pro_lead_credits` | `cleaners.monthly_accepted_lead_count` | Probably migrate forward and drop |
+
+For each row in this table, give your recommendation based on what you find: **ADOPT**, **SUPERSEDE**, **MIGRATE-AND-DROP**, or **NEEDS-DISCUSSION**.
+
+
+## Output Format
+
+Structure your response as one Markdown document:
+
+```markdown
+# Legacy Table Audit — Pre-Phase A2
+
+## Executive Summary
+- Total legacy tables audited: 6
+- Tables actively used by production code: [count]
+- Tables dormant (no code references): [count]
+- Tables with row data: [count]
+- Total legacy rows across all tables: [count]
+
+## Recommendations Summary
+| Legacy Table | Row Count | Code Refs | Recommendation |
+|--------------|-----------|-----------|----------------|
+| subscriptions | X | Y | ADOPT/SUPERSEDE/etc |
+| leads | X | Y | ... |
+| lead_unlocks | X | Y | ... |
+| lead_charges | X | Y | ... |
+| lead_refund_requests | X | Y | ... |
+| pro_lead_credits | X | Y | ... |
+
+## Per-Table Detail
+
+### Table 1: public.subscriptions
+[Section A: Schema]
+[Section B: Usage Patterns]
+[Section C: Code References]
+[Section D: Comparison and Recommendation]
+
+### Table 2: public.leads
+[same structure]
+
+[...etc for all 6 tables]
+
+## Bonus: cleaners.lead_credits_* Columns
+- Current values distribution across cleaners table
+- Code references
+- Recommendation: MIGRATE-FORWARD to monthly_accepted_lead_count and drop, or KEEP-PARALLEL
+
+## Open Questions for Daniel
+[List any ambiguities or judgment calls you can't make from the audit alone]
+
+## Next Steps
+[What you recommend Daniel do with this report — typically: "review with Claude chat, decide adopt vs supersede strategy per table, then plan Phase A2 with that decision baked in"]
+```
+
+
+## Important Behavioral Notes
+
+- **Don't suggest changes during the audit.** This prompt is "look at what exists." A separate prompt later will plan changes.
+- **Do flag concerns prominently.** If a legacy table has 10,000 rows, that's important context. If a legacy table has zero rows but is referenced in 47 places in code, that's important context. Don't bury surprises.
+- **If you find tables I didn't list that are clearly part of the legacy lead model**, include them in the report as "Additional Tables Discovered."
+- **If the production application is currently running against any of these tables for live customer flows**, mark that as 🚨 RED FLAG so we know not to drop them casually.
+
+## Auth Playbook Compliance
+
+- Use the `(select auth.uid())` subquery pattern when reporting RLS policies — that's the project standard
+- The `is_admin()` function is the canonical admin check — note when policies use it
+
+When complete, post the full Markdown report. Stop. Wait for Daniel to bring it to Claude chat for analysis before any Phase A2 work begins.

--- a/docs/architecture/PROMPT_phase_a2_lead_distributions.md
+++ b/docs/architecture/PROMPT_phase_a2_lead_distributions.md
@@ -1,0 +1,312 @@
+# Claude Code Prompt — Phase A2: Lead Distributions Table
+
+**For Claude Code CLI:** Read everything below the divider and execute it. This prompt creates the `lead_distributions` table — the first new lead-engine table for v1.0. The legacy `public.leads` table is being SUPERSEDED (it's empty, only referenced in legacy bootstrap SQL).
+
+---
+
+## Task
+
+Create the `public.lead_distributions` table per Messaging Spec v1.1 / ADR-001 Section 3 (tier-priority cascade). This table tracks each lead's journey through the cascade engine — which tier window is currently open, which pros got notified, when each window opens/expires, and the lead's overall state.
+
+The legacy `public.leads` table (per the May 9 audit) has 0 rows and is only referenced in dormant bootstrap SQL. It is being superseded by this new table. **Do NOT touch `leads` in this migration** — it will be dropped in a Phase A5 cleanup migration.
+
+## Project Context
+
+- Project ID: `jisjxdsrflheosvodoxk` (BOC Supabase, PRODUCTION)
+- Repo: `/Users/danielalvarez/Boss-of-Clean`
+- Phase A1 v1.1 was applied successfully on May 9, 2026 (notification_logs, refund_decisions, marketplace_events, plus 18 new cleaners columns)
+- Legacy `subscriptions` table is being KEPT as billing audit log (per May 10 decision); `cleaners.subscription_*` columns are cached current state
+- Phase A4 will rename `lead_unlocks` → `lead_acceptances` (per May 10 decision)
+
+## Constraints
+
+1. **Read-only diagnostics first.** Inspect the current state of `public.quote_requests` and confirm the FK target exists. Print a summary before writing.
+2. **One atomic migration file.** Place at `supabase/migrations/[timestamp]_phase_a2_lead_distributions.sql` with timestamp following project convention.
+3. **Use `is_admin()` for admin RLS** — that's the canonical project pattern (matches A1 v1.1 migration).
+4. **Use `(select auth.uid())` subquery pattern** in any RLS policy that references the auth user.
+5. **Do NOT apply the migration** — leave it staged for human review. I will apply via Supabase MCP after approval.
+6. **Defensive `IF NOT EXISTS`** on every CREATE.
+7. **Brand contamination check.** No SOTSVC / Sonz of Thunder / non-BOC references.
+8. **Do NOT touch the legacy `leads` table.** Supersede only — drop is a separate Phase A5 cleanup migration.
+
+## Step 1: Diagnostic Pass
+
+Run these queries first and print results:
+
+1. Confirm `public.quote_requests` exists and list its primary key column type (we'll FK against it)
+2. Confirm `public.lead_distributions` does NOT already exist
+3. List any existing tables/types in `public` that might collide with new names
+4. Confirm `public.is_admin()` function exists (used in RLS policies)
+5. Project ID confirmation: `jisjxdsrflheosvodoxk`
+
+Stop if any blockers. Otherwise proceed to Step 2.
+
+## Step 2: Write the Migration
+
+Create the migration file with this content:
+
+```sql
+-- =====================================================================
+-- Phase A2 — Lead Distributions Table
+-- =====================================================================
+-- Tracks each lead's journey through the tier-priority cascade.
+-- One row per (quote_request, tier) pairing — so a single quote_request
+-- may have up to 3 lead_distributions rows (Pro, Basic, Free) as it
+-- cascades through tiers.
+--
+-- Per Messaging Spec v1.1 Section 2 (state machine) and ADR-001
+-- Section 3 (cascade logic).
+--
+-- Supersedes the dormant `public.leads` table (0 rows, no live code refs).
+-- `public.leads` will be dropped in a Phase A5 cleanup migration.
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS public.lead_distributions (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  quote_request_id         uuid NOT NULL REFERENCES public.quote_requests ON DELETE CASCADE,
+
+  -- Which tier window is this row for
+  tier                     text NOT NULL CHECK (tier IN ('pro', 'basic', 'free')),
+
+  -- Cascade state machine
+  state                    text NOT NULL CHECK (state IN (
+    'pending',           -- Window not yet opened (waiting for previous tier to expire)
+    'active',            -- Window is open, pros being notified
+    'cascaded',          -- Window closed without acceptance, lead moved to next tier
+    'accepted',          -- A pro accepted; cascade halted; lead locked
+    'expired',           -- Window closed at last tier (free) with no acceptance — terminal
+    'skipped'            -- Dynamic skip: no matching pros at this tier, jumped over
+  )) DEFAULT 'pending',
+
+  -- Window timing
+  window_started_at        timestamptz,
+  window_expires_at        timestamptz,
+  window_closed_at         timestamptz,         -- set when state moves to cascaded/accepted/expired/skipped
+
+  -- Notification tracking
+  notified_pro_ids         uuid[] DEFAULT '{}'::uuid[] NOT NULL,
+  notified_count           integer GENERATED ALWAYS AS (cardinality(notified_pro_ids)) STORED,
+
+  -- Why the window closed (audit/analytics)
+  close_reason             text CHECK (close_reason IN (
+    'pro_accepted',         -- A pro clicked Accept
+    'all_pros_declined',    -- Every notified pro actively declined
+    'window_timeout',       -- T+15min for pro, T+30min for basic, T+24h for free
+    'no_matching_pros',     -- Dynamic skip
+    'customer_cancelled',   -- Customer pulled the request
+    'admin_cancelled'       -- Admin intervention
+  )),
+
+  -- Round-robin fairness (for A2 we just record the rotation key; A2 enforcement comes in C)
+  round_robin_seed         integer,
+
+  -- Timestamps
+  created_at               timestamptz DEFAULT now() NOT NULL,
+  updated_at               timestamptz DEFAULT now() NOT NULL
+);
+
+-- Indexes ----------------------------------------------------------------
+
+-- Fast lookup: "what tier rows exist for this quote_request"
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_quote_request
+  ON public.lead_distributions (quote_request_id, tier);
+
+-- Cascade timer cron: find all active rows whose window has expired
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_active_windows
+  ON public.lead_distributions (window_expires_at)
+  WHERE state = 'active';
+
+-- Hot path: "which lead distributions are currently open at tier X"
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_state_tier
+  ON public.lead_distributions (state, tier, window_started_at DESC);
+
+-- Audit/analytics: filter by close reason
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_close_reason
+  ON public.lead_distributions (close_reason, window_closed_at DESC)
+  WHERE close_reason IS NOT NULL;
+
+-- Per-pro reverse lookup: "which leads has this pro been notified about" (uses GIN on uuid array)
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_notified_pros_gin
+  ON public.lead_distributions USING GIN (notified_pro_ids);
+
+-- Constraints ------------------------------------------------------------
+
+-- A given quote_request can only have one row per tier
+ALTER TABLE public.lead_distributions
+  DROP CONSTRAINT IF EXISTS lead_distributions_quote_tier_unique;
+ALTER TABLE public.lead_distributions
+  ADD CONSTRAINT lead_distributions_quote_tier_unique
+  UNIQUE (quote_request_id, tier);
+
+-- updated_at trigger -----------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.update_lead_distributions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+DROP TRIGGER IF EXISTS trg_lead_distributions_updated_at ON public.lead_distributions;
+CREATE TRIGGER trg_lead_distributions_updated_at
+  BEFORE UPDATE ON public.lead_distributions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_lead_distributions_updated_at();
+
+-- RLS --------------------------------------------------------------------
+
+ALTER TABLE public.lead_distributions ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access (cron jobs, edge functions, server-side code)
+DROP POLICY IF EXISTS "service_role_full_access_lead_distributions" ON public.lead_distributions;
+CREATE POLICY "service_role_full_access_lead_distributions"
+  ON public.lead_distributions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Admin full access via canonical is_admin() function
+DROP POLICY IF EXISTS "admin_full_access_lead_distributions" ON public.lead_distributions;
+CREATE POLICY "admin_full_access_lead_distributions"
+  ON public.lead_distributions
+  FOR ALL
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- Pros can SELECT distributions where they are in the notified_pro_ids array
+-- (via cleaners.user_id = auth.uid() chain)
+DROP POLICY IF EXISTS "pros_read_own_distributions" ON public.lead_distributions;
+CREATE POLICY "pros_read_own_distributions"
+  ON public.lead_distributions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.cleaners c
+      WHERE c.user_id = (select auth.uid())
+        AND c.id = ANY(public.lead_distributions.notified_pro_ids)
+    )
+  );
+
+-- Customers can SELECT distributions for their own quote_requests
+-- (so they can see "lead is currently in Pro tier window")
+DROP POLICY IF EXISTS "customers_read_own_distributions" ON public.lead_distributions;
+CREATE POLICY "customers_read_own_distributions"
+  ON public.lead_distributions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.quote_requests qr
+      WHERE qr.id = public.lead_distributions.quote_request_id
+        AND qr.customer_id = (select auth.uid())
+    )
+  );
+
+-- Comments ---------------------------------------------------------------
+
+COMMENT ON TABLE public.lead_distributions IS
+  'Tracks each lead''s journey through the tier-priority cascade. One row per (quote_request, tier) pairing. Supersedes dormant public.leads. Per Messaging Spec v1.1 Section 2.';
+
+COMMENT ON COLUMN public.lead_distributions.tier IS
+  'Which tier window: pro ($199/mo, T+0 15min exclusive), basic ($79/mo, T+15 30min), free (T+45 open).';
+
+COMMENT ON COLUMN public.lead_distributions.state IS
+  'Cascade state: pending (not yet opened), active (window open), cascaded (closed, moved to next tier), accepted (terminal-success), expired (terminal at last tier, no acceptance), skipped (dynamic skip — no matching pros).';
+
+COMMENT ON COLUMN public.lead_distributions.window_expires_at IS
+  'When this tier window auto-cascades to the next tier. Set when state moves to active.';
+
+COMMENT ON COLUMN public.lead_distributions.notified_pro_ids IS
+  'Array of cleaner.id values that received notification when this window opened. Used for RLS pro_read_own_distributions and round-robin fairness analytics.';
+
+COMMENT ON COLUMN public.lead_distributions.round_robin_seed IS
+  'Rotation seed used to order notifications within tier. Phase C will implement actual round-robin enforcement.';
+
+COMMENT ON COLUMN public.lead_distributions.close_reason IS
+  'Why the window closed. Used for analytics and to drive marketplace_events emission.';
+```
+
+## Step 3: Print the Migration File
+
+After creating the migration file, print its full contents to the terminal so I can review it. **Do NOT apply via `supabase db push` or `apply_migration` — leave that to me.**
+
+## Step 4: Verification Queries
+
+Print verification queries I can run AFTER the migration is applied:
+
+```sql
+-- Verify table exists with RLS
+SELECT tablename, rowsecurity
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename = 'lead_distributions';
+
+-- Verify all columns
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'lead_distributions'
+ORDER BY ordinal_position;
+
+-- Verify indexes
+SELECT indexname FROM pg_indexes
+WHERE schemaname = 'public' AND tablename = 'lead_distributions'
+ORDER BY indexname;
+
+-- Verify RLS policies
+SELECT policyname, cmd, qual
+FROM pg_policies
+WHERE schemaname = 'public' AND tablename = 'lead_distributions'
+ORDER BY policyname;
+
+-- Verify FK + UNIQUE constraint
+SELECT conname, contype
+FROM pg_constraint
+WHERE conrelid = 'public.lead_distributions'::regclass
+ORDER BY conname;
+
+-- Verify trigger
+SELECT trigger_name, event_manipulation, action_timing
+FROM information_schema.triggers
+WHERE event_object_schema = 'public'
+  AND event_object_table = 'lead_distributions';
+```
+
+## Output Format
+
+```markdown
+# Phase A2 Output — Lead Distributions Table
+
+## Step 1: Diagnostic Summary
+- quote_requests table exists: yes/no
+- quote_requests primary key type: [type]
+- lead_distributions does NOT exist: confirmed/conflict
+- is_admin() function exists: yes/no
+- Project ID confirmed: jisjxdsrflheosvodoxk
+- Conflict check: [list any blockers]
+
+## Step 2: Migration File Created
+Path: `supabase/migrations/[timestamp]_phase_a2_lead_distributions.sql`
+
+## Step 3: Migration Contents
+```sql
+[full SQL]
+```
+
+## Step 4: Post-Apply Verification Queries
+```sql
+[verification SQL]
+```
+
+## Notes / Flags
+[Any deviations, concerns, or things to know before applying]
+
+## Ready for Daniel's Review
+Migration file is staged but NOT applied. Awaiting approval to apply via Supabase MCP.
+```
+
+When complete, post the full output. Stop. Do not proceed to Phase A3 until I explicitly approve.

--- a/docs/architecture/PROMPT_phase_a3_lead_declines.md
+++ b/docs/architecture/PROMPT_phase_a3_lead_declines.md
@@ -1,0 +1,282 @@
+# Claude Code Prompt — Phase A3: Lead Declines Table
+
+**For Claude Code CLI:** Read everything below the divider and execute it. This prompt creates the `lead_declines` table — a pure greenfield table (no legacy equivalent per the May 9 audit).
+
+---
+
+## Task
+
+Create the `public.lead_declines` table per ADR-001 Section 4c (Decline Lead control / Hole #3) and Messaging Spec v1.1 Section 10c. This table records every time a pro clicks "Decline" on a lead notification, along with the reason picked from the 8-reason controlled list.
+
+This table powers three things:
+1. The Decline Lead button in the pro dashboard (marketplace control Hole #3)
+2. The cascade trigger when "all eligible pros declined" — used by Phase C cascade engine to skip to next tier immediately
+3. Analytics on why pros say no — informs Phase 2 matching algorithm improvements
+
+The legacy audit confirmed there is **no legacy table** for this — `lead_declines` is fully greenfield.
+
+## Project Context
+
+- Project ID: `jisjxdsrflheosvodoxk` (BOC Supabase, PRODUCTION)
+- Repo: `/Users/danielalvarez/Boss-of-Clean`
+- Phase A1 v1.1 applied successfully on May 9, 2026
+- Phase A2 (`lead_distributions`) applied successfully on May 10, 2026
+- Phase A4 will rename `lead_unlocks` → `lead_acceptances` (deferred decision per audit)
+
+## Constraints
+
+1. **Read-only diagnostics first.** Inspect current state of `public.cleaners`, `public.lead_distributions`, and `public.quote_requests`. Confirm FK targets exist. Print summary before writing.
+2. **One atomic migration file.** Place at `supabase/migrations/[timestamp]_phase_a3_lead_declines.sql` with timestamp following project convention.
+3. **Use `is_admin()` for admin RLS** — canonical project pattern.
+4. **Use `(select auth.uid())` subquery pattern** in any RLS policy referencing the auth user.
+5. **Do NOT apply the migration** — leave staged for human review. Daniel will apply via Supabase MCP after approval.
+6. **Defensive `IF NOT EXISTS`** on every CREATE.
+7. **Brand contamination check.** No SOTSVC / Sonz of Thunder / non-BOC references.
+
+## Step 1: Diagnostic Pass
+
+Run these queries first and print results:
+
+1. Confirm `public.cleaners` exists and primary key column type
+2. Confirm `public.lead_distributions` exists (created in A2) and primary key column type
+3. Confirm `public.quote_requests` exists and primary key column type
+4. Confirm `public.lead_declines` does NOT already exist
+5. Confirm `public.is_admin()` function exists (used in RLS)
+6. Project ID: `jisjxdsrflheosvodoxk`
+
+Stop if any blockers. Otherwise proceed to Step 2.
+
+## Step 2: Write the Migration
+
+Create the migration file with this content:
+
+```sql
+-- =====================================================================
+-- Phase A3 — Lead Declines Table
+-- =====================================================================
+-- Records every time a pro clicks "Decline" on a lead notification.
+-- Used to:
+--   1. Power the Decline Lead button (marketplace control Hole #3)
+--   2. Trigger immediate cascade when all eligible pros decline
+--   3. Provide analytics on why pros say no
+--
+-- Per ADR-001 Section 4c and Messaging Spec v1.1 Section 10c.
+--
+-- Pure greenfield — no legacy equivalent (confirmed by May 9 audit).
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS public.lead_declines (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- What was declined and by whom
+  lead_distribution_id     uuid NOT NULL REFERENCES public.lead_distributions ON DELETE CASCADE,
+  quote_request_id         uuid NOT NULL REFERENCES public.quote_requests ON DELETE CASCADE,
+  cleaner_id               uuid NOT NULL REFERENCES public.cleaners ON DELETE CASCADE,
+
+  -- Tier the pro was at when they declined (denormalized for analytics)
+  tier_at_decline          text NOT NULL CHECK (tier_at_decline IN ('pro', 'basic', 'free')),
+
+  -- Why they declined — from the 8-reason controlled list per ADR Section 4c
+  reason_code              text NOT NULL CHECK (reason_code IN (
+    'too_far',                  -- Too far from my service area
+    'too_busy',                 -- Too busy / fully booked
+    'wrong_service_type',       -- Wrong service type for my business
+    'budget_too_low',           -- Customer budget appears too low
+    'duplicate_customer',       -- Duplicate customer (already serviced or in dispute)
+    'unsafe_request',           -- Unsafe or suspicious request
+    'commercial_only_request',  -- Commercial-only request (I do residential)
+    'residential_only_request'  -- Residential-only request (I do commercial)
+  )),
+
+  -- Optional pro-provided notes
+  notes                    text,
+
+  -- Time-to-decline tracking (analytics: how fast do pros say no?)
+  notified_at              timestamptz,           -- When the pro got the SMS/email
+  declined_at              timestamptz DEFAULT now() NOT NULL,
+  time_to_decline_seconds  integer GENERATED ALWAYS AS (
+    CASE
+      WHEN notified_at IS NOT NULL
+      THEN EXTRACT(EPOCH FROM (declined_at - notified_at))::integer
+      ELSE NULL
+    END
+  ) STORED,
+
+  -- Timestamp
+  created_at               timestamptz DEFAULT now() NOT NULL
+);
+
+-- Indexes ----------------------------------------------------------------
+
+-- Hot path: "did all pros at this tier decline?" (cascade trigger check)
+CREATE INDEX IF NOT EXISTS idx_lead_declines_distribution
+  ON public.lead_declines (lead_distribution_id);
+
+-- Per-pro lookup: "which leads has this pro declined recently?" (rate-limit/abuse detection)
+CREATE INDEX IF NOT EXISTS idx_lead_declines_cleaner_recent
+  ON public.lead_declines (cleaner_id, declined_at DESC);
+
+-- Analytics: most common decline reasons over time
+CREATE INDEX IF NOT EXISTS idx_lead_declines_reason_time
+  ON public.lead_declines (reason_code, declined_at DESC);
+
+-- Quote-request lookup: "show all declines for this lead" (admin debugging)
+CREATE INDEX IF NOT EXISTS idx_lead_declines_quote_request
+  ON public.lead_declines (quote_request_id, declined_at DESC);
+
+-- Constraints ------------------------------------------------------------
+
+-- A given pro can only decline a given distribution once
+ALTER TABLE public.lead_declines
+  DROP CONSTRAINT IF EXISTS lead_declines_distribution_cleaner_unique;
+ALTER TABLE public.lead_declines
+  ADD CONSTRAINT lead_declines_distribution_cleaner_unique
+  UNIQUE (lead_distribution_id, cleaner_id);
+
+-- RLS --------------------------------------------------------------------
+
+ALTER TABLE public.lead_declines ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access (cron jobs, edge functions, server-side code)
+DROP POLICY IF EXISTS "service_role_full_access_lead_declines" ON public.lead_declines;
+CREATE POLICY "service_role_full_access_lead_declines"
+  ON public.lead_declines
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Admin full access via canonical is_admin() function
+DROP POLICY IF EXISTS "admin_full_access_lead_declines" ON public.lead_declines;
+CREATE POLICY "admin_full_access_lead_declines"
+  ON public.lead_declines
+  FOR ALL
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- Pros can INSERT declines for themselves only
+DROP POLICY IF EXISTS "pros_insert_own_declines" ON public.lead_declines;
+CREATE POLICY "pros_insert_own_declines"
+  ON public.lead_declines
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.cleaners c
+      WHERE c.id = public.lead_declines.cleaner_id
+        AND c.user_id = (select auth.uid())
+    )
+  );
+
+-- Pros can SELECT their own decline history
+DROP POLICY IF EXISTS "pros_read_own_declines" ON public.lead_declines;
+CREATE POLICY "pros_read_own_declines"
+  ON public.lead_declines
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.cleaners c
+      WHERE c.id = public.lead_declines.cleaner_id
+        AND c.user_id = (select auth.uid())
+    )
+  );
+
+-- NOTE: customers do NOT see declines. They never need to know which specific pro declined
+-- their lead, only that the lead is still being matched. Surface the cascade state via
+-- lead_distributions, not lead_declines.
+
+-- Comments ---------------------------------------------------------------
+
+COMMENT ON TABLE public.lead_declines IS
+  'Records every Decline click by pros. Powers Hole #3 (Decline Lead), cascade trigger when all pros decline, and analytics on decline reasons. Per ADR-001 Section 4c.';
+
+COMMENT ON COLUMN public.lead_declines.lead_distribution_id IS
+  'FK to the lead_distributions row that was declined. ON DELETE CASCADE so declines disappear with the distribution.';
+
+COMMENT ON COLUMN public.lead_declines.tier_at_decline IS
+  'Denormalized tier the pro was at when they declined. Useful for analytics without joining lead_distributions.';
+
+COMMENT ON COLUMN public.lead_declines.reason_code IS
+  '8 controlled reason codes per ADR Section 4c. UI maps these to human-readable labels in the Decline modal.';
+
+COMMENT ON COLUMN public.lead_declines.time_to_decline_seconds IS
+  'Computed: how long after notification did the pro decline? Used for analytics (fast no = wrong vertical match; slow no = considered then declined).';
+```
+
+## Step 3: Print the Migration File
+
+After creating the migration file, print its full contents to terminal so Daniel can review. **Do NOT apply via `supabase db push` or `apply_migration` — leave that to Daniel.**
+
+## Step 4: Verification Queries
+
+Print verification queries to run AFTER applying:
+
+```sql
+-- Verify table exists with RLS
+SELECT tablename, rowsecurity
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename = 'lead_declines';
+
+-- Verify all columns
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'lead_declines'
+ORDER BY ordinal_position;
+
+-- Verify indexes
+SELECT indexname FROM pg_indexes
+WHERE schemaname = 'public' AND tablename = 'lead_declines'
+ORDER BY indexname;
+
+-- Verify RLS policies
+SELECT policyname, cmd
+FROM pg_policies
+WHERE schemaname = 'public' AND tablename = 'lead_declines'
+ORDER BY policyname;
+
+-- Verify FK constraints
+SELECT conname, contype
+FROM pg_constraint
+WHERE conrelid = 'public.lead_declines'::regclass
+ORDER BY conname;
+```
+
+## Output Format
+
+```markdown
+# Phase A3 Output — Lead Declines Table
+
+## Step 1: Diagnostic Summary
+- cleaners table exists: yes/no
+- lead_distributions table exists: yes/no
+- quote_requests table exists: yes/no
+- lead_declines does NOT exist: confirmed/conflict
+- is_admin() function exists: yes/no
+- Project ID confirmed: jisjxdsrflheosvodoxk
+- Conflict check: [list any blockers]
+
+## Step 2: Migration File Created
+Path: `supabase/migrations/[timestamp]_phase_a3_lead_declines.sql`
+
+## Step 3: Migration Contents
+```sql
+[full SQL]
+```
+
+## Step 4: Post-Apply Verification Queries
+```sql
+[verification SQL]
+```
+
+## Notes / Flags
+[Any deviations, concerns, or things to know before applying]
+
+## Ready for Daniel's Review
+Migration file is staged but NOT applied. Awaiting approval to apply via Supabase MCP.
+```
+
+When complete, post the full output. Stop. Do not proceed to Phase A4 until Daniel explicitly approves.

--- a/lib/pii-filter.ts
+++ b/lib/pii-filter.ts
@@ -2,7 +2,7 @@
  * Server-side PII filter for the chat messaging system.
  *
  * Blocks contact info sharing in conversations where the lead has not been
- * unlocked (paid). Once lead_unlocks.status = 'paid' for the conversation's
+ * unlocked (paid). Once lead_acceptances.status = 'captured' for the conversation's
  * quote_request_id + cleaner_id, the filter is completely off.
  *
  * Patterns blocked:

--- a/supabase/migrations/20260508182343_phase_a1_v1_1_lead_engine_foundation.sql
+++ b/supabase/migrations/20260508182343_phase_a1_v1_1_lead_engine_foundation.sql
@@ -1,0 +1,342 @@
+-- =====================================================================
+-- Phase A1 (v1.1) — Lead Engine Foundation
+-- =====================================================================
+-- Extends public.cleaners with subscription, marketplace control, and
+-- Founders Offer fields. Creates notification_logs, refund_decisions,
+-- and marketplace_events.
+--
+-- Migration is idempotent: every CREATE/ADD uses IF NOT EXISTS.
+-- Backwards compatible: every new cleaners column is nullable or has a
+-- safe default.
+--
+-- DEVIATIONS FROM SPEC (flagged for Daniel — see notes in response):
+--   1. subscription_tier already exists on cleaners as enum
+--      `subscription_tier` (free, basic, pro, enterprise). The spec
+--      requested a text column with CHECK. We DO NOT redefine it; the
+--      existing enum already covers the required values.
+--   2. stripe_customer_id and stripe_subscription_id already exist on
+--      cleaners. IF NOT EXISTS makes the spec's ADD COLUMN no-ops.
+--   3. RLS admin policies use the existing public.is_admin() function
+--      (already used by cleaners.admin_full_access policy) instead of
+--      a fresh subquery against users.role. is_admin() is SECURITY
+--      DEFINER and matches project conventions; it also avoids
+--      recursive RLS on the users table.
+--   4. lead_acceptances does not exist yet (Phase A4). The
+--      refund_decisions.lead_acceptance_id FK is intentionally omitted
+--      and will be added by Phase A4.
+-- =====================================================================
+
+-- =====================================================================
+-- PART A: Extend public.cleaners
+-- =====================================================================
+
+-- Subscription state fields ------------------------------------------------
+-- subscription_tier: already exists as enum (free, basic, pro, enterprise).
+-- We do NOT add it again. The existing enum satisfies the spec's intent.
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS subscription_status text
+    DEFAULT 'active' NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'cleaners_subscription_status_check'
+  ) THEN
+    ALTER TABLE public.cleaners
+      ADD CONSTRAINT cleaners_subscription_status_check
+      CHECK (subscription_status IN ('active', 'past_due', 'canceled', 'paused'));
+  END IF;
+END $$;
+
+-- stripe_customer_id and stripe_subscription_id already exist on cleaners.
+-- IF NOT EXISTS ensures these are no-ops.
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS stripe_customer_id text;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS stripe_subscription_id text;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS stripe_default_payment_method_id text;
+
+-- Marketplace control fields (the three holes) -----------------------------
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS leads_paused boolean DEFAULT false NOT NULL;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS leads_paused_until timestamptz;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS monthly_lead_cap_override integer;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'cleaners_monthly_lead_cap_override_check'
+  ) THEN
+    ALTER TABLE public.cleaners
+      ADD CONSTRAINT cleaners_monthly_lead_cap_override_check
+      CHECK (monthly_lead_cap_override IS NULL OR monthly_lead_cap_override >= 0);
+  END IF;
+END $$;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS monthly_accepted_lead_count integer DEFAULT 0 NOT NULL;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS monthly_lead_count_resets_at timestamptz;
+
+-- Founders Offer tracking --------------------------------------------------
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS is_founding_pro boolean DEFAULT false NOT NULL;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS founding_pro_discount_ends_at timestamptz;
+
+-- Opt-in compliance fields (Messaging Spec v1.1 Section 12) ----------------
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS sms_opted_in boolean DEFAULT false NOT NULL;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS sms_opted_in_at timestamptz;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS sms_opt_out_keyword text;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS sms_opted_out_at timestamptz;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS email_opted_in boolean DEFAULT true NOT NULL;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS email_opted_out_at timestamptz;
+
+ALTER TABLE public.cleaners
+  ADD COLUMN IF NOT EXISTS email_opt_out_token text;
+
+-- Indexes ------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_cleaners_stripe_customer_id
+  ON public.cleaners (stripe_customer_id)
+  WHERE stripe_customer_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_cleaners_stripe_subscription_id
+  ON public.cleaners (stripe_subscription_id)
+  WHERE stripe_subscription_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_cleaners_lead_eligibility
+  ON public.cleaners (subscription_tier, subscription_status, leads_paused)
+  WHERE subscription_status = 'active' AND leads_paused = false;
+
+CREATE INDEX IF NOT EXISTS idx_cleaners_email_opt_out_token
+  ON public.cleaners (email_opt_out_token)
+  WHERE email_opt_out_token IS NOT NULL;
+
+-- Column comments ----------------------------------------------------------
+COMMENT ON COLUMN public.cleaners.subscription_status IS
+  'Subscription status: active, past_due, canceled, paused. Per ADR-001 Section 2.';
+
+COMMENT ON COLUMN public.cleaners.leads_paused IS
+  'Pause Leads toggle. When true, cleaner is excluded from lead notification rotation but subscription continues billing. Per ADR-001 Section 4a.';
+
+COMMENT ON COLUMN public.cleaners.monthly_lead_cap_override IS
+  'Optional per-cleaner cap below the tier default. Null = use tier default (30 pro, 10 basic, 0 free). Per ADR-001 Section 4b.';
+
+COMMENT ON COLUMN public.cleaners.monthly_accepted_lead_count IS
+  'Counter incremented on each lead acceptance. Resets at start of each billing cycle.';
+
+COMMENT ON COLUMN public.cleaners.is_founding_pro IS
+  'True for first 100 Pro tier signups. Per ADR-001 Section 2 Founders Offer.';
+
+COMMENT ON COLUMN public.cleaners.sms_opted_in IS
+  'TCPA-compliant SMS opt-in flag. MUST be true to receive any SMS. Per Messaging Spec v1.1 Section 12.';
+
+COMMENT ON COLUMN public.cleaners.email_opted_in IS
+  'CAN-SPAM compliant email opt-in. Default true for transactional emails. Per Messaging Spec v1.1 Section 12.';
+
+-- =====================================================================
+-- PART B: public.notification_logs (Messaging Spec v1.1 Section 5e)
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS public.notification_logs (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id                 uuid NOT NULL UNIQUE,
+  event_type               text NOT NULL,
+  quote_request_id         uuid REFERENCES public.quote_requests ON DELETE SET NULL,
+  recipient_id             uuid NOT NULL,
+  recipient_role           text NOT NULL CHECK (recipient_role IN ('cleaner', 'customer', 'admin')),
+  recipient_channel        text NOT NULL CHECK (recipient_channel IN ('sms', 'email')),
+  recipient_address        text NOT NULL,
+  dedupe_hash              text NOT NULL,
+  bucket_window_iso        timestamptz NOT NULL,
+  provider                 text NOT NULL CHECK (provider IN ('twilio', 'resend')),
+  provider_message_id      text,
+  provider_response_raw    jsonb,
+  delivery_state           text NOT NULL CHECK (delivery_state IN (
+    'queued', 'dispatched', 'accepted', 'delivered',
+    'failed', 'bounced', 'unsubscribed', 'rate_limited',
+    'quiet_hours', 'duplicate'
+  )) DEFAULT 'queued',
+  retry_count              integer DEFAULT 0 NOT NULL,
+  last_retry_at            timestamptz,
+  next_retry_at            timestamptz,
+  created_at               timestamptz DEFAULT now() NOT NULL,
+  dispatched_at            timestamptz,
+  delivered_at             timestamptz,
+  failed_at                timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_logs_recipient
+  ON public.notification_logs (recipient_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_notification_logs_dedupe
+  ON public.notification_logs (dedupe_hash, bucket_window_iso);
+
+CREATE INDEX IF NOT EXISTS idx_notification_logs_event_type_state
+  ON public.notification_logs (event_type, delivery_state);
+
+CREATE INDEX IF NOT EXISTS idx_notification_logs_retry
+  ON public.notification_logs (next_retry_at)
+  WHERE delivery_state IN ('failed', 'rate_limited', 'quiet_hours');
+
+CREATE INDEX IF NOT EXISTS idx_notification_logs_provider_msg_id
+  ON public.notification_logs (provider_message_id)
+  WHERE provider_message_id IS NOT NULL;
+
+ALTER TABLE public.notification_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access_notification_logs" ON public.notification_logs;
+CREATE POLICY "service_role_full_access_notification_logs"
+  ON public.notification_logs
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "admin_read_notification_logs" ON public.notification_logs;
+CREATE POLICY "admin_read_notification_logs"
+  ON public.notification_logs
+  FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+COMMENT ON TABLE public.notification_logs IS
+  'Every SMS and email dispatched by the platform. Tracks idempotency, delivery state, and retry policy. Per Messaging Spec v1.1 Section 5e.';
+
+-- =====================================================================
+-- PART C: public.refund_decisions (Messaging Spec v1.1 Section 7)
+-- =====================================================================
+-- Note: lead_acceptance_id FK to public.lead_acceptances will be added in
+-- Phase A4 when that table is created.
+CREATE TABLE IF NOT EXISTS public.refund_decisions (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  lead_acceptance_id       uuid NOT NULL UNIQUE,
+  state                    text NOT NULL CHECK (state IN (
+    'pending', 'auto_approved', 'auto_denied',
+    'manual_review', 'approved', 'denied',
+    'escalated', 'admin_override_approved', 'admin_override_denied'
+  )) DEFAULT 'pending',
+  trigger_reason           text NOT NULL,
+  initial_state_reason     text,
+  reviewer_id              uuid,
+  reviewer_notes           text,
+  refund_amount_cents      integer,
+  stripe_refund_id         text,
+  stripe_action            text CHECK (stripe_action IN (
+    'void_authorization', 'refund_payment', 'no_action'
+  )),
+  state_history            jsonb DEFAULT '[]'::jsonb NOT NULL,
+  sla_breached             boolean DEFAULT false NOT NULL,
+  created_at               timestamptz DEFAULT now() NOT NULL,
+  decided_at               timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_refund_decisions_state
+  ON public.refund_decisions (state, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_refund_decisions_pending_review
+  ON public.refund_decisions (state, created_at)
+  WHERE state IN ('manual_review', 'escalated');
+
+CREATE INDEX IF NOT EXISTS idx_refund_decisions_reviewer
+  ON public.refund_decisions (reviewer_id)
+  WHERE reviewer_id IS NOT NULL;
+
+ALTER TABLE public.refund_decisions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access_refund_decisions" ON public.refund_decisions;
+CREATE POLICY "service_role_full_access_refund_decisions"
+  ON public.refund_decisions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "admin_full_access_refund_decisions" ON public.refund_decisions;
+CREATE POLICY "admin_full_access_refund_decisions"
+  ON public.refund_decisions
+  FOR ALL
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+COMMENT ON TABLE public.refund_decisions IS
+  'Refund decision state machine: pending -> auto_approved/auto_denied/manual_review -> approved/denied/escalated -> admin_override. Per Messaging Spec v1.1 Section 7.';
+
+COMMENT ON COLUMN public.refund_decisions.lead_acceptance_id IS
+  'FK to lead_acceptances table. Constraint will be added in Phase A4 when lead_acceptances exists.';
+
+-- =====================================================================
+-- PART D: public.marketplace_events (Messaging Spec v1.1 Section 16)
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS public.marketplace_events (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_name          text NOT NULL,
+  event_category      text NOT NULL CHECK (event_category IN (
+    'lifecycle', 'monetization', 'trust', 'notification', 'admin'
+  )),
+  actor_id            uuid,
+  actor_role          text CHECK (actor_role IN (
+    'cleaner', 'customer', 'admin', 'system'
+  )),
+  subject_id          uuid,
+  subject_type        text,
+  properties          jsonb DEFAULT '{}'::jsonb NOT NULL,
+  created_at          timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_events_name_time
+  ON public.marketplace_events (event_name, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_events_actor
+  ON public.marketplace_events (actor_id, created_at DESC)
+  WHERE actor_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_events_subject
+  ON public.marketplace_events (subject_id, created_at DESC)
+  WHERE subject_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_events_category
+  ON public.marketplace_events (event_category, created_at DESC);
+
+ALTER TABLE public.marketplace_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access_marketplace_events" ON public.marketplace_events;
+CREATE POLICY "service_role_full_access_marketplace_events"
+  ON public.marketplace_events
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "admin_read_marketplace_events" ON public.marketplace_events;
+CREATE POLICY "admin_read_marketplace_events"
+  ON public.marketplace_events
+  FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+COMMENT ON TABLE public.marketplace_events IS
+  'Append-only event log for analytics. Captures lead.submitted, lead.accepted, booking.confirmed, refund.issued, etc. Per Messaging Spec v1.1 Section 16.';

--- a/supabase/migrations/20260510040743_phase_a2_lead_distributions.sql
+++ b/supabase/migrations/20260510040743_phase_a2_lead_distributions.sql
@@ -1,0 +1,184 @@
+-- =====================================================================
+-- Phase A2 — Lead Distributions Table
+-- =====================================================================
+-- Tracks each lead's journey through the tier-priority cascade.
+-- One row per (quote_request, tier) pairing — so a single quote_request
+-- may have up to 3 lead_distributions rows (Pro, Basic, Free) as it
+-- cascades through tiers.
+--
+-- Per Messaging Spec v1.1 Section 2 (state machine) and ADR-001
+-- Section 3 (cascade logic).
+--
+-- Supersedes the dormant `public.leads` table (0 rows, no live code refs).
+-- `public.leads` will be dropped in a Phase A5 cleanup migration.
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS public.lead_distributions (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  quote_request_id         uuid NOT NULL REFERENCES public.quote_requests ON DELETE CASCADE,
+
+  -- Which tier window is this row for
+  tier                     text NOT NULL CHECK (tier IN ('pro', 'basic', 'free')),
+
+  -- Cascade state machine
+  state                    text NOT NULL CHECK (state IN (
+    'pending',           -- Window not yet opened (waiting for previous tier to expire)
+    'active',            -- Window is open, pros being notified
+    'cascaded',          -- Window closed without acceptance, lead moved to next tier
+    'accepted',          -- A pro accepted; cascade halted; lead locked
+    'expired',           -- Window closed at last tier (free) with no acceptance — terminal
+    'skipped'            -- Dynamic skip: no matching pros at this tier, jumped over
+  )) DEFAULT 'pending',
+
+  -- Window timing
+  window_started_at        timestamptz,
+  window_expires_at        timestamptz,
+  window_closed_at         timestamptz,         -- set when state moves to cascaded/accepted/expired/skipped
+
+  -- Notification tracking
+  notified_pro_ids         uuid[] DEFAULT '{}'::uuid[] NOT NULL,
+  notified_count           integer GENERATED ALWAYS AS (cardinality(notified_pro_ids)) STORED,
+
+  -- Why the window closed (audit/analytics)
+  close_reason             text CHECK (close_reason IN (
+    'pro_accepted',         -- A pro clicked Accept
+    'all_pros_declined',    -- Every notified pro actively declined
+    'window_timeout',       -- T+15min for pro, T+30min for basic, T+24h for free
+    'no_matching_pros',     -- Dynamic skip
+    'customer_cancelled',   -- Customer pulled the request
+    'admin_cancelled'       -- Admin intervention
+  )),
+
+  -- Round-robin fairness (for A2 we just record the rotation key; A2 enforcement comes in C)
+  round_robin_seed         integer,
+
+  -- Timestamps
+  created_at               timestamptz DEFAULT now() NOT NULL,
+  updated_at               timestamptz DEFAULT now() NOT NULL
+);
+
+-- Indexes ----------------------------------------------------------------
+
+-- Fast lookup: "what tier rows exist for this quote_request"
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_quote_request
+  ON public.lead_distributions (quote_request_id, tier);
+
+-- Cascade timer cron: find all active rows whose window has expired
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_active_windows
+  ON public.lead_distributions (window_expires_at)
+  WHERE state = 'active';
+
+-- Hot path: "which lead distributions are currently open at tier X"
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_state_tier
+  ON public.lead_distributions (state, tier, window_started_at DESC);
+
+-- Audit/analytics: filter by close reason
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_close_reason
+  ON public.lead_distributions (close_reason, window_closed_at DESC)
+  WHERE close_reason IS NOT NULL;
+
+-- Per-pro reverse lookup: "which leads has this pro been notified about" (uses GIN on uuid array)
+CREATE INDEX IF NOT EXISTS idx_lead_distributions_notified_pros_gin
+  ON public.lead_distributions USING GIN (notified_pro_ids);
+
+-- Constraints ------------------------------------------------------------
+
+-- A given quote_request can only have one row per tier
+ALTER TABLE public.lead_distributions
+  DROP CONSTRAINT IF EXISTS lead_distributions_quote_tier_unique;
+ALTER TABLE public.lead_distributions
+  ADD CONSTRAINT lead_distributions_quote_tier_unique
+  UNIQUE (quote_request_id, tier);
+
+-- updated_at trigger -----------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.update_lead_distributions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+DROP TRIGGER IF EXISTS trg_lead_distributions_updated_at ON public.lead_distributions;
+CREATE TRIGGER trg_lead_distributions_updated_at
+  BEFORE UPDATE ON public.lead_distributions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_lead_distributions_updated_at();
+
+-- RLS --------------------------------------------------------------------
+
+ALTER TABLE public.lead_distributions ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access (cron jobs, edge functions, server-side code)
+DROP POLICY IF EXISTS "service_role_full_access_lead_distributions" ON public.lead_distributions;
+CREATE POLICY "service_role_full_access_lead_distributions"
+  ON public.lead_distributions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Admin full access via canonical is_admin() function
+DROP POLICY IF EXISTS "admin_full_access_lead_distributions" ON public.lead_distributions;
+CREATE POLICY "admin_full_access_lead_distributions"
+  ON public.lead_distributions
+  FOR ALL
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- Pros can SELECT distributions where they are in the notified_pro_ids array
+-- (via cleaners.user_id = auth.uid() chain)
+DROP POLICY IF EXISTS "pros_read_own_distributions" ON public.lead_distributions;
+CREATE POLICY "pros_read_own_distributions"
+  ON public.lead_distributions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.cleaners c
+      WHERE c.user_id = (select auth.uid())
+        AND c.id = ANY(public.lead_distributions.notified_pro_ids)
+    )
+  );
+
+-- Customers can SELECT distributions for their own quote_requests
+-- (so they can see "lead is currently in Pro tier window")
+DROP POLICY IF EXISTS "customers_read_own_distributions" ON public.lead_distributions;
+CREATE POLICY "customers_read_own_distributions"
+  ON public.lead_distributions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.quote_requests qr
+      WHERE qr.id = public.lead_distributions.quote_request_id
+        AND qr.customer_id = (select auth.uid())
+    )
+  );
+
+-- Comments ---------------------------------------------------------------
+
+COMMENT ON TABLE public.lead_distributions IS
+  'Tracks each lead''s journey through the tier-priority cascade. One row per (quote_request, tier) pairing. Supersedes dormant public.leads. Per Messaging Spec v1.1 Section 2.';
+
+COMMENT ON COLUMN public.lead_distributions.tier IS
+  'Which tier window: pro ($199/mo, T+0 15min exclusive), basic ($79/mo, T+15 30min), free (T+45 open).';
+
+COMMENT ON COLUMN public.lead_distributions.state IS
+  'Cascade state: pending (not yet opened), active (window open), cascaded (closed, moved to next tier), accepted (terminal-success), expired (terminal at last tier, no acceptance), skipped (dynamic skip — no matching pros).';
+
+COMMENT ON COLUMN public.lead_distributions.window_expires_at IS
+  'When this tier window auto-cascades to the next tier. Set when state moves to active.';
+
+COMMENT ON COLUMN public.lead_distributions.notified_pro_ids IS
+  'Array of cleaner.id values that received notification when this window opened. Used for RLS pro_read_own_distributions and round-robin fairness analytics.';
+
+COMMENT ON COLUMN public.lead_distributions.round_robin_seed IS
+  'Rotation seed used to order notifications within tier. Phase C will implement actual round-robin enforcement.';
+
+COMMENT ON COLUMN public.lead_distributions.close_reason IS
+  'Why the window closed. Used for analytics and to drive marketplace_events emission.';

--- a/supabase/migrations/20260510165428_phase_a3_lead_declines.sql
+++ b/supabase/migrations/20260510165428_phase_a3_lead_declines.sql
@@ -1,0 +1,154 @@
+-- =====================================================================
+-- Phase A3 — Lead Declines Table
+-- =====================================================================
+-- Records every time a pro clicks "Decline" on a lead notification.
+-- Used to:
+--   1. Power the Decline Lead button (marketplace control Hole #3)
+--   2. Trigger immediate cascade when all eligible pros decline
+--   3. Provide analytics on why pros say no
+--
+-- Per ADR-001 Section 4c and Messaging Spec v1.1 Section 10c.
+--
+-- Pure greenfield — no legacy equivalent (confirmed by May 9 audit).
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS public.lead_declines (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- What was declined and by whom
+  lead_distribution_id     uuid NOT NULL REFERENCES public.lead_distributions ON DELETE CASCADE,
+  quote_request_id         uuid NOT NULL REFERENCES public.quote_requests ON DELETE CASCADE,
+  cleaner_id               uuid NOT NULL REFERENCES public.cleaners ON DELETE CASCADE,
+
+  -- Tier the pro was at when they declined (denormalized for analytics)
+  tier_at_decline          text NOT NULL CHECK (tier_at_decline IN ('pro', 'basic', 'free')),
+
+  -- Why they declined — from the 8-reason controlled list per ADR Section 4c
+  reason_code              text NOT NULL CHECK (reason_code IN (
+    'too_far',                  -- Too far from my service area
+    'too_busy',                 -- Too busy / fully booked
+    'wrong_service_type',       -- Wrong service type for my business
+    'budget_too_low',           -- Customer budget appears too low
+    'duplicate_customer',       -- Duplicate customer (already serviced or in dispute)
+    'unsafe_request',           -- Unsafe or suspicious request
+    'commercial_only_request',  -- Commercial-only request (I do residential)
+    'residential_only_request'  -- Residential-only request (I do commercial)
+  )),
+
+  -- Optional pro-provided notes
+  notes                    text,
+
+  -- Time-to-decline tracking (analytics: how fast do pros say no?)
+  notified_at              timestamptz,           -- When the pro got the SMS/email
+  declined_at              timestamptz DEFAULT now() NOT NULL,
+  time_to_decline_seconds  integer GENERATED ALWAYS AS (
+    CASE
+      WHEN notified_at IS NOT NULL
+      THEN EXTRACT(EPOCH FROM (declined_at - notified_at))::integer
+      ELSE NULL
+    END
+  ) STORED,
+
+  -- Timestamp
+  created_at               timestamptz DEFAULT now() NOT NULL
+);
+
+-- Indexes ----------------------------------------------------------------
+
+-- Hot path: "did all pros at this tier decline?" (cascade trigger check)
+CREATE INDEX IF NOT EXISTS idx_lead_declines_distribution
+  ON public.lead_declines (lead_distribution_id);
+
+-- Per-pro lookup: "which leads has this pro declined recently?" (rate-limit/abuse detection)
+CREATE INDEX IF NOT EXISTS idx_lead_declines_cleaner_recent
+  ON public.lead_declines (cleaner_id, declined_at DESC);
+
+-- Analytics: most common decline reasons over time
+CREATE INDEX IF NOT EXISTS idx_lead_declines_reason_time
+  ON public.lead_declines (reason_code, declined_at DESC);
+
+-- Quote-request lookup: "show all declines for this lead" (admin debugging)
+CREATE INDEX IF NOT EXISTS idx_lead_declines_quote_request
+  ON public.lead_declines (quote_request_id, declined_at DESC);
+
+-- Constraints ------------------------------------------------------------
+
+-- A given pro can only decline a given distribution once
+ALTER TABLE public.lead_declines
+  DROP CONSTRAINT IF EXISTS lead_declines_distribution_cleaner_unique;
+ALTER TABLE public.lead_declines
+  ADD CONSTRAINT lead_declines_distribution_cleaner_unique
+  UNIQUE (lead_distribution_id, cleaner_id);
+
+-- RLS --------------------------------------------------------------------
+
+ALTER TABLE public.lead_declines ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access (cron jobs, edge functions, server-side code)
+DROP POLICY IF EXISTS "service_role_full_access_lead_declines" ON public.lead_declines;
+CREATE POLICY "service_role_full_access_lead_declines"
+  ON public.lead_declines
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Admin full access via canonical is_admin() function
+DROP POLICY IF EXISTS "admin_full_access_lead_declines" ON public.lead_declines;
+CREATE POLICY "admin_full_access_lead_declines"
+  ON public.lead_declines
+  FOR ALL
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- Pros can INSERT declines for themselves only
+DROP POLICY IF EXISTS "pros_insert_own_declines" ON public.lead_declines;
+CREATE POLICY "pros_insert_own_declines"
+  ON public.lead_declines
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.cleaners c
+      WHERE c.id = public.lead_declines.cleaner_id
+        AND c.user_id = (select auth.uid())
+    )
+  );
+
+-- Pros can SELECT their own decline history
+DROP POLICY IF EXISTS "pros_read_own_declines" ON public.lead_declines;
+CREATE POLICY "pros_read_own_declines"
+  ON public.lead_declines
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.cleaners c
+      WHERE c.id = public.lead_declines.cleaner_id
+        AND c.user_id = (select auth.uid())
+    )
+  );
+
+-- NOTE: customers do NOT see declines. They never need to know which specific pro declined
+-- their lead, only that the lead is still being matched. Surface the cascade state via
+-- lead_distributions, not lead_declines.
+
+-- Comments ---------------------------------------------------------------
+
+COMMENT ON TABLE public.lead_declines IS
+  'Records every Decline click by pros. Powers Hole #3 (Decline Lead), cascade trigger when all pros decline, and analytics on decline reasons. Per ADR-001 Section 4c.';
+
+COMMENT ON COLUMN public.lead_declines.lead_distribution_id IS
+  'FK to the lead_distributions row that was declined. ON DELETE CASCADE so declines disappear with the distribution.';
+
+COMMENT ON COLUMN public.lead_declines.tier_at_decline IS
+  'Denormalized tier the pro was at when they declined. Useful for analytics without joining lead_distributions.';
+
+COMMENT ON COLUMN public.lead_declines.reason_code IS
+  '8 controlled reason codes per ADR Section 4c. UI maps these to human-readable labels in the Decline modal.';
+
+COMMENT ON COLUMN public.lead_declines.time_to_decline_seconds IS
+  'Computed: how long after notification did the pro decline? Used for analytics (fast no = wrong vertical match; slow no = considered then declined).';

--- a/supabase/migrations/20260511135013_phase_a4_lead_acceptances.sql
+++ b/supabase/migrations/20260511135013_phase_a4_lead_acceptances.sql
@@ -1,0 +1,429 @@
+-- =====================================================================
+-- Phase A4 — Rename lead_unlocks → lead_acceptances + Extend
+-- =====================================================================
+-- Per ADR-001 and the May 9 legacy audit decision: RENAME-AND-EXTEND
+-- (not supersede) because 24 live code references depend on this table,
+-- including the Stripe webhook handler.
+--
+-- This migration:
+--   A. Renames the table public.lead_unlocks → public.lead_acceptances
+--   B. Adds v1.1 spec columns (distribution link, tier, capture timing, voids)
+--   C. Notes that lead_charges columns are already covered by existing columns
+--   D. Updates the status check constraint to v1.1 state machine
+--   E. Adds FK from refund_decisions.lead_acceptance_id → lead_acceptances.id
+--   F. Adds new indexes for capture cron, distribution lookup, tier analytics
+--   G. Rewrites the 3 dependent RPC functions to reference the new table
+--      name and new status values (Postgres does NOT auto-rewrite function
+--      bodies on ALTER TABLE RENAME — function source is stored as text).
+--
+-- All wrapped in a single transaction so partial failure rolls back cleanly.
+--
+-- DIAGNOSTICS NOTE:
+--   lead_unlocks: 0 rows — safe to change semantics.
+--   lead_charges: 0 rows, columns (stripe_payment_intent_id, amount_cents,
+--     status) already mirrored on lead_unlocks. No data to migrate.
+--   refund_decisions.lead_acceptance_id: column exists (created in A1) with
+--     no FK constraint yet.
+--   lead_refund_requests.lead_unlock_id FK: stays pointing at the renamed
+--     table (Postgres preserves FK references through RENAME by oid). The
+--     constraint name lead_refund_requests_lead_unlock_id_fkey is now
+--     cosmetically stale but functional. Will be retired with the table in
+--     Phase A5 cleanup.
+-- =====================================================================
+
+BEGIN;
+
+-- =====================================================================
+-- PART A: Rename lead_unlocks → lead_acceptances
+-- =====================================================================
+-- Idempotent: only rename if lead_unlocks still exists AND lead_acceptances does not.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='lead_unlocks')
+     AND NOT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='lead_acceptances')
+  THEN
+    EXECUTE 'ALTER TABLE public.lead_unlocks RENAME TO lead_acceptances';
+  END IF;
+END $$;
+
+-- Rename existing indexes to match new table name (cosmetic but useful).
+-- IF EXISTS guards make this idempotent.
+ALTER INDEX IF EXISTS public.lead_unlocks_pkey
+  RENAME TO lead_acceptances_pkey;
+ALTER INDEX IF EXISTS public.lead_unlocks_quote_request_id_cleaner_id_key
+  RENAME TO lead_acceptances_quote_request_id_cleaner_id_key;
+ALTER INDEX IF EXISTS public.idx_lead_unlocks_cleaner
+  RENAME TO idx_lead_acceptances_cleaner;
+ALTER INDEX IF EXISTS public.idx_lead_unlocks_cleaner_status
+  RENAME TO idx_lead_acceptances_cleaner_status;
+ALTER INDEX IF EXISTS public.idx_lead_unlocks_quote_request
+  RENAME TO idx_lead_acceptances_quote_request;
+ALTER INDEX IF EXISTS public.idx_lead_unlocks_quote_status
+  RENAME TO idx_lead_acceptances_quote_status;
+ALTER INDEX IF EXISTS public.idx_lead_unlocks_status
+  RENAME TO idx_lead_acceptances_status;
+
+-- Rename existing FK constraints on lead_acceptances for clarity.
+-- (Postgres lets you rename constraints via ALTER TABLE.)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname='public' AND c.relname='lead_acceptances'
+      AND con.conname='lead_unlocks_cleaner_id_fkey'
+  ) THEN
+    ALTER TABLE public.lead_acceptances
+      RENAME CONSTRAINT lead_unlocks_cleaner_id_fkey TO lead_acceptances_cleaner_id_fkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname='public' AND c.relname='lead_acceptances'
+      AND con.conname='lead_unlocks_quote_request_id_fkey'
+  ) THEN
+    ALTER TABLE public.lead_acceptances
+      RENAME CONSTRAINT lead_unlocks_quote_request_id_fkey TO lead_acceptances_quote_request_id_fkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname='public' AND c.relname='lead_acceptances'
+      AND con.conname='lead_unlocks_status_check'
+  ) THEN
+    ALTER TABLE public.lead_acceptances
+      RENAME CONSTRAINT lead_unlocks_status_check TO lead_acceptances_status_check;
+  END IF;
+END $$;
+
+-- =====================================================================
+-- PART B: Add v1.1 fields to lead_acceptances
+-- =====================================================================
+
+ALTER TABLE public.lead_acceptances
+  ADD COLUMN IF NOT EXISTS lead_distribution_id uuid
+    REFERENCES public.lead_distributions ON DELETE CASCADE;
+
+ALTER TABLE public.lead_acceptances
+  ADD COLUMN IF NOT EXISTS tier_at_acceptance text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='lead_acceptances_tier_at_acceptance_check'
+  ) THEN
+    ALTER TABLE public.lead_acceptances
+      ADD CONSTRAINT lead_acceptances_tier_at_acceptance_check
+      CHECK (tier_at_acceptance IS NULL OR tier_at_acceptance IN ('pro', 'basic', 'free'));
+  END IF;
+END $$;
+
+ALTER TABLE public.lead_acceptances
+  ADD COLUMN IF NOT EXISTS counts_against_cap boolean DEFAULT true NOT NULL;
+
+ALTER TABLE public.lead_acceptances
+  ADD COLUMN IF NOT EXISTS founding_pro_perk_used boolean DEFAULT false NOT NULL;
+
+ALTER TABLE public.lead_acceptances
+  ADD COLUMN IF NOT EXISTS capture_before timestamptz;
+
+ALTER TABLE public.lead_acceptances
+  ADD COLUMN IF NOT EXISTS captured_at timestamptz;
+
+ALTER TABLE public.lead_acceptances
+  ADD COLUMN IF NOT EXISTS voided_at timestamptz;
+
+ALTER TABLE public.lead_acceptances
+  ADD COLUMN IF NOT EXISTS void_reason text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='lead_acceptances_void_reason_check'
+  ) THEN
+    ALTER TABLE public.lead_acceptances
+      ADD CONSTRAINT lead_acceptances_void_reason_check
+      CHECK (
+        void_reason IS NULL OR void_reason IN (
+          'customer_non_response_48h',
+          'customer_silence_7d',
+          'duplicate_lead',
+          'contact_bounce',
+          'admin_cancelled'
+        )
+      );
+  END IF;
+END $$;
+
+-- =====================================================================
+-- PART C: lead_charges columns — no new columns needed
+-- =====================================================================
+-- The existing columns stripe_payment_intent_id, amount_cents, and status
+-- on lead_acceptances already cover what lead_charges duplicates. No-op.
+-- lead_charges will be dropped in a Phase A5 cleanup migration.
+
+-- =====================================================================
+-- PART D: Update status check constraint to v1.1 state machine
+-- =====================================================================
+-- Old: status IN ('pending','paid','refunded','credited')
+-- New: status IN ('pending','authorized','captured','voided','refunded')
+--
+-- Safe because lead_acceptances has 0 rows. Use DROP IF EXISTS / ADD pattern
+-- so this migration is re-runnable.
+
+ALTER TABLE public.lead_acceptances
+  DROP CONSTRAINT IF EXISTS lead_acceptances_status_check;
+
+ALTER TABLE public.lead_acceptances
+  ADD CONSTRAINT lead_acceptances_status_check
+  CHECK (status IN ('pending','authorized','captured','voided','refunded'));
+
+-- =====================================================================
+-- PART E: Add FK from refund_decisions.lead_acceptance_id
+-- =====================================================================
+-- A1 v1.1 created refund_decisions.lead_acceptance_id with a comment saying
+-- "FK will be added in Phase A4." This is that addition.
+-- ON DELETE RESTRICT so we never silently drop a refund decision when its
+-- underlying acceptance is removed (admin must reconcile first).
+
+ALTER TABLE public.refund_decisions
+  DROP CONSTRAINT IF EXISTS refund_decisions_lead_acceptance_id_fkey;
+
+ALTER TABLE public.refund_decisions
+  ADD CONSTRAINT refund_decisions_lead_acceptance_id_fkey
+  FOREIGN KEY (lead_acceptance_id)
+  REFERENCES public.lead_acceptances(id)
+  ON DELETE RESTRICT;
+
+-- =====================================================================
+-- PART F: New indexes
+-- =====================================================================
+
+-- Hot path for the capture cron: find acceptances whose Stripe auth is about
+-- to expire and that have not been captured or voided yet.
+CREATE INDEX IF NOT EXISTS idx_lead_acceptances_capture_before
+  ON public.lead_acceptances (capture_before)
+  WHERE captured_at IS NULL AND voided_at IS NULL;
+
+-- Lookup acceptances by distribution (e.g., when a distribution cascades and
+-- we need to find which acceptance halted it).
+CREATE INDEX IF NOT EXISTS idx_lead_acceptances_distribution
+  ON public.lead_acceptances (lead_distribution_id)
+  WHERE lead_distribution_id IS NOT NULL;
+
+-- Analytics: tier mix of acceptances over time.
+CREATE INDEX IF NOT EXISTS idx_lead_acceptances_tier_recent
+  ON public.lead_acceptances (tier_at_acceptance, created_at DESC);
+
+-- =====================================================================
+-- PART G: Comments
+-- =====================================================================
+
+COMMENT ON TABLE public.lead_acceptances IS
+  'A pro accepting a distributed lead. Was lead_unlocks pre-Phase-A4. One row per (quote_request, cleaner) — UNIQUE constraint preserved from the rename. Stripe state machine: pending -> authorized -> captured | voided | refunded. Per Messaging Spec v1.1.';
+
+COMMENT ON COLUMN public.lead_acceptances.lead_distribution_id IS
+  'FK to the lead_distributions row this acceptance halted (cascade-stopper). Nullable for backwards compatibility while the cascade engine is being built; will be required once Phase C ships.';
+
+COMMENT ON COLUMN public.lead_acceptances.tier_at_acceptance IS
+  'Denormalized tier the cleaner held when they accepted. Useful for analytics and refund-eligibility decisions without joining cleaners.';
+
+COMMENT ON COLUMN public.lead_acceptances.counts_against_cap IS
+  'True for Basic/Pro tier acceptances (consume a monthly included lead). False for Free tier — they pay per lead, so no cap.';
+
+COMMENT ON COLUMN public.lead_acceptances.founding_pro_perk_used IS
+  'True if this acceptance consumed a Founders Offer perk slot. Per ADR-001 Section 2 Founders Offer.';
+
+COMMENT ON COLUMN public.lead_acceptances.capture_before IS
+  'Deadline by which Stripe authorization must be captured or voided. Set when status moves to authorized.';
+
+COMMENT ON COLUMN public.lead_acceptances.captured_at IS
+  'When the Stripe charge was actually captured (status -> captured).';
+
+COMMENT ON COLUMN public.lead_acceptances.voided_at IS
+  'When the Stripe authorization was voided (status -> voided). Mutually exclusive with captured_at.';
+
+COMMENT ON COLUMN public.lead_acceptances.void_reason IS
+  'Why the auth was voided. Controlled list per Messaging Spec v1.1 Section 7.';
+
+-- =====================================================================
+-- PART H: Rewrite RPCs to reference the new table name and new statuses
+-- =====================================================================
+-- Postgres stores function bodies as text and does NOT rewrite them on
+-- ALTER TABLE RENAME. Without these rewrites, all 3 RPCs would break the
+-- moment Part A applies.
+--
+-- We also remap the old "completed" status values:
+--   old: status IN ('paid', 'credited')      -- a pro had unlocked the lead
+--   new: status IN ('authorized', 'captured') -- a pro accepted the lead
+-- Both old values are gone (Part D drop). We use authorized + captured
+-- because those are the two states where a pro has committed to the lead
+-- (auth held or charge taken). 'pending' stays as the in-flight state used
+-- by the "already started but not finished" check.
+
+CREATE OR REPLACE FUNCTION public.check_lead_competition_cap()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  acceptance_count integer;
+BEGIN
+  SELECT COUNT(*) INTO acceptance_count
+  FROM public.lead_acceptances
+  WHERE quote_request_id = NEW.quote_request_id
+    AND status IN ('authorized', 'captured');
+
+  IF acceptance_count >= 3 THEN
+    RAISE EXCEPTION 'Competition cap reached: maximum 3 pros can accept this lead'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.check_lead_unlock_cap(
+  p_quote_request_id uuid,
+  p_cleaner_id uuid
+)
+RETURNS TABLE(unlock_count integer, already_unlocked boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_count integer;
+  v_already boolean;
+BEGIN
+  -- Lock existing acceptance rows for this lead to prevent concurrent inserts
+  PERFORM 1 FROM lead_acceptances
+  WHERE quote_request_id = p_quote_request_id
+    AND status IN ('authorized', 'captured')
+  FOR UPDATE;
+
+  -- Count active acceptances (authorized or captured)
+  SELECT count(*)::integer INTO v_count
+  FROM lead_acceptances
+  WHERE quote_request_id = p_quote_request_id
+    AND status IN ('authorized', 'captured');
+
+  -- Check if this cleaner already has an acceptance (any active status)
+  SELECT EXISTS(
+    SELECT 1 FROM lead_acceptances
+    WHERE quote_request_id = p_quote_request_id
+      AND cleaner_id = p_cleaner_id
+      AND status IN ('authorized', 'captured', 'pending')
+  ) INTO v_already;
+
+  RETURN QUERY SELECT v_count, v_already;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.match_lead_pros(p_quote_request_id uuid)
+RETURNS TABLE(
+  cleaner_id uuid,
+  business_name text,
+  subscription_tier subscription_tier,
+  response_rate numeric,
+  average_rating numeric,
+  distance_miles numeric
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_zip text;
+  v_service_type text;
+  v_cleaner_id uuid;
+  v_lat numeric;
+  v_lng numeric;
+BEGIN
+  -- Get the lead's zip + service_type + cleaner_id
+  SELECT qr.zip_code, qr.service_type, qr.cleaner_id
+  INTO v_zip, v_service_type, v_cleaner_id
+  FROM quote_requests qr
+  WHERE qr.id = p_quote_request_id;
+
+  -- If lead not found, return empty
+  IF v_zip IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- If cleaner_id IS NOT NULL, this is a direct request — no matching needed
+  IF v_cleaner_id IS NOT NULL THEN
+    RETURN;
+  END IF;
+
+  -- Get lead zip lat/lng for distance calc
+  SELECT fz.latitude, fz.longitude
+  INTO v_lat, v_lng
+  FROM florida_zipcodes fz
+  WHERE fz.zip_code = v_zip;
+
+  RETURN QUERY
+  SELECT
+    c.id AS cleaner_id,
+    c.business_name,
+    c.subscription_tier,
+    c.response_rate,
+    c.average_rating,
+    -- Haversine distance in miles (if lat/lng available)
+    CASE
+      WHEN v_lat IS NOT NULL AND fz2.latitude IS NOT NULL THEN
+        ROUND((
+          3959 * acos(
+            LEAST(1.0,
+              cos(radians(v_lat)) * cos(radians(fz2.latitude))
+              * cos(radians(fz2.longitude) - radians(v_lng))
+              + sin(radians(v_lat)) * sin(radians(fz2.latitude))
+            )
+          )
+        )::numeric, 1)
+      ELSE NULL
+    END AS distance_miles
+  FROM cleaners c
+  -- Join through the service_areas table to find cleaners covering this zip
+  INNER JOIN service_areas sa ON sa.cleaner_id = c.id AND sa.zip_code = v_zip
+  -- Get cleaner's primary zip for distance calculation
+  LEFT JOIN service_areas sa_primary
+    ON sa_primary.cleaner_id = c.id AND sa_primary.is_primary = true
+  LEFT JOIN florida_zipcodes fz2 ON fz2.zip_code = sa_primary.zip_code
+  WHERE c.approval_status = 'approved'
+    -- Exclude pros who already have an acceptance for this lead
+    AND NOT EXISTS (
+      SELECT 1 FROM lead_acceptances la
+      WHERE la.quote_request_id = p_quote_request_id
+        AND la.cleaner_id = c.id
+        AND la.status IN ('authorized', 'captured', 'pending')
+    )
+    -- Enforce competition cap: max 3 active acceptances per lead
+    AND (
+      SELECT count(*) FROM lead_acceptances la2
+      WHERE la2.quote_request_id = p_quote_request_id
+        AND la2.status IN ('authorized', 'captured')
+    ) < 3
+  ORDER BY
+    -- Tier priority: enterprise > pro > basic > free
+    CASE c.subscription_tier
+      WHEN 'enterprise' THEN 1
+      WHEN 'pro' THEN 2
+      WHEN 'basic' THEN 3
+      WHEN 'free' THEN 4
+      ELSE 5
+    END,
+    c.response_rate DESC NULLS LAST,
+    c.average_rating DESC NULLS LAST;
+END;
+$function$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Lands the first 4 phases of the BOC Lead Engine v1.0 database build, plus the code refactor required by the lead_unlocks to lead_acceptances rename.

All 4 migrations were applied to production via Supabase MCP between May 9-11, 2026. This PR brings them and dependent code into version control as the authoritative source of truth.

## What's Included

### Phase A1+A2 (commit 5dbebf9)
- Phase A1 v1.1: Extended cleaners with 18 new columns. Created notification_logs, refund_decisions, marketplace_events tables.
- Phase A2: Created lead_distributions table for cascade engine state tracking.

### Phase A3+A4 (commit c510d49)
- Phase A3: Created lead_declines table with 8-reason controlled list.
- Phase A4: Renamed lead_unlocks to lead_acceptances. Added 8 v1.1 columns. Updated status check (pending/authorized/captured/voided/refunded). Added FK from refund_decisions. Rewrote 3 RPCs.
- Code refactor: 7 files updated. Status mapping: paid to captured, credited to captured. Added counts_against_cap to free-credit insert.

## Verification
- TypeScript: 56 errors (baseline ~57), zero new errors
- grep lead_unlocks across 7 files: zero hits
- grep lead_acceptances across 7 files: hits in all 7
- All migrations confirmed applied in production Supabase

## Deferred to Phase A5
lead_refund_requests, pro_lead_credits, pro_spending_caps, cleaners.lead_credits_* columns, lead_unlock_id variable rename, pre-existing filterPIIWithWindow baseline issue.