### PR TITLE
DLD-449: Pro signup category selection (primary + secondary)

### DIFF
--- a/app/api/cleaners/onboarding/route.ts
+++ b/app/api/cleaners/onboarding/route.ts
@@ -1,11 +1,15 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { createLogger } from '@/lib/utils/logger'
+import {
+  normalizeCategorySlugs,
+  reconcileProCategories,
+} from '@/lib/services/pro-categories'
 
 const logger = createLogger({ file: 'api/cleaners/onboarding/route' })
 
 // GET /api/cleaners/onboarding - Get current onboarding draft
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   try {
     const supabase = await createClient()
 
@@ -14,49 +18,65 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Get cleaner profile with onboarding data
-    const { data: cleaner, error } = await supabase
-      .from('cleaners')
-      .select('id, onboarding_step, onboarding_data, onboarding_completed_at, business_name, business_description, business_phone, business_email, website_url, services, service_areas, hourly_rate, minimum_hours, years_experience, employees_count, profile_image_url, business_images')
+    // DLD-449: pros table is the source of truth; the `cleaners` view is
+    // legacy backwards-compat from DLD-444.
+    const { data: pro, error } = await supabase
+      .from('pros')
+      .select(
+        'id, onboarding_step, onboarding_data, onboarding_completed_at, business_name, business_description, business_phone, business_email, website_url, services, service_areas, hourly_rate, minimum_hours, years_experience, employees_count, profile_image_url, business_images, primary_category'
+      )
       .eq('user_id', user.id)
       .single()
 
-    if (error && error.code !== 'PGRST116') { // PGRST116 = no rows found
-      logger.error('Error fetching cleaner', { function: 'GET' }, error)
+    if (error && error.code !== 'PGRST116') {
+      logger.error('Error fetching pro', { function: 'GET' }, error)
       return NextResponse.json({ error: 'Failed to fetch onboarding data' }, { status: 500 })
     }
 
-    // If no cleaner profile exists, return empty state
-    if (!cleaner) {
+    if (!pro) {
       return NextResponse.json({
         cleaner_id: null,
         onboarding_step: 1,
         onboarding_data: {},
-        onboarding_completed_at: null
+        onboarding_completed_at: null,
       })
     }
 
+    const { data: categoryRows, error: categoriesError } = await supabase
+      .from('pro_categories')
+      .select('category, is_primary')
+      .eq('pro_id', pro.id)
+
+    if (categoriesError) {
+      logger.error('Error fetching pro_categories', { function: 'GET' }, categoriesError)
+    }
+
+    const secondaryCategories = (categoryRows ?? [])
+      .filter((row) => !row.is_primary)
+      .map((row) => row.category)
+
     return NextResponse.json({
-      cleaner_id: cleaner.id,
-      onboarding_step: cleaner.onboarding_step || 1,
-      onboarding_data: cleaner.onboarding_data || {},
-      onboarding_completed_at: cleaner.onboarding_completed_at,
-      // Include existing profile data for pre-filling
+      cleaner_id: pro.id,
+      onboarding_step: pro.onboarding_step || 1,
+      onboarding_data: pro.onboarding_data || {},
+      onboarding_completed_at: pro.onboarding_completed_at,
       profile: {
-        business_name: cleaner.business_name,
-        business_description: cleaner.business_description,
-        business_phone: cleaner.business_phone,
-        business_email: cleaner.business_email,
-        website_url: cleaner.website_url,
-        services: cleaner.services,
-        service_areas: cleaner.service_areas,
-        hourly_rate: cleaner.hourly_rate,
-        minimum_hours: cleaner.minimum_hours,
-        years_experience: cleaner.years_experience,
-        employees_count: cleaner.employees_count,
-        profile_image_url: cleaner.profile_image_url,
-        portfolio_images: cleaner.business_images
-      }
+        business_name: pro.business_name,
+        business_description: pro.business_description,
+        business_phone: pro.business_phone,
+        business_email: pro.business_email,
+        website_url: pro.website_url,
+        services: pro.services,
+        service_areas: pro.service_areas,
+        hourly_rate: pro.hourly_rate,
+        minimum_hours: pro.minimum_hours,
+        years_experience: pro.years_experience,
+        employees_count: pro.employees_count,
+        profile_image_url: pro.profile_image_url,
+        portfolio_images: pro.business_images,
+        primary_category: pro.primary_category,
+        secondary_categories: secondaryCategories,
+      },
     })
   } catch (error) {
     logger.error('Error in GET /api/cleaners/onboarding', { function: 'GET' }, error)
@@ -81,81 +101,129 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid step' }, { status: 400 })
     }
 
-    // Check if cleaner profile exists
-    const { data: existingCleaner, error: fetchError } = await supabase
-      .from('cleaners')
-      .select('id, onboarding_data')
+    // DLD-449: Resolve category slugs against the canonical taxonomy.
+    // Unknown slugs are silently dropped so a single bad client value can't
+    // break the whole save. Validation happens again at submit time.
+    let primaryCategory: string | null | undefined = undefined
+    if (data?.primary_category !== undefined) {
+      const [canonicalPrimary] = await normalizeCategorySlugs(
+        supabase,
+        data.primary_category ? [data.primary_category] : []
+      )
+      primaryCategory = canonicalPrimary ?? null
+    }
+
+    let secondaryCategories: string[] | undefined = undefined
+    if (Array.isArray(data?.secondary_categories)) {
+      secondaryCategories = await normalizeCategorySlugs(
+        supabase,
+        data.secondary_categories.filter((s: unknown): s is string => typeof s === 'string')
+      )
+      if (primaryCategory) {
+        secondaryCategories = secondaryCategories.filter((s) => s !== primaryCategory)
+      }
+    }
+
+    const { data: existingPro, error: fetchError } = await supabase
+      .from('pros')
+      .select('id, onboarding_data, primary_category')
       .eq('user_id', user.id)
       .single()
 
     if (fetchError && fetchError.code !== 'PGRST116') {
-      logger.error('Error fetching cleaner', { function: 'POST' }, fetchError)
-      return NextResponse.json({ error: 'Failed to fetch cleaner profile' }, { status: 500 })
+      logger.error('Error fetching pro', { function: 'POST' }, fetchError)
+      return NextResponse.json({ error: 'Failed to fetch pro profile' }, { status: 500 })
     }
 
-    let cleanerId: string
+    let proId: string
 
-    if (existingCleaner) {
-      // Update existing cleaner
-      const mergedData = { ...(existingCleaner.onboarding_data || {}), ...data }
+    if (existingPro) {
+      const mergedData = { ...(existingPro.onboarding_data || {}), ...data }
+      const legacyServices: string[] | undefined = primaryCategory && secondaryCategories
+        ? [primaryCategory, ...secondaryCategories]
+        : Array.isArray(data.services)
+          ? data.services
+          : undefined
+
+      const updatePayload: Record<string, unknown> = {
+        onboarding_step: step,
+        onboarding_data: mergedData,
+        updated_at: new Date().toISOString(),
+      }
+      if (data.business_name) updatePayload.business_name = data.business_name
+      if (data.business_description) updatePayload.business_description = data.business_description
+      if (data.business_phone) updatePayload.business_phone = data.business_phone
+      if (data.business_email) updatePayload.business_email = data.business_email
+      if (data.website_url !== undefined) updatePayload.website_url = data.website_url
+      if (legacyServices) updatePayload.services = legacyServices
+      if (data.service_areas) updatePayload.service_areas = data.service_areas
+      if (data.hourly_rate) updatePayload.hourly_rate = data.hourly_rate
+      if (data.minimum_hours) updatePayload.minimum_hours = data.minimum_hours
+      if (data.years_experience !== undefined) updatePayload.years_experience = data.years_experience
+      if (data.employees_count) updatePayload.employees_count = data.employees_count
+      if (data.profile_image_url) updatePayload.profile_image_url = data.profile_image_url
+      if (data.portfolio_images) updatePayload.business_images = data.portfolio_images
+      if (primaryCategory !== undefined) updatePayload.primary_category = primaryCategory
 
       const { error: updateError } = await supabase
-        .from('cleaners')
-        .update({
-          onboarding_step: step,
-          onboarding_data: mergedData,
-          // Update main profile fields if provided
-          ...(data.business_name && { business_name: data.business_name }),
-          ...(data.business_description && { business_description: data.business_description }),
-          ...(data.business_phone && { business_phone: data.business_phone }),
-          ...(data.business_email && { business_email: data.business_email }),
-          ...(data.website_url !== undefined && { website_url: data.website_url }),
-          ...(data.services && { services: data.services }),
-          ...(data.service_areas && { service_areas: data.service_areas }),
-          ...(data.hourly_rate && { hourly_rate: data.hourly_rate }),
-          ...(data.minimum_hours && { minimum_hours: data.minimum_hours }),
-          ...(data.years_experience !== undefined && { years_experience: data.years_experience }),
-          ...(data.employees_count && { employees_count: data.employees_count }),
-          ...(data.profile_image_url && { profile_image_url: data.profile_image_url }),
-          ...(data.portfolio_images && { business_images: data.portfolio_images }),
-          updated_at: new Date().toISOString()
-        })
-        .eq('id', existingCleaner.id)
+        .from('pros')
+        .update(updatePayload)
+        .eq('id', existingPro.id)
 
       if (updateError) {
-        logger.error('Error updating cleaner', { function: 'POST' }, updateError)
+        logger.error('Error updating pro', { function: 'POST' }, updateError)
         return NextResponse.json({ error: 'Failed to save draft' }, { status: 500 })
       }
 
-      cleanerId = existingCleaner.id
+      proId = existingPro.id
     } else {
-      // Create new cleaner profile
-      const { data: newCleaner, error: insertError } = await supabase
-        .from('cleaners')
-        .insert({
-          user_id: user.id,
-          business_name: data.business_name || 'New Business',
-          business_email: data.business_email || user.email,
-          onboarding_step: step,
-          onboarding_data: data,
-          approval_status: 'pending'
-        })
+      const insertPayload: Record<string, unknown> = {
+        user_id: user.id,
+        business_name: data.business_name || 'New Business',
+        business_email: data.business_email || user.email,
+        onboarding_step: step,
+        onboarding_data: data,
+        approval_status: 'pending',
+      }
+      if (primaryCategory !== undefined) insertPayload.primary_category = primaryCategory
+      if (primaryCategory && secondaryCategories) {
+        insertPayload.services = [primaryCategory, ...secondaryCategories]
+      } else if (Array.isArray(data.services)) {
+        insertPayload.services = data.services
+      }
+
+      const { data: newPro, error: insertError } = await supabase
+        .from('pros')
+        .insert(insertPayload)
         .select('id')
         .single()
 
-      if (insertError) {
-        logger.error('Error creating cleaner', { function: 'POST' }, insertError)
-        return NextResponse.json({ error: 'Failed to create cleaner profile' }, { status: 500 })
+      if (insertError || !newPro) {
+        logger.error('Error creating pro', { function: 'POST' }, insertError)
+        return NextResponse.json({ error: 'Failed to create pro profile' }, { status: 500 })
       }
 
-      cleanerId = newCleaner.id
+      proId = newPro.id
+    }
+
+    if (primaryCategory !== undefined || secondaryCategories !== undefined) {
+      const reconcileResult = await reconcileProCategories(supabase, {
+        proId,
+        selection: {
+          primary: primaryCategory ?? null,
+          secondary: secondaryCategories ?? [],
+        },
+      })
+      if (!reconcileResult.ok) {
+        return NextResponse.json({ error: reconcileResult.error }, { status: 500 })
+      }
     }
 
     return NextResponse.json({
       success: true,
-      cleaner_id: cleanerId,
-      step: step,
-      message: 'Draft saved successfully'
+      cleaner_id: proId,
+      step,
+      message: 'Draft saved successfully',
     })
   } catch (error) {
     logger.error('Error in POST /api/cleaners/onboarding', { function: 'POST' }, error)

--- a/app/api/cleaners/onboarding/submit/route.ts
+++ b/app/api/cleaners/onboarding/submit/route.ts
@@ -5,7 +5,7 @@ import { createLogger } from '@/lib/utils/logger'
 const logger = createLogger({ file: 'api/cleaners/onboarding/submit/route' })
 
 // POST /api/cleaners/onboarding/submit - Submit onboarding for approval
-export async function POST(request: NextRequest) {
+export async function POST(_request: NextRequest) {
   try {
     const supabase = await createClient()
 
@@ -14,62 +14,64 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Get cleaner profile
-    const { data: cleaner, error: fetchError } = await supabase
-      .from('cleaners')
+    // DLD-449: write through the pros table directly.
+    const { data: pro, error: fetchError } = await supabase
+      .from('pros')
       .select('*')
       .eq('user_id', user.id)
       .single()
 
-    if (fetchError || !cleaner) {
-      return NextResponse.json({ error: 'Cleaner profile not found' }, { status: 404 })
+    if (fetchError || !pro) {
+      return NextResponse.json({ error: 'Pro profile not found' }, { status: 404 })
     }
 
-    // Validate required fields
     const requiredFields = ['business_name', 'business_phone', 'business_email']
-    const missingFields = requiredFields.filter(field => !cleaner[field])
+    const missingFields = requiredFields.filter((field) => !pro[field])
 
     if (missingFields.length > 0) {
-      return NextResponse.json({
-        error: 'Missing required fields',
-        missing: missingFields
-      }, { status: 400 })
+      return NextResponse.json(
+        {
+          error: 'Missing required fields',
+          missing: missingFields,
+        },
+        { status: 400 }
+      )
     }
 
-    // Validate services and service areas
-    if (!cleaner.services || cleaner.services.length === 0) {
-      return NextResponse.json({ error: 'At least one service is required' }, { status: 400 })
+    if (!pro.primary_category) {
+      return NextResponse.json(
+        { error: 'Choose your primary service category before submitting' },
+        { status: 400 }
+      )
     }
 
-    if (!cleaner.service_areas || cleaner.service_areas.length === 0) {
+    if (!pro.service_areas || pro.service_areas.length === 0) {
       return NextResponse.json({ error: 'At least one service area is required' }, { status: 400 })
     }
 
-    // Apply photo data from onboarding_data to cleaner profile
-    const onboardingData = cleaner.onboarding_data || {}
+    const onboardingData = pro.onboarding_data || {}
 
-    // Update cleaner status to submitted
     const { error: updateError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .update({
         onboarding_step: 6,
         onboarding_completed_at: new Date().toISOString(),
         approval_status: 'pending',
         ...(onboardingData.profile_image_url && { profile_image_url: onboardingData.profile_image_url }),
         ...(onboardingData.portfolio_images && { business_images: onboardingData.portfolio_images }),
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
-      .eq('id', cleaner.id)
+      .eq('id', pro.id)
 
     if (updateError) {
-      logger.error('Error updating cleaner', { function: 'POST' }, updateError)
+      logger.error('Error updating pro', { function: 'POST' }, updateError)
       return NextResponse.json({ error: 'Failed to submit onboarding' }, { status: 500 })
     }
 
     return NextResponse.json({
       success: true,
       message: 'Onboarding submitted for approval',
-      cleaner_id: cleaner.id
+      cleaner_id: pro.id,
     })
   } catch (error) {
     logger.error('Error in POST /api/cleaners/onboarding/submit', { function: 'POST' }, error)

--- a/app/api/pros/categories/route.ts
+++ b/app/api/pros/categories/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createLogger } from '@/lib/utils/logger'
+import {
+  normalizeCategorySlugs,
+  reconcileProCategories,
+} from '@/lib/services/pro-categories'
+
+const logger = createLogger({ file: 'api/pros/categories/route' })
+
+// GET /api/pros/categories — return the signed-in pro's current selection.
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: pro, error: proError } = await supabase
+      .from('pros')
+      .select('id, primary_category')
+      .eq('user_id', user.id)
+      .single()
+
+    if (proError || !pro) {
+      return NextResponse.json({ error: 'Pro profile not found' }, { status: 404 })
+    }
+
+    const { data: rows } = await supabase
+      .from('pro_categories')
+      .select('category, is_primary')
+      .eq('pro_id', pro.id)
+
+    const secondary = (rows ?? [])
+      .filter((r) => !r.is_primary)
+      .map((r) => r.category)
+
+    return NextResponse.json({
+      primary_category: pro.primary_category,
+      secondary_categories: secondary,
+    })
+  } catch (error) {
+    logger.error('Error in GET /api/pros/categories', { function: 'GET' }, error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// PATCH /api/pros/categories — replace the pro's category selection.
+export async function PATCH(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = (await request.json()) as {
+      primary_category?: string | null
+      secondary_categories?: unknown
+    }
+
+    const { data: pro, error: proError } = await supabase
+      .from('pros')
+      .select('id')
+      .eq('user_id', user.id)
+      .single()
+    if (proError || !pro) {
+      return NextResponse.json({ error: 'Pro profile not found' }, { status: 404 })
+    }
+
+    const [canonicalPrimary] = await normalizeCategorySlugs(
+      supabase,
+      body.primary_category ? [body.primary_category] : []
+    )
+    const primary = canonicalPrimary ?? null
+
+    const rawSecondary = Array.isArray(body.secondary_categories)
+      ? body.secondary_categories.filter((s): s is string => typeof s === 'string')
+      : []
+    const secondary = (await normalizeCategorySlugs(supabase, rawSecondary)).filter(
+      (s) => s !== primary
+    )
+
+    const { error: updateError } = await supabase
+      .from('pros')
+      .update({
+        primary_category: primary,
+        services: primary ? [primary, ...secondary] : secondary,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', pro.id)
+
+    if (updateError) {
+      logger.error('Failed to update pros.primary_category', { proId: pro.id }, updateError)
+      return NextResponse.json({ error: 'Failed to save categories' }, { status: 500 })
+    }
+
+    const reconcile = await reconcileProCategories(supabase, {
+      proId: pro.id,
+      selection: { primary, secondary },
+    })
+    if (!reconcile.ok) {
+      return NextResponse.json({ error: reconcile.error }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      primary_category: primary,
+      secondary_categories: secondary,
+    })
+  } catch (error) {
+    logger.error('Error in PATCH /api/pros/categories', { function: 'PATCH' }, error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/service-categories/route.ts
+++ b/app/api/service-categories/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createLogger } from '@/lib/utils/logger'
+
+const logger = createLogger({ file: 'api/service-categories/route' })
+
+export const dynamic = 'force-dynamic'
+
+export type ServiceCategory = {
+  slug: string
+  display_name: string
+  description: string | null
+  fee_tier: string
+  supports_residential: boolean
+  supports_commercial: boolean
+  requires_license_fl: boolean
+  alias_for: string | null
+  priority_order: number
+}
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+
+    const { data, error } = await supabase
+      .from('service_categories')
+      .select(
+        'slug, display_name, description, fee_tier, supports_residential, supports_commercial, requires_license_fl, alias_for, priority_order'
+      )
+      .eq('is_active', true)
+      .order('priority_order', { ascending: true })
+      .order('slug', { ascending: true })
+
+    if (error) {
+      logger.error('Failed to load service_categories', { function: 'GET' }, error)
+      return NextResponse.json({ error: 'Failed to load categories' }, { status: 500 })
+    }
+
+    return NextResponse.json({ categories: (data ?? []) as ServiceCategory[] })
+  } catch (error) {
+    logger.error('Unhandled error in GET /api/service-categories', { function: 'GET' }, error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/dashboard/pro/profile/page.tsx
+++ b/app/dashboard/pro/profile/page.tsx
@@ -13,6 +13,7 @@ import {
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { createLogger } from '@/lib/utils/logger';
+import CategorySelector from '@/components/onboarding/CategorySelector';
 
 const logger = createLogger({ file: 'app/dashboard/pro/profile/page.tsx' });
 
@@ -37,14 +38,10 @@ interface CleanerProfile {
   business_state?: string;
   business_zip?: string;
   business_images: string[];
+  // DLD-449
+  primary_category?: string | null;
+  secondary_categories?: string[];
 }
-
-const AVAILABLE_SERVICES = [
-  'House Cleaning', 'Deep Cleaning', 'Move-in/Move-out Cleaning',
-  'Post-Construction Cleaning', 'Carpet Cleaning',
-  'Window Cleaning', 'Pressure Washing', 'Organizing Services',
-  'Laundry Services', 'Pet-Friendly Cleaning', 'Green/Eco Cleaning'
-];
 
 export default function CleanerProfilePage() {
   const { user } = useAuth();
@@ -64,16 +61,28 @@ export default function CleanerProfilePage() {
 
   const loadProfile = async () => {
     try {
+      // DLD-449: source from `pros` directly; the `cleaners` view is legacy.
       const { data, error } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('*')
         .eq('user_id', user?.id)
         .single();
 
       if (error && error.code !== 'PGRST116') throw error;
-      
+
       if (data) {
-        setProfile(data);
+        const { data: catRows } = await supabase
+          .from('pro_categories')
+          .select('category, is_primary')
+          .eq('pro_id', data.id);
+        type CategoryRow = { category: string; is_primary: boolean };
+        const secondary = ((catRows ?? []) as CategoryRow[])
+          .filter((r: CategoryRow) => !r.is_primary)
+          .map((r: CategoryRow) => r.category);
+        setProfile({
+          ...data,
+          secondary_categories: secondary,
+        });
       } else {
         // Create default profile if none exists
         const newProfile = {
@@ -94,7 +103,7 @@ export default function CleanerProfilePage() {
         };
         
         const { data: created, error: createError } = await supabase
-          .from('cleaners')
+          .from('pros')
           .insert(newProfile)
           .select()
           .single();
@@ -115,12 +124,21 @@ export default function CleanerProfilePage() {
     setProfile({ ...profile, [field]: value });
   };
 
-  const handleServiceToggle = (service: string) => {
+  const handleCategoriesChange = ({
+    primary,
+    secondary,
+  }: {
+    primary: string | null;
+    secondary: string[];
+  }) => {
     if (!profile) return;
-    const services = profile.services.includes(service)
-      ? profile.services.filter(s => s !== service)
-      : [...profile.services, service];
-    setProfile({ ...profile, services });
+    const legacyServices = primary ? [primary, ...secondary] : secondary;
+    setProfile({
+      ...profile,
+      primary_category: primary,
+      secondary_categories: secondary,
+      services: legacyServices,
+    });
   };
 
   const handlePhotoUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -179,14 +197,29 @@ export default function CleanerProfilePage() {
     
     setSaving(true);
     try {
+      // DLD-449: route category changes through the dedicated endpoint so
+      // pro_categories stays in sync with pros.primary_category.
+      const categoriesResponse = await fetch('/api/pros/categories', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          primary_category: profile.primary_category ?? null,
+          secondary_categories: profile.secondary_categories ?? [],
+        }),
+      });
+      if (!categoriesResponse.ok) {
+        const result = await categoriesResponse.json().catch(() => ({}));
+        setMessage(`Error saving categories: ${result.error || 'Unknown error'}`);
+        return;
+      }
+
       const { error } = await supabase
-        .from('cleaners')
+        .from('pros')
         .update({
           business_name: profile.business_name,
           business_description: profile.business_description,
           business_phone: profile.business_phone,
           business_email: profile.business_email,
-          services: profile.services,
           hourly_rate: profile.hourly_rate,
           minimum_hours: profile.minimum_hours,
           years_experience: profile.years_experience,
@@ -205,7 +238,7 @@ export default function CleanerProfilePage() {
         setMessage(`Error saving profile: ${error.message}`);
         return;
       }
-      
+
       setMessage('Profile updated successfully!');
       setTimeout(() => setMessage(''), 3000);
     } catch (error) {
@@ -486,26 +519,19 @@ export default function CleanerProfilePage() {
               </div>
             </div>
 
-            {/* Services Offered */}
+            {/* Services Offered (DLD-449) */}
             <div className="bg-white rounded-lg shadow-sm p-6">
               <h2 className="text-lg font-semibold text-gray-900 mb-6 flex items-center gap-2">
                 <Award className="h-5 w-5" />
                 Services Offered
               </h2>
-              
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                {AVAILABLE_SERVICES.map((service) => (
-                  <label key={service} className="flex items-center p-3 border rounded-lg hover:bg-gray-50 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={profile.services.includes(service)}
-                      onChange={() => handleServiceToggle(service)}
-                      className="mr-3"
-                    />
-                    <span className="text-sm">{service}</span>
-                  </label>
-                ))}
-              </div>
+
+              <CategorySelector
+                primary={profile.primary_category ?? null}
+                secondary={profile.secondary_categories ?? []}
+                onChange={handleCategoriesChange}
+                disabled={saving}
+              />
             </div>
 
             {/* Photo Gallery */}

--- a/components/onboarding/CategorySelector.tsx
+++ b/components/onboarding/CategorySelector.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Loader2, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ServiceCategory } from '@/lib/types/service-category'
+
+interface CategorySelectorProps {
+  primary: string | null | undefined
+  secondary: string[] | undefined
+  onChange: (next: { primary: string | null; secondary: string[] }) => void
+  errors?: { primary?: string; secondary?: string }
+  disabled?: boolean
+}
+
+export default function CategorySelector({
+  primary,
+  secondary,
+  onChange,
+  errors,
+  disabled,
+}: CategorySelectorProps) {
+  const [categories, setCategories] = useState<ServiceCategory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const response = await fetch('/api/service-categories')
+        if (!response.ok) {
+          throw new Error('Failed to load categories')
+        }
+        const result = (await response.json()) as { categories: ServiceCategory[] }
+        if (!cancelled) {
+          setCategories(result.categories ?? [])
+          setLoading(false)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setLoadError('Could not load service categories. Refresh and try again.')
+          setLoading(false)
+        }
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const safeSecondary = useMemo(() => secondary ?? [], [secondary])
+
+  const handlePrimaryChange = (slug: string) => {
+    const cleaned = safeSecondary.filter((s) => s !== slug)
+    onChange({ primary: slug, secondary: cleaned })
+  }
+
+  const toggleSecondary = (slug: string) => {
+    if (slug === primary) return
+    const next = safeSecondary.includes(slug)
+      ? safeSecondary.filter((s) => s !== slug)
+      : [...safeSecondary, slug]
+    onChange({ primary: primary ?? null, secondary: next })
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-gray-500">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading service categories...
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return <p className="text-sm text-red-600">{loadError}</p>
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="primary_category" className="text-lg">
+          Primary category <span className="text-red-500">*</span>
+        </Label>
+        <p className="text-sm text-gray-500">
+          Your main business. Leads in this category route to you first.
+        </p>
+        <Select
+          value={primary ?? undefined}
+          onValueChange={handlePrimaryChange}
+          disabled={disabled}
+        >
+          <SelectTrigger
+            id="primary_category"
+            className={cn('w-full max-w-md', errors?.primary && 'border-red-500')}
+            aria-invalid={!!errors?.primary}
+          >
+            <SelectValue placeholder="Choose your primary service" />
+          </SelectTrigger>
+          <SelectContent>
+            {categories.map((c) => (
+              <SelectItem key={c.slug} value={c.slug}>
+                {c.display_name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {errors?.primary && (
+          <p className="text-sm text-red-600">{errors.primary}</p>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <Label className="text-lg">Additional services you offer</Label>
+        <p className="text-sm text-gray-500">
+          Optional. Pick any other categories you serve — you&apos;ll also see leads
+          for these, ranked below your primary.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {categories.map((c) => {
+            const isPrimary = c.slug === primary
+            const isSelected = safeSecondary.includes(c.slug)
+            return (
+              <button
+                key={c.slug}
+                type="button"
+                disabled={disabled || isPrimary}
+                onClick={() => toggleSecondary(c.slug)}
+                aria-pressed={isSelected}
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+                  isPrimary &&
+                    'cursor-not-allowed border-[#FF5F1F]/40 bg-[#FF5F1F]/10 text-[#FF5F1F]',
+                  !isPrimary && isSelected &&
+                    'border-[#FF5F1F] bg-[#FF5F1F] text-white hover:bg-[#e85410]',
+                  !isPrimary && !isSelected &&
+                    'border-gray-300 bg-white text-gray-700 hover:border-[#FF5F1F]/60 hover:bg-[#FF5F1F]/5'
+                )}
+              >
+                {c.display_name}
+                {isPrimary && (
+                  <span className="ml-1 rounded-full bg-[#FF5F1F] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white">
+                    Primary
+                  </span>
+                )}
+                {!isPrimary && isSelected && <X className="h-3 w-3" />}
+              </button>
+            )
+          })}
+        </div>
+        {errors?.secondary && (
+          <p className="text-sm text-red-600">{errors.secondary}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/onboarding/ServicesForm.tsx
+++ b/components/onboarding/ServicesForm.tsx
@@ -1,21 +1,21 @@
 'use client'
 
 import { useState } from 'react'
-import { StepProps, SERVICE_TYPES } from './types'
+import { StepProps } from './types'
+import CategorySelector from './CategorySelector'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Checkbox } from '@/components/ui/checkbox'
 import { DollarSign, Clock, ArrowRight, ArrowLeft } from 'lucide-react'
 
 export default function ServicesForm({ data, onChange, onNext, onBack, isSubmitting }: StepProps) {
-  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [errors, setErrors] = useState<{ primary?: string; hourly_rate?: string }>({})
 
   const validateForm = () => {
-    const newErrors: Record<string, string> = {}
+    const newErrors: { primary?: string; hourly_rate?: string } = {}
 
-    if (!data.services || data.services.length === 0) {
-      newErrors.services = 'Please select at least one service'
+    if (!data.primary_category) {
+      newErrors.primary = 'Choose your primary service category'
     }
     if (!data.hourly_rate || data.hourly_rate < 15) {
       newErrors.hourly_rate = 'Please enter a valid hourly rate (minimum $15)'
@@ -31,52 +31,45 @@ export default function ServicesForm({ data, onChange, onNext, onBack, isSubmitt
     }
   }
 
-  const handleServiceToggle = (service: string) => {
-    const currentServices = data.services || []
-    const newServices = currentServices.includes(service)
-      ? currentServices.filter((s) => s !== service)
-      : [...currentServices, service]
-    onChange({ ...data, services: newServices })
-    if (errors.services) {
-      setErrors({ ...errors, services: '' })
+  const handleCategoriesChange = ({
+    primary,
+    secondary,
+  }: {
+    primary: string | null
+    secondary: string[]
+  }) => {
+    // Keep legacy services[] in sync with [primary, ...secondary] so the
+    // ~30 codepaths still reading pros.services keep working until DLD-444's
+    // follow-up sweep drops that column.
+    const legacyServices = primary ? [primary, ...secondary] : secondary
+    onChange({
+      ...data,
+      primary_category: primary ?? undefined,
+      secondary_categories: secondary,
+      services: legacyServices,
+    })
+    if (errors.primary && primary) {
+      setErrors({ ...errors, primary: undefined })
     }
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div>
         <h2 className="text-2xl font-bold text-gray-900">Services You Offer</h2>
-        <p className="text-gray-600 mt-1">Select the services you provide and set your rate</p>
+        <p className="text-gray-600 mt-1">
+          Pick the categories you serve so leads route to the right Pros, and set your base rate.
+        </p>
       </div>
 
-      {/* Services Selection */}
-      <div className="space-y-4">
-        <Label className="text-lg">Services Offered *</Label>
-        {errors.services && (
-          <p className="text-sm text-red-500">{errors.services}</p>
-        )}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {SERVICE_TYPES.map((service) => (
-            <div
-              key={service.value}
-              className={`flex items-center space-x-3 p-3 border rounded-lg cursor-pointer transition-colors ${
-                data.services?.includes(service.value)
-                  ? 'border-blue-400 bg-blue-50'
-                  : 'hover:bg-gray-50'
-              }`}
-              onClick={() => handleServiceToggle(service.value)}
-            >
-              <Checkbox
-                checked={data.services?.includes(service.value) || false}
-                onCheckedChange={() => handleServiceToggle(service.value)}
-              />
-              <Label className="cursor-pointer font-normal">{service.label}</Label>
-            </div>
-          ))}
-        </div>
-      </div>
+      <CategorySelector
+        primary={data.primary_category ?? null}
+        secondary={data.secondary_categories ?? []}
+        onChange={handleCategoriesChange}
+        errors={{ primary: errors.primary }}
+        disabled={isSubmitting}
+      />
 
-      {/* Pricing */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="space-y-2">
           <Label htmlFor="hourly_rate">Hourly Rate ($) *</Label>
@@ -91,7 +84,7 @@ export default function ServicesForm({ data, onChange, onNext, onBack, isSubmitt
               value={data.hourly_rate || ''}
               onChange={(e) => {
                 onChange({ ...data, hourly_rate: parseFloat(e.target.value) || 0 })
-                if (errors.hourly_rate) setErrors({ ...errors, hourly_rate: '' })
+                if (errors.hourly_rate) setErrors({ ...errors, hourly_rate: undefined })
               }}
               placeholder="50"
               className={`pl-10 ${errors.hourly_rate ? 'border-red-500' : ''}`}

--- a/components/onboarding/index.ts
+++ b/components/onboarding/index.ts
@@ -1,6 +1,7 @@
 export { default as ProgressIndicator } from './ProgressIndicator'
 export { default as BusinessInfoForm } from './BusinessInfoForm'
 export { default as ServicesForm } from './ServicesForm'
+export { default as CategorySelector } from './CategorySelector'
 export { default as ServiceAreasForm } from './ServiceAreasForm'
 export { default as DocumentUploadForm } from './DocumentUploadForm'
 export { default as PhotoUploadForm } from './PhotoUploadForm'

--- a/components/onboarding/types.ts
+++ b/components/onboarding/types.ts
@@ -18,6 +18,12 @@ export interface OnboardingData {
   years_experience: number
 
   // Step 2: Services
+  // DLD-449: primary_category + secondary_categories are the canonical fields
+  // (FK -> service_categories.slug). `services` is kept populated as
+  // [primary, ...secondary] for backwards-compat with the ~30 codepaths
+  // that still read pros.services[].
+  primary_category: string | null
+  secondary_categories: string[]
   services: string[]
   hourly_rate: number
   minimum_hours: number

--- a/lib/services/pro-categories.ts
+++ b/lib/services/pro-categories.ts
@@ -1,0 +1,128 @@
+// DLD-449 — Helpers for persisting a pro's category selection.
+//
+// Writes `pros.primary_category` (the trigger handles syncing the
+// pro_categories.is_primary row) and reconciles secondary rows so the
+// join table reflects the canonical [primary, ...secondary] set.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createLogger } from '@/lib/utils/logger'
+
+const logger = createLogger({ file: 'lib/services/pro-categories' })
+
+export interface CategorySelection {
+  primary: string | null
+  secondary: string[]
+}
+
+export interface PersistCategoriesInput {
+  proId: string
+  selection: CategorySelection
+}
+
+/**
+ * Resolve a slug to its canonical form via the DB resolver, returning
+ * null for unknown slugs.
+ */
+export async function resolveCanonicalSlug(
+  supabase: SupabaseClient,
+  slug: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .rpc('canonical_service_slug', { p_slug: slug })
+    .single<string | null>()
+  if (error) {
+    logger.error('canonical_service_slug RPC failed', { slug }, error)
+    return null
+  }
+  return data
+}
+
+/**
+ * Filter a list of slugs to only those that resolve through
+ * service_categories. Returns canonical slugs.
+ */
+export async function normalizeCategorySlugs(
+  supabase: SupabaseClient,
+  slugs: string[]
+): Promise<string[]> {
+  if (slugs.length === 0) return []
+  const { data, error } = await supabase
+    .from('service_categories')
+    .select('slug, alias_for')
+    .in('slug', slugs)
+  if (error) {
+    logger.error('normalizeCategorySlugs failed', {}, error)
+    return []
+  }
+  const map = new Map<string, string>()
+  for (const row of data ?? []) {
+    map.set(row.slug, row.alias_for ?? row.slug)
+  }
+  return Array.from(
+    new Set(slugs.map((s) => map.get(s)).filter((s): s is string => !!s))
+  )
+}
+
+/**
+ * Reconcile pro_categories rows for a pro against the canonical
+ * [primary, ...secondary] set. The caller is expected to have already
+ * written pros.primary_category (which the DB trigger uses to set
+ * is_primary on the join row).
+ *
+ * RLS-aware — pass a SupabaseClient already authenticated as the pro
+ * or as service-role.
+ */
+export async function reconcileProCategories(
+  supabase: SupabaseClient,
+  input: PersistCategoriesInput
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const { proId, selection } = input
+
+  const all = await normalizeCategorySlugs(
+    supabase,
+    [selection.primary, ...selection.secondary].filter(
+      (s): s is string => typeof s === 'string' && s.length > 0
+    )
+  )
+
+  // Insert any rows that don't already exist.
+  if (all.length > 0) {
+    const upsertPayload = all.map((category) => ({
+      pro_id: proId,
+      category,
+      is_primary: false,
+    }))
+    const { error: upsertError } = await supabase
+      .from('pro_categories')
+      .upsert(upsertPayload, {
+        onConflict: 'pro_id,category',
+        ignoreDuplicates: true,
+      })
+    if (upsertError) {
+      logger.error('Failed to upsert pro_categories rows', { proId }, upsertError)
+      return { ok: false, error: 'Failed to save categories' }
+    }
+  }
+
+  // Delete rows that are no longer in the selection.
+  const deleteQuery = supabase.from('pro_categories').delete().eq('pro_id', proId)
+  if (all.length > 0) {
+    const { error: deleteError } = await deleteQuery.not(
+      'category',
+      'in',
+      `(${all.map((c) => `"${c}"`).join(',')})`
+    )
+    if (deleteError) {
+      logger.error('Failed to prune pro_categories rows', { proId }, deleteError)
+      return { ok: false, error: 'Failed to update categories' }
+    }
+  } else {
+    const { error: deleteAllError } = await deleteQuery
+    if (deleteAllError) {
+      logger.error('Failed to clear pro_categories rows', { proId }, deleteAllError)
+      return { ok: false, error: 'Failed to clear categories' }
+    }
+  }
+
+  return { ok: true }
+}

--- a/lib/services/quote-service.ts
+++ b/lib/services/quote-service.ts
@@ -267,33 +267,69 @@ export class QuoteService {
 
   private async notifyCleanersInArea(zipCode: string, serviceType: string, quoteId: string) {
     try {
-      // Get cleaners who serve this area and offer this service
-      const { data: cleaners } = await this.supabase
-        .from('cleaners')
-        .select(`
-          id,
-          user_id,
-          business_name,
-          services,
-          users!user_id(email, full_name)
-        `)
-        .eq('approval_status', 'approved')
-        .contains('services', [serviceType])
-        .in('id', 
-          // Subquery to get cleaners serving this ZIP code
-          (await this.supabase
-            .from('cleaner_service_areas')
-            .select('cleaner_id')
-            .eq('zip_code', zipCode)
-          ).data?.map(area => area.cleaner_id) || []
-        );
+      // DLD-449: match pros whose primary OR secondary category equals the
+      // lead's service_type. Resolve the service_type slug through the
+      // canonical resolver first so aliases (pool_cleaning -> pool_service)
+      // route correctly. Primary matches sort above secondary so the
+      // strongest fit is contacted first.
+      let canonicalServiceType = serviceType;
+      const { data: canonical } = await this.supabase
+        .rpc('canonical_service_slug', { p_slug: serviceType })
+        .single();
+      if (typeof canonical === 'string' && canonical.length > 0) {
+        canonicalServiceType = canonical;
+      }
 
-      // Send email notifications (this would integrate with your email service)
-      for (const cleaner of cleaners || []) {
-        await this.sendQuoteNotificationEmail(cleaner, quoteId);
+      const { data: serviceAreas } = await this.supabase
+        .from('cleaner_service_areas')
+        .select('cleaner_id')
+        .eq('zip_code', zipCode);
+
+      const proIdsInArea = (serviceAreas ?? []).map((a: { cleaner_id: string }) => a.cleaner_id);
+      if (proIdsInArea.length === 0) {
+        return;
+      }
+
+      const { data: matchedRows, error: matchedError } = await this.supabase
+        .from('pro_categories')
+        .select('pro_id, is_primary')
+        .eq('category', canonicalServiceType)
+        .in('pro_id', proIdsInArea);
+
+      if (matchedError) {
+        logger.error('Error matching pro_categories:', {}, matchedError);
+        return;
+      }
+
+      // Rank: primary matches first, then secondary.
+      type MatchRow = { pro_id: string; is_primary: boolean };
+      const rankedProIds = ((matchedRows ?? []) as MatchRow[])
+        .sort((a: MatchRow, b: MatchRow) => Number(b.is_primary) - Number(a.is_primary))
+        .map((row: MatchRow) => row.pro_id);
+      if (rankedProIds.length === 0) {
+        return;
+      }
+
+      const { data: pros } = await this.supabase
+        .from('pros')
+        .select(
+          `id, user_id, business_name, services, primary_category, users!user_id(email, full_name)`
+        )
+        .eq('approval_status', 'approved')
+        .in('id', rankedProIds);
+
+      type ProRow = CleanerEmailData & { id: string };
+      const proRows = (pros ?? []) as ProRow[];
+      const proById = new Map<string, ProRow>(proRows.map((p: ProRow) => [p.id, p]));
+      const orderedPros: ProRow[] = rankedProIds
+        .map((id: string) => proById.get(id))
+        .filter((p): p is ProRow => !!p);
+
+      for (const pro of orderedPros) {
+        await this.sendQuoteNotificationEmail(pro, quoteId);
       }
     } catch (error) {
-      logger.error('Error notifying cleaners:', {}, error);
+      logger.error('Error notifying pros:', {}, error);
     }
   }
 

--- a/lib/types/service-category.ts
+++ b/lib/types/service-category.ts
@@ -1,0 +1,13 @@
+// DLD-449 — canonical service category shape served by /api/service-categories.
+
+export interface ServiceCategory {
+  slug: string
+  display_name: string
+  description: string | null
+  fee_tier: 'standard' | 'deep_clean' | 'specialty' | string
+  supports_residential: boolean
+  supports_commercial: boolean
+  requires_license_fl: boolean
+  alias_for: string | null
+  priority_order: number
+}

--- a/supabase/migrations/20260515170000_dld449_pro_categories.sql
+++ b/supabase/migrations/20260515170000_dld449_pro_categories.sql
@@ -1,0 +1,271 @@
+-- =====================================================================
+-- DLD-449 — Pro service category selection (primary + secondary)
+-- =====================================================================
+-- A pro signs up and must declare which service categories they offer.
+-- Lead matching/cascade routes leads to pros whose primary OR secondary
+-- category matches `lead.service_type`, weighting primary above secondary.
+--
+-- This migration introduces:
+--   * public.pros.primary_category (nullable FK -> service_categories.slug)
+--   * public.pro_categories join table (pro_id, category, is_primary)
+--   * RLS policies that mirror public.pros (own profile RW, public can
+--     read approved pros' categories, admins all)
+--   * Sync trigger on pros.primary_category that keeps pro_categories
+--     in lockstep
+--   * Backfill from the legacy pros.services[] column for existing rows
+--     (primary stays NULL; pros pick on next edit)
+--
+-- Out of scope (follow-up tickets):
+--   * Removing the legacy pros.services[] column (kept populated by the
+--     app layer as [primary, ...secondary] for backwards compat with the
+--     ~30 codepaths that still read it).
+--   * Per-category residential/commercial flag on a pro (board flagged
+--     as may-be-follow-up).
+--   * Lead-fee-tier overrides per pro (DLD-446).
+--
+-- Idempotent. Wrapped in a transaction.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- PART A: pros.primary_category column
+-- ---------------------------------------------------------------------
+ALTER TABLE public.pros
+  ADD COLUMN IF NOT EXISTS primary_category TEXT
+    REFERENCES public.service_categories(slug)
+    ON UPDATE CASCADE
+    ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.pros.primary_category IS
+  'DLD-449. The pro''s primary service category — single FK into service_categories.slug. NULL allowed for legacy rows and mid-onboarding drafts. UI guarantees it is set before approval.';
+
+CREATE INDEX IF NOT EXISTS idx_pros_primary_category
+  ON public.pros(primary_category)
+  WHERE primary_category IS NOT NULL;
+
+-- ---------------------------------------------------------------------
+-- PART B: pro_categories join table
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.pro_categories (
+  pro_id      UUID NOT NULL REFERENCES public.pros(id) ON DELETE CASCADE,
+  category    TEXT NOT NULL REFERENCES public.service_categories(slug)
+                ON UPDATE CASCADE
+                ON DELETE RESTRICT,
+  is_primary  BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (pro_id, category)
+);
+
+COMMENT ON TABLE public.pro_categories IS
+  'DLD-449. Many-to-many: a pro can offer multiple service categories. Exactly one row per pro may have is_primary=true (enforced by a partial unique index). Kept in sync with pros.primary_category via trigger.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_pro_categories_one_primary_per_pro
+  ON public.pro_categories(pro_id)
+  WHERE is_primary;
+
+CREATE INDEX IF NOT EXISTS idx_pro_categories_category
+  ON public.pro_categories(category);
+
+CREATE INDEX IF NOT EXISTS idx_pro_categories_pro
+  ON public.pro_categories(pro_id);
+
+-- ---------------------------------------------------------------------
+-- PART C: RLS policies on pro_categories
+-- ---------------------------------------------------------------------
+ALTER TABLE public.pro_categories ENABLE ROW LEVEL SECURITY;
+
+-- The pro themself: full CRUD on their own rows.
+DROP POLICY IF EXISTS pro_categories_owner_select ON public.pro_categories;
+CREATE POLICY pro_categories_owner_select
+  ON public.pro_categories
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.pros p
+      WHERE p.id = pro_categories.pro_id
+        AND p.user_id = (SELECT auth.uid())
+    )
+  );
+
+DROP POLICY IF EXISTS pro_categories_owner_insert ON public.pro_categories;
+CREATE POLICY pro_categories_owner_insert
+  ON public.pro_categories
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.pros p
+      WHERE p.id = pro_categories.pro_id
+        AND p.user_id = (SELECT auth.uid())
+    )
+  );
+
+DROP POLICY IF EXISTS pro_categories_owner_update ON public.pro_categories;
+CREATE POLICY pro_categories_owner_update
+  ON public.pro_categories
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.pros p
+      WHERE p.id = pro_categories.pro_id
+        AND p.user_id = (SELECT auth.uid())
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.pros p
+      WHERE p.id = pro_categories.pro_id
+        AND p.user_id = (SELECT auth.uid())
+    )
+  );
+
+DROP POLICY IF EXISTS pro_categories_owner_delete ON public.pro_categories;
+CREATE POLICY pro_categories_owner_delete
+  ON public.pro_categories
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.pros p
+      WHERE p.id = pro_categories.pro_id
+        AND p.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- Public read access for approved pros' categories (mirrors
+-- public_can_view_approved_cleaners on pros).
+DROP POLICY IF EXISTS pro_categories_public_view_approved ON public.pro_categories;
+CREATE POLICY pro_categories_public_view_approved
+  ON public.pro_categories
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.pros p
+      WHERE p.id = pro_categories.pro_id
+        AND p.approval_status = 'approved'
+    )
+  );
+
+-- Admins: full access.
+DROP POLICY IF EXISTS pro_categories_admin_all ON public.pro_categories;
+CREATE POLICY pro_categories_admin_all
+  ON public.pro_categories
+  FOR ALL
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- ---------------------------------------------------------------------
+-- PART D: Sync trigger — pros.primary_category -> pro_categories.is_primary
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.sync_pros_primary_category()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_canonical TEXT;
+BEGIN
+  -- No-op when primary_category did not change.
+  IF TG_OP = 'UPDATE' AND NEW.primary_category IS NOT DISTINCT FROM OLD.primary_category THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.primary_category IS NULL THEN
+    -- Clear any existing primary flag.
+    UPDATE public.pro_categories
+       SET is_primary = FALSE,
+           updated_at = now()
+     WHERE pro_id = NEW.id
+       AND is_primary = TRUE;
+    RETURN NEW;
+  END IF;
+
+  -- Resolve to canonical slug (collapses legacy aliases like
+  -- pool_cleaning -> pool_service).
+  v_canonical := public.canonical_service_slug(NEW.primary_category);
+  IF v_canonical IS NULL THEN
+    RAISE EXCEPTION 'DLD-449: primary_category % is not a known service category', NEW.primary_category;
+  END IF;
+
+  -- Demote everyone else first to satisfy the partial unique index.
+  UPDATE public.pro_categories
+     SET is_primary = FALSE,
+         updated_at = now()
+   WHERE pro_id = NEW.id
+     AND is_primary = TRUE
+     AND category <> v_canonical;
+
+  -- Upsert the chosen primary row.
+  INSERT INTO public.pro_categories (pro_id, category, is_primary)
+       VALUES (NEW.id, v_canonical, TRUE)
+  ON CONFLICT (pro_id, category)
+  DO UPDATE SET is_primary = TRUE,
+                updated_at = now();
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.sync_pros_primary_category IS
+  'DLD-449. Mirrors pros.primary_category into pro_categories.is_primary so the join table is the single matching source for lead distribution.';
+
+DROP TRIGGER IF EXISTS trg_sync_pros_primary_category ON public.pros;
+CREATE TRIGGER trg_sync_pros_primary_category
+  AFTER INSERT OR UPDATE OF primary_category ON public.pros
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_pros_primary_category();
+
+-- ---------------------------------------------------------------------
+-- PART E: Backfill from legacy pros.services[]
+-- ---------------------------------------------------------------------
+-- Resolve each legacy slug through canonical_service_slug() so aliases
+-- collapse. Skip any slug that doesn't resolve (defensive — should not
+-- happen given the current 4 rows, but protects forward-compat).
+INSERT INTO public.pro_categories (pro_id, category, is_primary)
+SELECT
+  p.id,
+  public.canonical_service_slug(s.slug) AS category,
+  FALSE
+FROM public.pros p
+CROSS JOIN LATERAL UNNEST(COALESCE(p.services, ARRAY[]::TEXT[])) AS s(slug)
+WHERE public.canonical_service_slug(s.slug) IS NOT NULL
+ON CONFLICT (pro_id, category) DO NOTHING;
+
+-- ---------------------------------------------------------------------
+-- PART F: Sanity checks
+-- ---------------------------------------------------------------------
+DO $$
+DECLARE
+  v_column_exists boolean;
+  v_table_exists boolean;
+  v_trigger_exists boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'pros'
+      AND column_name = 'primary_category'
+  ) INTO v_column_exists;
+  IF NOT v_column_exists THEN
+    RAISE EXCEPTION 'DLD-449 sanity: public.pros.primary_category missing';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM pg_tables
+    WHERE schemaname = 'public' AND tablename = 'pro_categories'
+  ) INTO v_table_exists;
+  IF NOT v_table_exists THEN
+    RAISE EXCEPTION 'DLD-449 sanity: public.pro_categories missing';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_sync_pros_primary_category'
+  ) INTO v_trigger_exists;
+  IF NOT v_trigger_exists THEN
+    RAISE EXCEPTION 'DLD-449 sanity: sync trigger missing';
+  END IF;
+END$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds a primary service category (FK) + secondary categories (join table) to `public.pros`, with RLS, a sync trigger, and a non-breaking backfill for the existing 4 pros.
- Builds a reusable `CategorySelector` (Boss Orange dropdown + chips) wired into onboarding `ServicesForm` and the pro profile edit page.
- Routes new `/api/service-categories` (canonical taxonomy) and `/api/pros/categories` (PATCH reconcile) so the join table stays in lockstep with `pros.primary_category`.
- Updates `quote-service.notifyCleanersInArea` to match on primary OR secondary, ranking primary above secondary and resolving the lead's `service_type` through `canonical_service_slug()`.

## Schema migration
File: `supabase/migrations/20260515170000_dld449_pro_categories.sql`. Idempotent, wrapped in a transaction, sanity-asserts at the end. Migration is **not applied** yet — Board to merge + apply.

## TypeScript baseline
`npx tsc --noEmit` reports **55 errors** (down from the documented baseline of 56). No new errors introduced. `npm run build` succeeds.

## Reads/writes use `public.pros` directly
Per DLD-444 follow-up directive, all new code in this PR writes to `pros`; the `cleaners` view is preserved for legacy callers only.

## Out of scope (follow-ups)
- Removing the legacy `pros.services[]` column (kept populated for backwards compat).
- Per-pro residential/commercial flag (board called it agent's call; punted to a follow-up).
- Sweep of remaining `.from('cleaners')` callers — that's the DLD-444 follow-up.

## Test plan
- [ ] Apply migration on staging; confirm 4 pro_categories rows backfilled for `magic clean` + `sonz of thunder`, none for the two empty-services rows.
- [ ] Onboarding flow: choose primary + 2 secondary, advance through draft saves, submit. Confirm `pros.primary_category` set and `pro_categories` matches; `services[]` also populated as `[primary, ...secondary]`.
- [ ] Profile edit: change primary, add/remove secondaries, save. Confirm `pro_categories` reconciles correctly and trigger flips `is_primary`.
- [ ] Submit endpoint rejects an onboarding submission without `primary_category`.
- [ ] Quote request matching: leads with `service_type=residential` route to pros with `residential` primary first, then secondary; `pool_cleaning` alias resolves to `pool_service`.
- [ ] RLS: pros can only insert/select their own pro_categories rows; admins see all; public sees only approved pros' rows.
- [ ] Build + typecheck: 55 TS errors (≤ baseline 56), `npm run build` succeeds.

Closes DLD-449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)