### PR TITLE
fix(dashboard): DLD-462 'Cleaner Dashboard' → 'Pro Dashboard' fallback

### DIFF
--- a/app/dashboard/pro/error.tsx
+++ b/app/dashboard/pro/error.tsx
@@ -13,7 +13,7 @@ export default function CleanerDashboardError({
     <ErrorDisplay
       error={error}
       reset={reset}
-      title="Cleaner dashboard error"
+      title="Pro dashboard error"
       backHref="/dashboard/pro"
       backLabel="Back to dashboard"
     />

--- a/app/dashboard/pro/page.tsx
+++ b/app/dashboard/pro/page.tsx
@@ -190,7 +190,7 @@ export default function CleanerDashboard() {
             <div className="flex justify-between items-center py-6">
               <div>
                 <h1 className="text-2xl font-bold text-gray-900">
-                  {profile?.business_name || 'Cleaner Dashboard'}
+                  {profile?.business_name || 'Pro Dashboard'}
                 </h1>
                 {profile?.approval_status === 'pending' && (
                   <p className="text-sm text-yellow-600 mt-1">


### PR DESCRIPTION
## Summary

- Replace fallback title `'Cleaner Dashboard'` with `'Pro Dashboard'` in `app/dashboard/pro/page.tsx:193`
- Replace error display title `"Cleaner dashboard error"` with `"Pro dashboard error"` in `app/dashboard/pro/error.tsx:16`

## Why

New pro signups without `business_name` set were greeted with "Cleaner Dashboard" — contradicts BOC's locked multi-service marketplace positioning. This is the first thing a pro sees post-signup.

## Audit scope

Audited all `app/dashboard/pro/**/*.tsx` for "Cleaner" UI strings. Remaining references are internal code identifiers (component names, TS types, `cleanerId` variables, log function names, comments, imports) — these belong to the broader cleaners→pros rename tracked in [DLD-461](/DLD/issues/DLD-461) and [DLD-444](/DLD/issues/DLD-444).

## Verification

- `npm run build` ✅
- `npx tsc --noEmit` → 55 errors (baseline 56, unchanged)

## Test plan

- [ ] New pro signup without business_name → header reads "Pro Dashboard"
- [ ] Trigger error boundary on /dashboard/pro → title reads "Pro dashboard error"
- [ ] Existing pros with `business_name` set still see their business name

Closes [DLD-462](/DLD/issues/DLD-462)

🤖 Generated with [Claude Code](https://claude.com/claude-code)