### PR TITLE
feat(schema): DLD-444 rename cleaners table to pros + backwards-compat view

### DIFF
--- a/supabase/migrations/20260515152653_dld444_rename_cleaners_to_pros.sql
+++ b/supabase/migrations/20260515152653_dld444_rename_cleaners_to_pros.sql
@@ -1,0 +1,120 @@
+-- =====================================================================
+-- DLD-444 — Rename public.cleaners → public.pros
+-- =====================================================================
+-- Internal table name `cleaners` is misleading now that BOC supports all
+-- professional service categories (handyman, HVAC, plumbing, electrical,
+-- pest, landscaping, pool, etc). Rename to `pros` to match Thumbtack-tier
+-- positioning and the existing `lead_acceptances` table semantics, which
+-- already documents itself as "A pro accepting a distributed lead".
+--
+-- STRATEGY: Expand-contract with a backwards-compat view.
+--   - Rename the table cleaners → pros.
+--   - Create an auto-updatable view public.cleaners AS SELECT * FROM pros
+--     with security_invoker=on so the view honors RLS defined on pros.
+--   - All ~590 existing code references to `cleaners` keep working
+--     through the view until a follow-up phase sweeps them to `pros`.
+--   - FK constraints, RLS policies, triggers, and indexes all follow the
+--     renamed table automatically (Postgres relinks by oid). The cosmetic
+--     index/constraint/trigger names (cleaners_*, idx_cleaners_*) remain
+--     stale-but-functional and will be renamed in a follow-up cleanup.
+--
+-- WHAT THIS MIGRATION DOES NOT DO (intentional — follow-up tickets):
+--   - Does not rename FK columns like `cleaner_id` on 20 dependent tables.
+--   - Does not rename sibling tables (cleaner_documents, cleaner_availability,
+--     cleaner_blocked_dates).
+--   - Does not rename PL/pgSQL function bodies that reference `cleaners`
+--     (they continue working through the view).
+--   - Does not touch the codebase (134 files, 590 occurrences).
+--
+-- ROLLBACK (manual, if needed):
+--   BEGIN;
+--   DROP VIEW IF EXISTS public.cleaners;
+--   ALTER TABLE public.pros RENAME TO cleaners;
+--   COMMIT;
+--
+-- Idempotent: each step is guarded so reruns are safe.
+-- =====================================================================
+
+BEGIN;
+
+-- =====================================================================
+-- PART A: Rename the table
+-- =====================================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='cleaners')
+     AND NOT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='pros') THEN
+    ALTER TABLE public.cleaners RENAME TO pros;
+  END IF;
+END$$;
+
+-- =====================================================================
+-- PART B: Create the backwards-compat view
+-- =====================================================================
+-- security_invoker=on (Postgres 15+) makes the view execute with the
+-- calling role's privileges, so RLS policies on `pros` apply through the
+-- view exactly as they did on `cleaners` pre-rename.
+--
+-- A simple `SELECT * FROM single_table` view is auto-updatable in Postgres,
+-- so INSERT/UPDATE/DELETE through `cleaners` routes to `pros` without
+-- INSTEAD OF triggers.
+CREATE OR REPLACE VIEW public.cleaners
+  WITH (security_invoker = on)
+  AS SELECT * FROM public.pros;
+
+COMMENT ON VIEW public.cleaners IS
+  'DLD-444 backwards-compat view. Aliases public.pros (renamed from cleaners). '
+  'Will be dropped after code sweep migrates all references to public.pros.';
+
+-- =====================================================================
+-- PART C: Grants on the view
+-- =====================================================================
+-- Mirror the grants the underlying table had so PostgREST + Supabase JS
+-- can hit `cleaners` from anon/authenticated/service_role exactly like before.
+-- RLS still gates row visibility per the policies on pros.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.cleaners TO anon, authenticated, service_role;
+
+-- =====================================================================
+-- PART D: Post-conditions sanity checks
+-- =====================================================================
+DO $$
+DECLARE
+  v_table_exists boolean;
+  v_view_exists boolean;
+  v_fk_count int;
+  v_policy_count int;
+BEGIN
+  -- pros must exist as a table
+  SELECT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='pros')
+    INTO v_table_exists;
+  IF NOT v_table_exists THEN
+    RAISE EXCEPTION 'DLD-444 sanity: public.pros table not found after rename';
+  END IF;
+
+  -- cleaners must exist as a view
+  SELECT EXISTS (SELECT 1 FROM pg_views WHERE schemaname='public' AND viewname='cleaners')
+    INTO v_view_exists;
+  IF NOT v_view_exists THEN
+    RAISE EXCEPTION 'DLD-444 sanity: public.cleaners backwards-compat view not created';
+  END IF;
+
+  -- FK constraints to pros must equal the count we saw on cleaners pre-rename (20)
+  SELECT count(*) INTO v_fk_count
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.constraint_column_usage ccu
+    ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+  WHERE tc.constraint_type='FOREIGN KEY'
+    AND ccu.table_schema='public' AND ccu.table_name='pros';
+  IF v_fk_count <> 20 THEN
+    RAISE EXCEPTION 'DLD-444 sanity: expected 20 inbound FKs on pros, found %', v_fk_count;
+  END IF;
+
+  -- RLS policies must have moved with the table (5 expected)
+  SELECT count(*) INTO v_policy_count
+  FROM pg_policies WHERE schemaname='public' AND tablename='pros';
+  IF v_policy_count <> 5 THEN
+    RAISE EXCEPTION 'DLD-444 sanity: expected 5 RLS policies on pros, found %', v_policy_count;
+  END IF;
+END$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Renames internal table `public.cleaners` → `public.pros` and creates a backwards-compat view so the rename can ship without touching the ~590 code references that still query `cleaners`. Expand-contract migration; follow-up tickets sweep code.

Closes [DLD-444](/DLD/issues/DLD-444).

**Naming:** `pros` — matches Thumbtack convention and the existing `lead_acceptances` table comment ("A pro accepting a distributed lead").

## What changed

1 file added: `supabase/migrations/20260515152653_dld444_rename_cleaners_to_pros.sql` (120 lines).

The migration:
- `ALTER TABLE public.cleaners RENAME TO pros` (guarded by `pg_tables` existence checks for idempotency)
- `CREATE OR REPLACE VIEW public.cleaners WITH (security_invoker = on) AS SELECT * FROM public.pros` — auto-updatable simple view, so INSERT/UPDATE/DELETE through `cleaners` routes to `pros` without INSTEAD OF triggers
- Grants on the view mirror what the table had (anon, authenticated, service_role)
- Post-condition sanity checks fail-fast if: `pros` table missing, `cleaners` view missing, inbound FK count ≠ 20, RLS policy count ≠ 5

## Why a view, not full code sweep

~590 occurrences of `cleaners` across **134 files** (app/api/, lib/, components/, supabase/*.sql). Bundling a 134-file sweep with a destructive table rename produces a ~1000-line diff that's nearly impossible to review safely. Expand-contract decouples the two concerns and matches the pattern A4/A5b used.

## Success criteria (from DLD-444)

- [x] **(1)** New table name: `pros`
- [x] **(2)** Backwards-compat view `cleaners` aliases `pros`
- [x] **(3)** RLS policies follow the table automatically (5 policies on `pros`); view uses `security_invoker=on` so existing policies still gate access
- [x] **(4)** FK constraints survive RENAME (Postgres relinks by oid); sanity check verifies all 20 inbound FKs target `pros` post-migration
- [x] **(5)** TS baseline maintained — zero code changes, baseline unaffected
- [x] **(6)** Feature branch: `feat/dld-444-rename-cleaners-to-pros`
- [x] **(7)** PR open for human review

## Not in this PR (intentional — follow-up tickets I'll open after merge)

- FK column renames (`cleaner_id` → `pro_id` on 20 dependent tables)
- Sibling table renames (`cleaner_documents`, `cleaner_availability`, `cleaner_blocked_dates`)
- PL/pgSQL function body sweep — 11 functions reference `cleaners` by name. They keep working through the view; renaming them is non-urgent and best done in a dedicated PR with regression tests
- Codebase sweep (134 files, ~590 occurrences) — the view is the bridge; sweep happens as ambient cleanup
- Cosmetic index/constraint/trigger name renames (`cleaners_pkey`, `idx_cleaners_*`, etc.) — functional, not user-visible

## Risk

**Low.**

- View is read+write transparent (auto-updatable simple `SELECT *` view)
- RLS preserved (policies moved with table; view forwards via `security_invoker=on`)
- FK constraints unchanged (Postgres relinks by oid through RENAME)
- Stripe webhook code path: unchanged. Still queries `cleaners`; hits the view; writes route to `pros`
- Idempotent guards on the rename so accidental rerun is a no-op

## Rollback

```sql
BEGIN;
DROP VIEW IF EXISTS public.cleaners;
ALTER TABLE public.pros RENAME TO cleaners;
COMMIT;
```

## Pre-Review Rebase Check

- [x] `git fetch origin && git rebase origin/main` — branch is up to date, no rebase needed
- [x] Diff stat: 1 file added, 120 insertions (see review comment on DLD-444)
- [x] `npm run build` — passing. Only pre-existing `@supabase/realtime-js` warning; no new warnings introduced
- [x] Force-with-lease pushed

## Test plan
- [ ] Reviewer applies migration to a Supabase branch / staging DB
- [ ] Reviewer queries `pros` directly: `SELECT count(*) FROM pros;` (should return 4)
- [ ] Reviewer queries `cleaners` via view: `SELECT count(*) FROM cleaners;` (should return 4)
- [ ] Reviewer verifies one of the live pages still loads (e.g. `/professionals` lists approved pros via the view)
- [ ] Reviewer confirms RLS by hitting `/api/cleaners/onboarding` as an authenticated cleaner user — should still see only their own row

🤖 Generated with [Claude Code](https://claude.com/claude-code)