### PR TITLE
feat(dld-445): pro_licenses scaffold for FL DBPR-licensed trades

### DIFF
--- a/app/api/admin/licenses/[id]/route.ts
+++ b/app/api/admin/licenses/[id]/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+// DLD-445 — admin verify / reject for a single pro_licenses row.
+// The DB trigger `pro_licenses_guard_verification_columns` is bypassed
+// for admins (public.is_admin() returns true) so the update lands as
+// requested. We also log the action to admin_actions so it shows up in
+// the existing audit trail next to document verifications.
+
+interface PatchBody {
+  action?: 'verify' | 'reject' | 'expire' | 'reset';
+  rejection_reason?: string | null;
+  notes?: string | null;
+  dbpr_status?: string | null;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const supabase = await createClient();
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: userRecord } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (userRecord?.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let body: PatchBody;
+  try {
+    body = (await request.json()) as PatchBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const action = body.action;
+  if (!action || !['verify', 'reject', 'expire', 'reset'].includes(action)) {
+    return NextResponse.json(
+      { error: 'action must be one of: verify, reject, expire, reset' },
+      { status: 400 }
+    );
+  }
+
+  if (action === 'reject' && !body.rejection_reason?.trim()) {
+    return NextResponse.json(
+      { error: 'rejection_reason required when rejecting' },
+      { status: 400 }
+    );
+  }
+
+  const { data: existing, error: existingError } = await supabase
+    .from('pro_licenses')
+    .select('id, pro_id, verification_status, license_type, license_number')
+    .eq('id', params.id)
+    .single();
+
+  if (existingError || !existing) {
+    return NextResponse.json({ error: 'License not found' }, { status: 404 });
+  }
+
+  const nowIso = new Date().toISOString();
+
+  const update: Record<string, unknown> = {};
+  switch (action) {
+    case 'verify':
+      update.verification_status = 'verified';
+      update.verified_at = nowIso;
+      update.verified_by = user.id;
+      update.rejection_reason = null;
+      if (typeof body.dbpr_status === 'string') update.dbpr_status = body.dbpr_status;
+      update.last_checked_at = nowIso;
+      break;
+    case 'reject':
+      update.verification_status = 'rejected';
+      update.verified_at = nowIso;
+      update.verified_by = user.id;
+      update.rejection_reason = body.rejection_reason!.trim();
+      break;
+    case 'expire':
+      update.verification_status = 'expired';
+      update.last_checked_at = nowIso;
+      break;
+    case 'reset':
+      update.verification_status = 'pending';
+      update.verified_at = null;
+      update.verified_by = null;
+      update.rejection_reason = null;
+      break;
+  }
+
+  if (typeof body.notes === 'string') {
+    update.notes = body.notes.trim() || null;
+  }
+
+  const { data: updated, error: updateError } = await supabase
+    .from('pro_licenses')
+    .update(update)
+    .eq('id', params.id)
+    .select()
+    .single();
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: 'Update failed', details: updateError.message },
+      { status: 500 }
+    );
+  }
+
+  // Audit. Don't fail the request if logging is unavailable.
+  try {
+    await supabase.from('admin_actions').insert({
+      admin_id: user.id,
+      action_type: `license_${action}`,
+      target_type: 'pro_license',
+      target_id: params.id,
+      notes: body.rejection_reason ?? body.notes ?? null,
+      metadata: {
+        license_type: existing.license_type,
+        license_number: existing.license_number,
+        pro_id: existing.pro_id,
+        previous_status: existing.verification_status,
+      },
+    });
+  } catch (auditErr) {
+    console.error('[admin-licenses] audit log failed:', auditErr);
+  }
+
+  return NextResponse.json(updated);
+}

--- a/app/api/admin/licenses/route.ts
+++ b/app/api/admin/licenses/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+// DLD-445 — admin queue listing for pro_licenses verification.
+// Default filter: pending. Pass ?status=verified|rejected|expired|all to
+// override. RLS already restricts to admins, but we also gate the route
+// at the application layer so a non-admin gets a clean 403.
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: userRecord } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (userRecord?.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const statusParam = request.nextUrl.searchParams.get('status') ?? 'pending';
+  const allowedStatuses = ['pending', 'verified', 'rejected', 'expired'];
+
+  let query = supabase
+    .from('pro_licenses')
+    .select(`
+      id,
+      pro_id,
+      license_type,
+      license_number,
+      issuing_state,
+      issuing_authority,
+      verification_status,
+      submitted_documents,
+      verified_at,
+      verified_by,
+      rejection_reason,
+      expires_at,
+      dbpr_status,
+      last_checked_at,
+      notes,
+      created_at,
+      updated_at,
+      pros (
+        id,
+        business_name,
+        user_id,
+        users (
+          full_name,
+          email
+        )
+      )
+    `)
+    .order('created_at', { ascending: false });
+
+  if (statusParam !== 'all') {
+    if (!allowedStatuses.includes(statusParam)) {
+      return NextResponse.json(
+        { error: `status must be one of: ${allowedStatuses.join(', ')}, all` },
+        { status: 400 }
+      );
+    }
+    query = query.eq('verification_status', statusParam);
+  }
+
+  const { data: licenses, error } = await query;
+
+  if (error) {
+    return NextResponse.json(
+      { error: 'Failed to fetch licenses', details: error.message },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json(licenses ?? []);
+}

--- a/app/api/pro/licenses/route.ts
+++ b/app/api/pro/licenses/route.ts
@@ -1,0 +1,170 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+// DLD-445 — pros self-service for license registration.
+// Verification (verification_status, verified_at, verified_by) is guarded
+// by `public.pro_licenses_guard_verification_columns()` at the DB layer:
+// non-admin inserts/updates always land as 'pending' regardless of what
+// the client sends.
+
+const ALLOWED_LICENSE_TYPES = [
+  'plumbing',
+  'hvac',
+  'electrical',
+  'general_contractor',
+  'pest_control',
+  'roofing',
+  'other',
+] as const;
+
+const ALLOWED_AUTHORITIES = ['FL_DBPR', 'OTHER'] as const;
+
+export async function GET() {
+  const supabase = await createClient();
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: pro, error: proError } = await supabase
+    .from('pros')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (proError || !pro) {
+    return NextResponse.json({ error: 'Pro profile not found' }, { status: 404 });
+  }
+
+  const { data: licenses, error } = await supabase
+    .from('pro_licenses')
+    .select(
+      'id, license_type, license_number, issuing_state, issuing_authority, ' +
+      'verification_status, submitted_documents, verified_at, rejection_reason, ' +
+      'expires_at, dbpr_status, last_checked_at, notes, created_at, updated_at'
+    )
+    .eq('pro_id', pro.id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: 'Failed to fetch licenses' }, { status: 500 });
+  }
+
+  return NextResponse.json(licenses ?? []);
+}
+
+interface SubmitLicenseBody {
+  license_type?: string;
+  license_number?: string;
+  issuing_state?: string;
+  issuing_authority?: string;
+  expires_at?: string | null;
+  submitted_documents?: Array<{ url: string; label?: string; uploaded_at?: string }>;
+  notes?: string | null;
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: pro, error: proError } = await supabase
+    .from('pros')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (proError || !pro) {
+    return NextResponse.json({ error: 'Pro profile not found' }, { status: 404 });
+  }
+
+  let body: SubmitLicenseBody;
+  try {
+    body = (await request.json()) as SubmitLicenseBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const licenseType = body.license_type?.trim().toLowerCase();
+  const licenseNumber = body.license_number?.trim();
+
+  if (!licenseType || !ALLOWED_LICENSE_TYPES.includes(licenseType as typeof ALLOWED_LICENSE_TYPES[number])) {
+    return NextResponse.json(
+      { error: `license_type must be one of: ${ALLOWED_LICENSE_TYPES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  if (!licenseNumber || licenseNumber.length < 3 || licenseNumber.length > 64) {
+    return NextResponse.json(
+      { error: 'license_number must be 3-64 characters' },
+      { status: 400 }
+    );
+  }
+
+  const issuingState = (body.issuing_state ?? 'FL').trim().toUpperCase();
+  if (issuingState.length !== 2) {
+    return NextResponse.json({ error: 'issuing_state must be a 2-letter code' }, { status: 400 });
+  }
+
+  const issuingAuthority = (body.issuing_authority ?? 'FL_DBPR').trim().toUpperCase();
+  if (!ALLOWED_AUTHORITIES.includes(issuingAuthority as typeof ALLOWED_AUTHORITIES[number])) {
+    return NextResponse.json(
+      { error: `issuing_authority must be one of: ${ALLOWED_AUTHORITIES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  let expiresAt: string | null = null;
+  if (body.expires_at) {
+    const parsed = new Date(body.expires_at);
+    if (Number.isNaN(parsed.getTime())) {
+      return NextResponse.json({ error: 'expires_at must be a valid ISO timestamp' }, { status: 400 });
+    }
+    expiresAt = parsed.toISOString();
+  }
+
+  const submittedDocuments = Array.isArray(body.submitted_documents)
+    ? body.submitted_documents.filter(
+        (d) => d && typeof d.url === 'string' && d.url.length > 0
+      )
+    : [];
+
+  const { data: license, error: insertError } = await supabase
+    .from('pro_licenses')
+    .insert({
+      pro_id: pro.id,
+      license_type: licenseType,
+      license_number: licenseNumber,
+      issuing_state: issuingState,
+      issuing_authority: issuingAuthority,
+      expires_at: expiresAt,
+      submitted_documents: submittedDocuments,
+      notes: body.notes?.trim() || null,
+      // verification_status is forced to 'pending' by the DB trigger
+      // regardless of what we send; we omit it to be explicit.
+    })
+    .select()
+    .single();
+
+  if (insertError) {
+    if (insertError.code === '23505') {
+      return NextResponse.json(
+        { error: 'You have already submitted this license. Update the existing record instead.' },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json(
+      { error: 'Failed to save license', details: insertError.message },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json(license, { status: 201 });
+}

--- a/app/dashboard/admin/layout.tsx
+++ b/app/dashboard/admin/layout.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { DashboardSidebar, type SidebarLink } from '@/components/dashboard/DashboardSidebar';
-import { LayoutDashboard, BarChart3, Star, MessageSquare, ShieldCheck } from 'lucide-react';
+import { LayoutDashboard, BarChart3, Star, MessageSquare, ShieldCheck, BadgeCheck } from 'lucide-react';
 
 const adminLinks: SidebarLink[] = [
   { href: '/dashboard/admin', label: 'Overview', icon: LayoutDashboard },
   { href: '/dashboard/admin/pros/documents', label: 'Pro Documents', icon: ShieldCheck },
+  { href: '/dashboard/admin/pros/licenses', label: 'Pro Licenses', icon: BadgeCheck },
   { href: '/dashboard/admin/analytics', label: 'Analytics', icon: BarChart3 },
   { href: '/dashboard/admin/reviews', label: 'Reviews', icon: Star },
   { href: '/dashboard/admin#messages', label: 'Messages', icon: MessageSquare },

--- a/app/dashboard/admin/pros/licenses/page.tsx
+++ b/app/dashboard/admin/pros/licenses/page.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { ProtectedRoute } from '@/lib/auth/protected-route';
+import { BadgeCheck, Clock, RotateCcw, ShieldAlert, XCircle } from 'lucide-react';
+
+// DLD-445 — admin queue for FL pro license verification.
+// First-pass UI: list pending / verified / rejected / expired in tabs,
+// show submitted documents (links only, the file storage layer is shared
+// with cleaner_documents and is gated by signed URLs in a follow-up),
+// and provide Verify / Reject / Expire / Reset buttons that PATCH
+// /api/admin/licenses/[id].
+
+type LicenseStatus = 'pending' | 'verified' | 'rejected' | 'expired';
+
+type SubmittedDocument = {
+  url?: string;
+  label?: string;
+  uploaded_at?: string;
+};
+
+interface AdminLicense {
+  id: string;
+  pro_id: string;
+  license_type: string;
+  license_number: string;
+  issuing_state: string;
+  issuing_authority: string;
+  verification_status: LicenseStatus;
+  submitted_documents: SubmittedDocument[] | null;
+  verified_at: string | null;
+  verified_by: string | null;
+  rejection_reason: string | null;
+  expires_at: string | null;
+  dbpr_status: string | null;
+  last_checked_at: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+  pros: {
+    id: string;
+    business_name: string | null;
+    user_id: string | null;
+    users: { full_name: string | null; email: string | null } | null;
+  } | null;
+}
+
+const LICENSE_TYPE_LABEL: Record<string, string> = {
+  plumbing: 'Plumbing',
+  hvac: 'HVAC',
+  electrical: 'Electrical',
+  general_contractor: 'General Contractor',
+  pest_control: 'Pest Control',
+  roofing: 'Roofing',
+  other: 'Other',
+};
+
+const STATUS_LABEL: Record<LicenseStatus, string> = {
+  pending: 'Pending',
+  verified: 'Verified',
+  rejected: 'Rejected',
+  expired: 'Expired',
+};
+
+function StatusBadge({ status }: { status: LicenseStatus }) {
+  const map: Record<LicenseStatus, string> = {
+    pending: 'bg-amber-50 text-amber-800 border-amber-200',
+    verified: 'bg-green-50 text-green-800 border-green-200',
+    rejected: 'bg-red-50 text-red-800 border-red-200',
+    expired: 'bg-gray-100 text-gray-700 border-gray-200',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs border ${map[status]}`}>
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+function formatDate(iso: string | null) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function AdminLicensesContent() {
+  const [tab, setTab] = useState<LicenseStatus>('pending');
+  const [licenses, setLicenses] = useState<AdminLicense[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionBusyId, setActionBusyId] = useState<string | null>(null);
+  const [reasonDraft, setReasonDraft] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/admin/licenses?status=${tab}`, { cache: 'no-store' })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? `Request failed (${res.status})`);
+        }
+        return res.json();
+      })
+      .then((data: AdminLicense[]) => {
+        if (!cancelled) setLicenses(Array.isArray(data) ? data : []);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tab]);
+
+  async function handleAction(
+    id: string,
+    action: 'verify' | 'reject' | 'expire' | 'reset'
+  ) {
+    if (action === 'reject') {
+      const reason = (reasonDraft[id] ?? '').trim();
+      if (!reason) {
+        setError('Rejection reason is required.');
+        return;
+      }
+    }
+
+    setActionBusyId(id);
+    setError(null);
+
+    try {
+      const body: Record<string, unknown> = { action };
+      if (action === 'reject') {
+        body.rejection_reason = reasonDraft[id]?.trim() ?? '';
+      }
+
+      const res = await fetch(`/api/admin/licenses/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}));
+        throw new Error(errBody.error ?? `Action failed (${res.status})`);
+      }
+
+      // Refresh current tab.
+      const refresh = await fetch(`/api/admin/licenses?status=${tab}`, { cache: 'no-store' });
+      const fresh = (await refresh.json()) as AdminLicense[];
+      setLicenses(Array.isArray(fresh) ? fresh : []);
+      setReasonDraft((prev) => ({ ...prev, [id]: '' }));
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setActionBusyId(null);
+    }
+  }
+
+  const tabs = useMemo(
+    () => [
+      { key: 'pending' as const, label: 'Pending', icon: Clock },
+      { key: 'verified' as const, label: 'Verified', icon: BadgeCheck },
+      { key: 'rejected' as const, label: 'Rejected', icon: XCircle },
+      { key: 'expired' as const, label: 'Expired', icon: ShieldAlert },
+    ],
+    []
+  );
+
+  return (
+    <div className="max-w-5xl mx-auto p-4 md:p-8">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">Pro License Verification</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          DLD-445 · FL DBPR scaffold. Manual verification for plumbing, HVAC,
+          electrical, and other licensed trades. Automated DBPR lookup ships
+          in a follow-up.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        {tabs.map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm border transition ${
+              tab === key
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'
+            }`}
+          >
+            <Icon className="w-4 h-4" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="py-16 text-center text-gray-500 text-sm">Loading licenses…</div>
+      ) : licenses.length === 0 ? (
+        <div className="py-16 text-center text-gray-500 text-sm">
+          No {STATUS_LABEL[tab].toLowerCase()} licenses.
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {licenses.map((license) => {
+            const proName =
+              license.pros?.business_name ??
+              license.pros?.users?.full_name ??
+              'Unknown pro';
+            const proEmail = license.pros?.users?.email ?? '';
+            const docs = license.submitted_documents ?? [];
+
+            return (
+              <li
+                key={license.id}
+                className="bg-white border border-gray-200 rounded-xl p-4 shadow-sm"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3 mb-2">
+                  <div>
+                    <h3 className="font-medium text-gray-900">
+                      {LICENSE_TYPE_LABEL[license.license_type] ?? license.license_type}
+                      <span className="text-gray-500 font-normal"> · {license.license_number}</span>
+                    </h3>
+                    <p className="text-sm text-gray-500">
+                      {proName}
+                      {proEmail ? ` · ${proEmail}` : ''}
+                    </p>
+                  </div>
+                  <StatusBadge status={license.verification_status} />
+                </div>
+
+                <dl className="grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-1 text-xs text-gray-600 mb-3">
+                  <div>
+                    <dt className="text-gray-400">Authority</dt>
+                    <dd>
+                      {license.issuing_authority} · {license.issuing_state}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-gray-400">Submitted</dt>
+                    <dd>{formatDate(license.created_at)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-gray-400">Expires</dt>
+                    <dd>{formatDate(license.expires_at)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-gray-400">Last checked</dt>
+                    <dd>{formatDate(license.last_checked_at)}</dd>
+                  </div>
+                </dl>
+
+                {docs.length > 0 && (
+                  <div className="mb-3 text-xs">
+                    <span className="text-gray-500">Documents: </span>
+                    {docs.map((d, i) => (
+                      <span key={i} className="mr-2">
+                        {d.url ? (
+                          <a
+                            href={d.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-blue-600 underline"
+                          >
+                            {d.label ?? `Document ${i + 1}`}
+                          </a>
+                        ) : (
+                          <span>{d.label ?? `Document ${i + 1}`}</span>
+                        )}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                {license.rejection_reason && (
+                  <div className="mb-3 text-xs px-3 py-2 rounded bg-red-50 border border-red-100 text-red-800">
+                    <span className="font-medium">Rejection reason:</span>{' '}
+                    {license.rejection_reason}
+                  </div>
+                )}
+
+                {license.notes && (
+                  <p className="text-xs text-gray-500 italic mb-3">Notes: {license.notes}</p>
+                )}
+
+                {tab === 'pending' && (
+                  <div className="flex flex-col gap-2 pt-2 border-t border-gray-100">
+                    <textarea
+                      placeholder="Rejection reason (required to reject)"
+                      value={reasonDraft[license.id] ?? ''}
+                      onChange={(e) =>
+                        setReasonDraft((prev) => ({ ...prev, [license.id]: e.target.value }))
+                      }
+                      rows={2}
+                      className="text-sm border border-gray-200 rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        disabled={actionBusyId === license.id}
+                        onClick={() => handleAction(license.id, 'verify')}
+                        className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg hover:bg-green-700 disabled:opacity-60"
+                      >
+                        <BadgeCheck className="w-4 h-4" />
+                        Verify
+                      </button>
+                      <button
+                        disabled={
+                          actionBusyId === license.id ||
+                          !(reasonDraft[license.id] ?? '').trim()
+                        }
+                        onClick={() => handleAction(license.id, 'reject')}
+                        className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed"
+                      >
+                        <XCircle className="w-4 h-4" />
+                        Reject
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {tab !== 'pending' && (
+                  <div className="flex gap-2 pt-2 border-t border-gray-100">
+                    <button
+                      disabled={actionBusyId === license.id}
+                      onClick={() => handleAction(license.id, 'reset')}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-100 text-gray-700 text-sm rounded-lg hover:bg-gray-200 disabled:opacity-60"
+                    >
+                      <RotateCcw className="w-4 h-4" />
+                      Reset to pending
+                    </button>
+                    {tab === 'verified' && (
+                      <button
+                        disabled={actionBusyId === license.id}
+                        onClick={() => handleAction(license.id, 'expire')}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-amber-100 text-amber-800 text-sm rounded-lg hover:bg-amber-200 disabled:opacity-60"
+                      >
+                        <ShieldAlert className="w-4 h-4" />
+                        Mark expired
+                      </button>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function AdminLicensesPage() {
+  return (
+    <ProtectedRoute requireRole="admin">
+      <AdminLicensesContent />
+    </ProtectedRoute>
+  );
+}

--- a/supabase/migrations/20260515160000_dld445_pro_licenses.sql
+++ b/supabase/migrations/20260515160000_dld445_pro_licenses.sql
@@ -1,0 +1,308 @@
+-- =====================================================================
+-- DLD-445 — public.pro_licenses + admin verification scaffold
+-- =====================================================================
+-- FL DBPR-licensed trades (plumbing, HVAC, electrical, certain general
+-- contractors) require state license verification before they can accept
+-- leads on the platform. This migration creates the scaffold:
+--
+--   1. `pro_licenses` table — one row per (pro, license_type, license_number)
+--      tuple. Tracks verification status, issuing authority, document
+--      uploads, expiration, and last-checked timestamps for the future
+--      automated DBPR API integration.
+--   2. RLS policies — pros can read/insert/update their OWN rows (but
+--      cannot self-set `verification_status` — that column is guarded by
+--      a trigger that resets non-admin updates back to 'pending').
+--      Admins (`public.is_admin()`) and `service_role` have full access.
+--   3. Indexes on the common admin-queue and cron-sweep predicates.
+--   4. `set_updated_at()` trigger for housekeeping.
+--
+-- DEPENDS ON:
+--   - public.pros (renamed from public.cleaners in DLD-444 migration
+--     `20260515152653_dld444_rename_cleaners_to_pros.sql`). Timestamp
+--     ordering ensures DLD-444 runs first.
+--   - public.is_admin() helper (already used by Phase A1 policies).
+--   - public.set_updated_at() trigger function (already used elsewhere).
+--
+-- WHAT THIS MIGRATION INTENTIONALLY DOES NOT DO:
+--   - Does NOT block lead acceptance for unverified licensed-trade pros
+--     (that's an enforcement layer wired into /api/leads/unlock — separate
+--     Phase E ticket).
+--   - Does NOT integrate with the FL DBPR public lookup API. `dbpr_status`
+--     and `last_checked_at` columns are stubs the future cron will fill.
+--   - Does NOT add a "License Verified" badge to the public pro profile
+--     (separate Phase C+ UX ticket).
+--   - Does NOT add 6-month re-verification cron. `expires_at` exists; the
+--     sweep runs in a follow-up.
+--
+-- Idempotent. All CREATE/ADD use IF NOT EXISTS guards.
+-- =====================================================================
+
+BEGIN;
+
+-- =====================================================================
+-- PART A: pro_licenses table
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS public.pro_licenses (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pro_id uuid NOT NULL REFERENCES public.pros(id) ON DELETE CASCADE,
+
+  -- Trade category. Free text for now (e.g. 'plumbing', 'hvac',
+  -- 'electrical', 'general_contractor'). A future migration may pin this
+  -- to a controlled enum once Phase E category taxonomy stabilizes.
+  license_type text NOT NULL,
+  license_number text NOT NULL,
+  issuing_state text NOT NULL DEFAULT 'FL',
+  issuing_authority text NOT NULL DEFAULT 'FL_DBPR',
+
+  -- Manual verification workflow ----------------------------------------
+  verification_status text NOT NULL DEFAULT 'pending',
+  submitted_documents jsonb NOT NULL DEFAULT '[]'::jsonb,
+  verified_at timestamptz,
+  verified_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  rejection_reason text,
+
+  -- Expiration + future automated DBPR lookups --------------------------
+  expires_at timestamptz,
+  dbpr_status text,
+  last_checked_at timestamptz,
+
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT pro_licenses_verification_status_check
+    CHECK (verification_status IN ('pending','verified','rejected','expired'))
+);
+
+-- Prevent duplicates: a pro can register a given (license_type, number)
+-- exactly once per issuing authority.
+CREATE UNIQUE INDEX IF NOT EXISTS pro_licenses_unique_per_pro
+  ON public.pro_licenses (pro_id, license_type, license_number, issuing_authority);
+
+-- Admin queue: filter pending rows fast.
+CREATE INDEX IF NOT EXISTS idx_pro_licenses_verification_status
+  ON public.pro_licenses (verification_status)
+  WHERE verification_status IN ('pending','expired');
+
+-- Pro dashboard + lead-eligibility join.
+CREATE INDEX IF NOT EXISTS idx_pro_licenses_pro_id
+  ON public.pro_licenses (pro_id);
+
+-- Future expiration sweep.
+CREATE INDEX IF NOT EXISTS idx_pro_licenses_expires_at
+  ON public.pro_licenses (expires_at)
+  WHERE expires_at IS NOT NULL AND verification_status = 'verified';
+
+COMMENT ON TABLE public.pro_licenses IS
+  'DLD-445. Per-pro license records for FL DBPR-licensed trades (plumbing, HVAC, electrical, general contractor over $ threshold). Verified manually by admins in v1; FL DBPR API integration is a follow-up ticket.';
+
+COMMENT ON COLUMN public.pro_licenses.verification_status IS
+  'pending (default on insert) | verified | rejected | expired. Pros cannot self-set this; trigger resets non-admin attempts to ''pending''.';
+
+COMMENT ON COLUMN public.pro_licenses.submitted_documents IS
+  'JSON array of supporting document references: [{ "url": "...", "label": "...", "uploaded_at": "..." }, ...]. Storage path lives in the existing documents/ bucket.';
+
+COMMENT ON COLUMN public.pro_licenses.dbpr_status IS
+  'Snapshot of the FL DBPR public-lookup response (Active / Expired / Null & Void / Delinquent). Populated by the future automated cron — manually verified rows leave this null.';
+
+COMMENT ON COLUMN public.pro_licenses.last_checked_at IS
+  'Last time the automated DBPR cron re-fetched status. Distinct from verified_at (manual admin sign-off).';
+
+-- =====================================================================
+-- PART B: updated_at trigger
+-- =====================================================================
+DROP TRIGGER IF EXISTS set_pro_licenses_updated_at ON public.pro_licenses;
+CREATE TRIGGER set_pro_licenses_updated_at
+  BEFORE UPDATE ON public.pro_licenses
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at();
+
+-- =====================================================================
+-- PART C: guard verification_status against pro self-promotion
+-- =====================================================================
+-- Pros can update most fields on their own row (e.g. submit new
+-- documents, fix a typo in license_number), but they MUST NOT be able
+-- to flip verification_status to 'verified' or set verified_at /
+-- verified_by themselves. service_role bypasses RLS, and admins go
+-- through is_admin(); both legitimate paths therefore skip this guard.
+CREATE OR REPLACE FUNCTION public.pro_licenses_guard_verification_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  -- service_role and admins are allowed to set verification columns.
+  -- For anyone else, force these columns back to their pre-update values
+  -- (or NULL for verified_at/verified_by on insert path).
+  IF current_setting('role', true) = 'service_role' OR public.is_admin() THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    -- Self-submissions always start as pending with no audit data.
+    NEW.verification_status := 'pending';
+    NEW.verified_at := NULL;
+    NEW.verified_by := NULL;
+    NEW.rejection_reason := NULL;
+    NEW.dbpr_status := NULL;
+    NEW.last_checked_at := NULL;
+    RETURN NEW;
+  END IF;
+
+  -- UPDATE path: keep audit/verification columns frozen.
+  NEW.verification_status := OLD.verification_status;
+  NEW.verified_at := OLD.verified_at;
+  NEW.verified_by := OLD.verified_by;
+  NEW.rejection_reason := OLD.rejection_reason;
+  NEW.dbpr_status := OLD.dbpr_status;
+  NEW.last_checked_at := OLD.last_checked_at;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS pro_licenses_guard_verification_columns
+  ON public.pro_licenses;
+CREATE TRIGGER pro_licenses_guard_verification_columns
+  BEFORE INSERT OR UPDATE ON public.pro_licenses
+  FOR EACH ROW
+  EXECUTE FUNCTION public.pro_licenses_guard_verification_columns();
+
+-- =====================================================================
+-- PART D: RLS
+-- =====================================================================
+ALTER TABLE public.pro_licenses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.pro_licenses FORCE ROW LEVEL SECURITY;
+
+-- service_role: unrestricted (Edge Functions, server-side cron).
+DROP POLICY IF EXISTS "service_role_full_access_pro_licenses"
+  ON public.pro_licenses;
+CREATE POLICY "service_role_full_access_pro_licenses"
+  ON public.pro_licenses
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Admins: full read/write through is_admin().
+DROP POLICY IF EXISTS "admin_full_access_pro_licenses"
+  ON public.pro_licenses;
+CREATE POLICY "admin_full_access_pro_licenses"
+  ON public.pro_licenses
+  FOR ALL
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- Pros: read their own license rows (ownership via pros.user_id = auth.uid()).
+DROP POLICY IF EXISTS "pros_read_own_licenses"
+  ON public.pro_licenses;
+CREATE POLICY "pros_read_own_licenses"
+  ON public.pro_licenses
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.pros p
+      WHERE p.id = public.pro_licenses.pro_id
+        AND p.user_id = (select auth.uid())
+    )
+  );
+
+-- Pros: insert their own license rows. The trigger above forces
+-- verification_status='pending' regardless of the submitted value.
+DROP POLICY IF EXISTS "pros_insert_own_licenses"
+  ON public.pro_licenses;
+CREATE POLICY "pros_insert_own_licenses"
+  ON public.pro_licenses
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.pros p
+      WHERE p.id = public.pro_licenses.pro_id
+        AND p.user_id = (select auth.uid())
+    )
+  );
+
+-- Pros: update their own license rows (e.g. resubmit docs after a
+-- rejection). The trigger above freezes verification_status,
+-- verified_at, verified_by, rejection_reason, dbpr_status, and
+-- last_checked_at so this path cannot self-promote.
+DROP POLICY IF EXISTS "pros_update_own_licenses"
+  ON public.pro_licenses;
+CREATE POLICY "pros_update_own_licenses"
+  ON public.pro_licenses
+  FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.pros p
+      WHERE p.id = public.pro_licenses.pro_id
+        AND p.user_id = (select auth.uid())
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.pros p
+      WHERE p.id = public.pro_licenses.pro_id
+        AND p.user_id = (select auth.uid())
+    )
+  );
+
+-- Pros: delete their own license rows (e.g. removed wrong type).
+DROP POLICY IF EXISTS "pros_delete_own_licenses"
+  ON public.pro_licenses;
+CREATE POLICY "pros_delete_own_licenses"
+  ON public.pro_licenses
+  FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.pros p
+      WHERE p.id = public.pro_licenses.pro_id
+        AND p.user_id = (select auth.uid())
+    )
+  );
+
+-- =====================================================================
+-- PART E: Post-conditions sanity checks
+-- =====================================================================
+DO $$
+DECLARE
+  v_policy_count int;
+  v_index_count int;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='pro_licenses') THEN
+    RAISE EXCEPTION 'DLD-445 sanity: public.pro_licenses not created';
+  END IF;
+
+  SELECT count(*) INTO v_policy_count
+  FROM pg_policies WHERE schemaname='public' AND tablename='pro_licenses';
+  IF v_policy_count <> 6 THEN
+    RAISE EXCEPTION 'DLD-445 sanity: expected 6 RLS policies on pro_licenses, found %', v_policy_count;
+  END IF;
+
+  SELECT count(*) INTO v_index_count
+  FROM pg_indexes WHERE schemaname='public' AND tablename='pro_licenses';
+  -- 4 explicit indexes + the implicit PK index = 5 total.
+  IF v_index_count < 4 THEN
+    RAISE EXCEPTION 'DLD-445 sanity: expected at least 4 indexes on pro_licenses, found %', v_index_count;
+  END IF;
+END$$;
+
+COMMIT;
+
+-- =====================================================================
+-- Manual rollback (if ever needed):
+-- =====================================================================
+-- BEGIN;
+-- DROP TRIGGER IF EXISTS pro_licenses_guard_verification_columns ON public.pro_licenses;
+-- DROP FUNCTION IF EXISTS public.pro_licenses_guard_verification_columns();
+-- DROP TABLE IF EXISTS public.pro_licenses;
+-- COMMIT;


### PR DESCRIPTION
## Summary

DLD-445 — foundation/scaffold for FL DBPR pro-license verification (plumbing, HVAC, electrical, general contractor over $ threshold). Manual admin verification in v1; automated FL DBPR public-lookup is a follow-up ticket.

- New table `public.pro_licenses` + RLS + indexes + audit guards
- Pro self-service: `/api/pro/licenses` (GET/POST)
- Admin queue: `/api/admin/licenses` (GET) + `/api/admin/licenses/[id]` (PATCH verify/reject/expire/reset)
- Admin UI at `/dashboard/admin/pros/licenses` (sidebar link added)

Stacks on top of DLD-444 (PR #11, merged). Rebased onto current `main`.

## Schema (`supabase/migrations/20260515160000_dld445_pro_licenses.sql`)

- `pro_licenses`: `id, pro_id (FK public.pros), license_type, license_number, issuing_state, issuing_authority, verification_status (pending|verified|rejected|expired), submitted_documents jsonb, verified_at, verified_by, rejection_reason, expires_at, dbpr_status, last_checked_at, notes, created_at, updated_at`
- Unique `(pro_id, license_type, license_number, issuing_authority)`
- Indexes: admin queue (`verification_status` partial), pro dashboard (`pro_id`), future expiration sweep (`expires_at` partial)
- `set_updated_at()` trigger
- `pro_licenses_guard_verification_columns` trigger: non-admin INSERT/UPDATE forcibly resets the verification + audit columns so pros cannot self-promote. `service_role` + `public.is_admin()` bypass.
- RLS (6 policies): `service_role` full; admin full via `is_admin()`; pros read/insert/update/delete own rows via `pros.user_id = auth.uid()`
- Post-conditions sanity block enforces 6 policies + ≥4 indexes
- Idempotent and contains documented manual rollback at the bottom

## API

| Route | Method | Caller | Purpose |
|---|---|---|---|
| `/api/pro/licenses` | GET | authenticated pro | list own licenses |
| `/api/pro/licenses` | POST | authenticated pro | submit a license (always lands as `pending` — DB trigger enforced) |
| `/api/admin/licenses?status=pending` | GET | admin | list licenses (default pending; `verified`, `rejected`, `expired`, `all` allowed) |
| `/api/admin/licenses/[id]` | PATCH | admin | `verify` \| `reject` \| `expire` \| `reset`, mirrors action into `admin_actions` |

`license_type` is validated server-side to `{plumbing, hvac, electrical, general_contractor, pest_control, roofing, other}`. `issuing_authority` is validated to `{FL_DBPR, OTHER}`.

## UI

- `/dashboard/admin/pros/licenses` — 4-tab queue (pending / verified / rejected / expired)
- Inline verify, reject (reason required), reset, expire actions
- Lists submitted document references (storage flow shares the existing `cleaner-documents` bucket in a follow-up; for now `submitted_documents` accepts a JSON array of `{url, label}` entries)
- Sidebar entry added to admin layout

## Out of scope (deliberate — separate Phase E / Phase C+ tickets)

- Lead-acceptance gate for unverified licensed-trade pros
- Public "License Verified" badge on pro profiles
- Automated FL DBPR public-lookup cron + `dbpr_status` writes
- 6-month re-verification expiration sweep
- File upload UX into the docs bucket (currently expects pre-uploaded URLs)

## TS baseline

`npx tsc --noEmit` reports **58** errors on this branch. Current `main` baseline is also **58** (board comment quoted 56 at the time of writing; main has since absorbed DLD-442/443/452 which raised the floor by 2). My new files add **zero** TS errors — verified by grepping the error output for `pro_licenses`, `pro/licenses`, `admin/licenses`, and the modified `admin/layout.tsx`. None appear.

## Diff stat (vs `origin/main`)

```
 app/api/admin/licenses/[id]/route.ts               | 140 ++++++++
 app/api/admin/licenses/route.ts                    |  84 +++++
 app/api/pro/licenses/route.ts                      | 170 ++++++++++
 app/dashboard/admin/layout.tsx                     |   3 +-
 app/dashboard/admin/pros/licenses/page.tsx         | 371 +++++++++++++++++++++
 .../20260515160000_dld445_pro_licenses.sql         | 308 +++++++++++++++++
 6 files changed, 1075 insertions(+), 1 deletion(-)
```

## Test plan

- [ ] Apply migration on a Supabase preview branch; rerun the embedded sanity block to confirm 6 policies + ≥4 indexes
- [ ] Smoke-test `POST /api/pro/licenses` as a non-admin pro — confirm response has `verification_status: 'pending'` even when payload explicitly tries to set `verified`
- [ ] Smoke-test `PATCH /api/admin/licenses/[id] {action: "verify"}` from an admin and confirm `admin_actions` row is created
- [ ] Visit `/dashboard/admin/pros/licenses`, click through Pending → Verified → Rejected tabs, exercise inline verify + reject (reason field)
- [ ] Verify a non-admin user cannot read other pros' license rows (RLS check via a service-role assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)