### PR TITLE
fix(privacy): DLD-457 hide pro business_phone from all public surfaces

### DIFF
--- a/app/cleaner/[slug]/page.tsx
+++ b/app/cleaner/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import Image from 'next/image';
 import {
-  Star, MapPin, Phone, Mail, Globe, Clock, Shield, Award,
+  Star, MapPin, Mail, Globe, Clock, Shield, Award,
   BadgeCheck, CheckCircle2, DollarSign, Users, Calendar,
   MessageSquare, ArrowLeft, Camera
 } from 'lucide-react';
@@ -14,12 +14,12 @@ import type { BusinessHours } from '@/lib/types/database';
 import { getCleanerBadges } from '@/lib/services/badges';
 import { BadgeDisplay, BadgeList } from '@/components/badges/BadgeDisplay';
 
+// NOTE: business_phone intentionally omitted — PII gated behind lead acceptance (DLD-457).
 interface CleanerProfile {
   id: string;
   business_name: string;
   business_slug: string;
   business_description: string;
-  business_phone: string;
   business_email: string;
   website_url: string;
   services: string[];
@@ -64,36 +64,60 @@ interface Review {
   value_rating: number | null;
 }
 
+// Explicit allowlist excluding business_phone (PII — gated by lead acceptance, DLD-457).
+const PUBLIC_PROFILE_COLUMNS = `
+  id,
+  business_name,
+  business_slug,
+  business_description,
+  business_email,
+  website_url,
+  services,
+  service_areas,
+  hourly_rate,
+  minimum_hours,
+  years_experience,
+  employees_count,
+  average_rating,
+  total_reviews,
+  total_jobs,
+  response_time_hours,
+  insurance_verified,
+  license_verified,
+  background_check,
+  is_certified,
+  instant_booking,
+  subscription_tier,
+  profile_image_url,
+  business_images,
+  business_hours,
+  created_at,
+  users(full_name, city, state, zip_code)
+`;
+
 async function getCleanerBySlug(slug: string): Promise<CleanerProfile | null> {
   const supabase = await createClient();
 
   const { data, error } = await supabase
     .from('cleaners')
-    .select(`
-      *,
-      users(full_name, city, state, zip_code)
-    `)
+    .select(PUBLIC_PROFILE_COLUMNS)
     .eq('business_slug', slug)
     .eq('approval_status', 'approved')
     .single();
 
   if (error || !data) {
-    // Try by ID as fallback
     const { data: dataById, error: errorById } = await supabase
       .from('cleaners')
-      .select(`
-        *,
-        users(full_name, city, state, zip_code)
-      `)
+      .select(PUBLIC_PROFILE_COLUMNS)
       .eq('id', slug)
       .eq('approval_status', 'approved')
       .single();
 
     if (errorById || !dataById) return null;
-    return dataById;
+    return dataById as unknown as CleanerProfile;
   }
 
-  return data;
+  return data as unknown as CleanerProfile;
 }
 
 async function getCleanerReviews(cleanerId: string): Promise<Review[]> {
@@ -310,16 +334,6 @@ export default async function CleanerProfilePage({ params }: { params: Promise<{
                   Request Quote
                 </Link>
 
-                {cleaner.business_phone && (
-                  <a
-                    href={`tel:${cleaner.business_phone}`}
-                    className="w-full mt-3 border border-gray-300 text-gray-700 px-6 py-3 rounded-lg hover:bg-gray-50 transition font-medium flex items-center justify-center gap-2"
-                  >
-                    <Phone className="h-5 w-5" />
-                    Call Now
-                  </a>
-                )}
-
                 <StartConversationButton
                   cleanerId={cleaner.id}
                   cleanerName={cleaner.business_name}
@@ -519,15 +533,6 @@ export default async function CleanerProfilePage({ params }: { params: Promise<{
             <div className="bg-white rounded-xl shadow-sm p-6">
               <h3 className="font-semibold text-gray-900 mb-4">Contact Information</h3>
               <div className="space-y-3">
-                {cleaner.business_phone && (
-                  <a
-                    href={`tel:${cleaner.business_phone}`}
-                    className="flex items-center gap-3 text-gray-600 hover:text-blue-600"
-                  >
-                    <Phone className="h-5 w-5" />
-                    <span>{cleaner.business_phone}</span>
-                  </a>
-                )}
                 {cleaner.business_email && (
                   <a
                     href={`mailto:${cleaner.business_email}`}

--- a/app/services/[serviceType]/ServicePageClient.tsx
+++ b/app/services/[serviceType]/ServicePageClient.tsx
@@ -7,12 +7,12 @@ import { ServiceType, getServiceDbValue } from '@/lib/data/service-types';
 import { ServiceTypeContent } from '@/components/seo/ServiceTypeContent';
 import { CleanerCardProps } from '@/components/search';
 
+// NOTE: business_phone intentionally omitted — PII gated behind lead acceptance (DLD-457).
 interface CleanerData {
   id: string;
   business_name: string;
   business_slug?: string;
   business_description?: string;
-  business_phone?: string;
   services?: string[];
   service_areas?: string[];
   hourly_rate?: number;
@@ -69,7 +69,6 @@ export function ServicePageClient({ serviceType }: ServicePageClientProps) {
     backgroundCheckVerified: cleaner.background_check || false,
     isCertified: cleaner.is_certified || false,
     instantBooking: cleaner.instant_booking || false,
-    businessPhone: cleaner.business_phone,
   });
 
   const loadCleaners = useCallback(async () => {

--- a/components/search/CleanerCard.tsx
+++ b/components/search/CleanerCard.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import {
   Star, DollarSign, Award, Shield, BadgeCheck,
-  CheckCircle2, MessageSquare, Phone, User, MapPin
+  CheckCircle2, MessageSquare, User, MapPin
 } from 'lucide-react';
 import { getCleanerBadges, type EarnedBadge } from '@/lib/services/badges';
 import { CompactBadgeDisplay } from '@/components/badges/BadgeDisplay';
@@ -29,7 +29,6 @@ export interface CleanerCardProps {
   backgroundCheckVerified?: boolean;
   isCertified?: boolean;
   instantBooking?: boolean;
-  businessPhone?: string;
   responseTimeHours?: number;
   distance?: number;
   onRequestQuote?: (cleanerId: string) => void;
@@ -55,7 +54,6 @@ export function CleanerCard({
   backgroundCheckVerified,
   isCertified,
   instantBooking,
-  businessPhone,
   responseTimeHours,
   distance,
   onRequestQuote
@@ -258,15 +256,6 @@ export function CleanerCard({
               <MessageSquare className="h-4 w-4" aria-hidden="true" />
               Request Quote
             </button>
-          )}
-          {businessPhone && (
-            <a
-              href={`tel:${businessPhone}`}
-              className="px-3 py-2 border border-gray-300 rounded-md hover:bg-gray-50 transition duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              aria-label={`Call ${businessName} at ${businessPhone}`}
-            >
-              <Phone className="h-4 w-4 text-gray-600" aria-hidden="true" />
-            </a>
           )}
           <Link
             href={profileUrl}

--- a/lib/seo/json-ld.ts
+++ b/lib/seo/json-ld.ts
@@ -128,11 +128,8 @@ export function generateCleanerSchema(cleaner: CleanerProfile, serviceArea?: Ser
     schema.image = cleaner.profile_image_url;
   }
 
-  // Add contact info (only if provided)
-  if (cleaner.business_phone) {
-    schema.telephone = cleaner.business_phone;
-  }
-
+  // Contact info: telephone intentionally excluded from public schema —
+  // PII gated behind lead acceptance (DLD-457).
   if (cleaner.business_email) {
     schema.email = cleaner.business_email;
   }


### PR DESCRIPTION
## Summary

Removes the "Call Now" PII bypass that let anonymous visitors call pros directly without going through the lead system — undermining BOC's entire pay-on-acceptance marketplace model.

Closes [DLD-457](/DLD/issues/DLD-457).

## Surfaces patched

- `app/cleaner/[slug]/page.tsx`
  - Drop "Call Now" button (the named offender)
  - Drop Contact Info sidebar phone link
  - Switch `select('*')` → explicit `PUBLIC_PROFILE_COLUMNS` allowlist excluding `business_phone`
- `components/search/CleanerCard.tsx` — drop `tel:` button + `businessPhone` prop
- `app/services/[serviceType]/ServicePageClient.tsx` — drop `businessPhone` from card mapping
- `lib/seo/json-ld.ts` — drop `telephone` from `LocalBusiness/ProfessionalService` schema so crawlers do not index pro phone numbers

## Still authorized

`business_phone` continues to flow to:
- Pro's own dashboard (their own data)
- Booking + customer dashboard quote views (post-lead-acceptance UI)
- Admin views

`Request Quote` and in-app messaging (`StartConversationButton`) are now the only pre-lead contact paths.

## Verification

- `npm run build` → success
- `npx tsc --noEmit` → 55 errors (baseline 56, -1, no regressions)
- `git diff --stat`:
  ```
  app/cleaner/[slug]/page.tsx                      | 69 +++++++++++++-----------
  app/services/[serviceType]/ServicePageClient.tsx |  3 +-
  components/search/CleanerCard.tsx                | 13 +----
  lib/seo/json-ld.ts                               |  7 +--
  4 files changed, 41 insertions(+), 51 deletions(-)
  ```

## Follow-ups (out of scope, flagged for triage)

- `lib/services/searchService.ts` still uses `select('*')` in 5+ functions — business_phone is no longer rendered, but still travels over the wire to public clients. Recommend explicit column lists in a follow-up.
- `app/dashboard/customer/page.tsx` shows `quote.cleaner?.business_phone` regardless of lead-acceptance status — customer-only surface, but pre-acceptance leak. Recommend gating on `quote.status === 'accepted'`.
- Email + website are still publicly rendered on `/cleaner/[slug]` — kept in scope per issue scope (phone-only).

## Test plan

- [ ] Visit `/cleaner/<approved-slug>` as anonymous user — confirm no "Call Now" button, no phone in Contact Info sidebar, Request Quote present
- [ ] Visit `/search` and `/services/<type>` — confirm no phone icon button on cleaner cards
- [ ] View page source on `/cleaner/<approved-slug>` — confirm `telephone` not present in JSON-LD `<script type="application/ld+json">`
- [ ] Confirm pro can still see own phone on `/dashboard/pro/profile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)