### PR TITLE
DLD-443: Add is_commercial flag to quote_requests + commercial toggle on customer form

### DIFF
--- a/app/quote-request/actions.ts
+++ b/app/quote-request/actions.ts
@@ -20,6 +20,7 @@ export interface QuoteRequestData {
   preferred_date?: string;
   flexibility?: 'exact' | 'flexible' | 'asap';
   notes?: string;
+  is_commercial?: boolean;
   tcpa_user_agent?: string;
 }
 
@@ -125,6 +126,7 @@ export async function submitQuoteRequest(
         service_date: data.preferred_date || null,
         address: '',
         status: 'pending',
+        is_commercial: data.is_commercial === true,
         tcpa_consent_at: now,
         tcpa_consent_ip: ip,
         tcpa_consent_ua: data.tcpa_user_agent ? data.tcpa_user_agent.slice(0, 512) : null,

--- a/app/quote-request/page.tsx
+++ b/app/quote-request/page.tsx
@@ -72,11 +72,12 @@ export default function QuoteRequestPage() {
     preferred_date: '',
     flexibility: 'flexible',
     notes: '',
+    is_commercial: false,
   });
 
   const handleInputChange = (
     field: keyof QuoteRequestData,
-    value: string | number | undefined
+    value: string | number | boolean | undefined
   ) => {
     setFormData({ ...formData, [field]: value });
     setError(null);
@@ -259,6 +260,36 @@ export default function QuoteRequestPage() {
             {/* Step 1: Service Details */}
             {step === 1 && (
               <div className="space-y-6">
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                    Is this for a business or facility?
+                  </h2>
+                  <p className="text-sm text-gray-600 mb-3">
+                    Commercial requests (offices, retail, multifamily, facilities) may be
+                    routed to a specialized commercial partner.
+                  </p>
+                  <div className="flex gap-3">
+                    {[
+                      { value: false, label: 'Residential (home)' },
+                      { value: true, label: 'Commercial (business / facility)' },
+                    ].map((option) => (
+                      <button
+                        key={option.label}
+                        type="button"
+                        onClick={() => handleInputChange('is_commercial', option.value)}
+                        aria-pressed={formData.is_commercial === option.value}
+                        className={`flex-1 py-2 px-3 border rounded-lg text-sm font-medium transition ${
+                          formData.is_commercial === option.value
+                            ? 'border-blue-500 bg-blue-50 text-blue-700'
+                            : 'border-gray-200 text-gray-600 hover:border-gray-300'
+                        }`}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
                 <div>
                   <h2 className="text-lg font-semibold text-gray-900 mb-4">
                     What type of cleaning do you need?
@@ -488,6 +519,10 @@ export default function QuoteRequestPage() {
                   <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
                     <h4 className="font-medium text-gray-900 mb-2">Your Quote Request Summary</h4>
                     <dl className="text-sm space-y-1">
+                      <div className="flex justify-between">
+                        <dt className="text-gray-600">Type:</dt>
+                        <dd className="font-medium">{formData.is_commercial ? 'Commercial (business / facility)' : 'Residential (home)'}</dd>
+                      </div>
                       <div className="flex justify-between">
                         <dt className="text-gray-600">Service:</dt>
                         <dd className="font-medium">{SERVICE_TYPES.find(s => s.value === formData.service_type)?.label || '-'}</dd>

--- a/supabase/migrations/20260515151809_dld443_quote_requests_is_commercial.sql
+++ b/supabase/migrations/20260515151809_dld443_quote_requests_is_commercial.sql
@@ -1,0 +1,17 @@
+-- DLD-443: Add is_commercial flag to quote_requests
+--
+-- BOC serves residential AND commercial customers. This boolean lets the
+-- customer quote form differentiate the two so downstream lead matching,
+-- fee tiers, and Coverall referral routing (DLD-451) can react later.
+--
+-- For now we only capture the flag in the schema + UI. No routing changes.
+
+ALTER TABLE public.quote_requests
+  ADD COLUMN IF NOT EXISTS is_commercial BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.quote_requests.is_commercial IS
+  'True if the customer indicated this is for a business or facility (commercial). Default false (residential). Captured by the customer quote form per DLD-443.';
+
+CREATE INDEX IF NOT EXISTS idx_quote_requests_is_commercial
+  ON public.quote_requests (is_commercial)
+  WHERE is_commercial = true;


### PR DESCRIPTION
## Summary

- Adds `quote_requests.is_commercial` BOOLEAN NOT NULL DEFAULT false (partial index on `is_commercial = true` for future routing lookups).
- Adds a Residential / Commercial toggle on Step 1 of `/quote-request` and surfaces the choice in the Step 3 review summary.
- `submitQuoteRequest` persists the new flag (defaults to false / residential).
- **Capture-only.** No lead routing, fee tier, or Coverall referral changes — that work belongs to [DLD-451](/DLD/issues/DLD-451).

Linked issue: [DLD-443](/DLD/issues/DLD-443)

## Migration

`supabase/migrations/20260515151809_dld443_quote_requests_is_commercial.sql`

```sql
ALTER TABLE public.quote_requests
  ADD COLUMN IF NOT EXISTS is_commercial BOOLEAN NOT NULL DEFAULT false;

CREATE INDEX IF NOT EXISTS idx_quote_requests_is_commercial
  ON public.quote_requests (is_commercial)
  WHERE is_commercial = true;
```

All 3 existing `quote_requests` rows default to `false` (residential) — no backfill needed.

## TypeScript baseline

`npx tsc --noEmit` reports **56 errors — unchanged from baseline**. Zero new errors from this change. Touched files (`app/quote-request/actions.ts`, `app/quote-request/page.tsx`) are clean.

## Build

`npm run build` succeeds. `/quote-request` route compiles at 7.53 kB (was ~7.4 kB).

## Test plan

- [ ] Apply migration in Supabase preview branch and confirm column + index exist
- [ ] Submit a quote as Residential — row stored with `is_commercial = false`
- [ ] Submit a quote as Commercial — row stored with `is_commercial = true`
- [ ] Review summary on Step 3 reflects the toggle selection
- [ ] Existing pro dashboards / lead lists render unchanged (no routing changes yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)