### PR TITLE
fix(favorites): DLD-463 customer Favorites page cleaner -> pro rename

### DIFF
--- a/app/dashboard/customer/favorites/page.tsx
+++ b/app/dashboard/customer/favorites/page.tsx
@@ -11,10 +11,10 @@ import { createLogger } from '@/lib/utils/logger';
 
 const logger = createLogger({ file: 'app/dashboard/customer/favorites/page.tsx' });
 
-interface FavoriteCleaner {
+interface FavoritePro {
   id: string;
   created_at: string;
-  cleaner: {
+  pro: {
     id: string;
     business_name: string;
     business_slug: string;
@@ -35,7 +35,7 @@ interface FavoriteCleaner {
 
 export default function CustomerFavoritesPage() {
   const { user } = useAuth();
-  const [favorites, setFavorites] = useState<FavoriteCleaner[]>([]);
+  const [favorites, setFavorites] = useState<FavoritePro[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -51,7 +51,15 @@ export default function CustomerFavoritesPage() {
       if (!response.ok) throw new Error('Failed to fetch favorites');
 
       const data = await response.json();
-      setFavorites(data.favorites || []);
+      // API still keys the joined row as `cleaner` (Supabase alias); remap to `pro` for the UI.
+      const mapped: FavoritePro[] = (data.favorites || []).map(
+        (f: { id: string; created_at: string; cleaner: FavoritePro['pro'] }) => ({
+          id: f.id,
+          created_at: f.created_at,
+          pro: f.cleaner,
+        }),
+      );
+      setFavorites(mapped);
     } catch (error) {
       logger.error('Error loading favorites', { function: 'loadFavorites', error });
     } finally {
@@ -59,13 +67,13 @@ export default function CustomerFavoritesPage() {
     }
   };
 
-  const handleRemoveFavorite = (cleanerId: string) => {
+  const handleRemoveFavorite = (proId: string) => {
     // Remove from local state immediately for better UX
-    setFavorites((prev) => prev.filter((f) => f.cleaner.id !== cleanerId));
+    setFavorites((prev) => prev.filter((f) => f.pro.id !== proId));
   };
 
   const formatServices = (services: string[] | null) => {
-    if (!services || services.length === 0) return 'General cleaning';
+    if (!services || services.length === 0) return 'General services';
     if (services.length <= 2) return services.join(', ');
     return `${services.slice(0, 2).join(', ')} +${services.length - 2} more`;
   };
@@ -84,9 +92,9 @@ export default function CustomerFavoritesPage() {
                 <ArrowLeft className="h-5 w-5" />
               </Link>
               <div>
-                <h1 className="text-2xl font-bold text-gray-900">My Favorite Cleaners</h1>
+                <h1 className="text-2xl font-bold text-gray-900">My Favorite Pros</h1>
                 <p className="text-sm text-gray-600 mt-1">
-                  {favorites.length} {favorites.length === 1 ? 'cleaner' : 'cleaners'} saved
+                  {favorites.length} {favorites.length === 1 ? 'pro' : 'pros'} saved
                 </p>
               </div>
             </div>
@@ -103,14 +111,14 @@ export default function CustomerFavoritesPage() {
               <Heart className="mx-auto h-16 w-16 text-gray-300 mb-4" />
               <h2 className="text-xl font-semibold text-gray-900 mb-2">No favorites yet</h2>
               <p className="text-gray-600 mb-6 max-w-md mx-auto">
-                Save your favorite cleaners to quickly find and book them later.
-                Click the heart icon on any cleaner profile to add them here.
+                Save your favorite pros to quickly find and book them later.
+                Click the heart icon on any pro&apos;s profile to add them here.
               </p>
               <Link
                 href="/search"
                 className="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
               >
-                Find Cleaners
+                Find Pros
               </Link>
             </div>
           ) : (
@@ -122,17 +130,17 @@ export default function CustomerFavoritesPage() {
                 >
                   {/* Image Section */}
                   <div className="relative h-48">
-                    {favorite.cleaner.profile_image_url ? (
+                    {favorite.pro.profile_image_url ? (
                       <Image
-                        src={favorite.cleaner.profile_image_url}
-                        alt={favorite.cleaner.business_name}
+                        src={favorite.pro.profile_image_url}
+                        alt={favorite.pro.business_name}
                         fill
                         className="object-cover"
                       />
                     ) : (
                       <div className="w-full h-full bg-gradient-to-br from-blue-100 to-blue-200 flex items-center justify-center">
                         <span className="text-4xl font-bold text-blue-400">
-                          {favorite.cleaner.business_name.charAt(0)}
+                          {favorite.pro.business_name.charAt(0)}
                         </span>
                       </div>
                     )}
@@ -140,7 +148,7 @@ export default function CustomerFavoritesPage() {
                     {/* Favorite Button */}
                     <div className="absolute top-3 right-3">
                       <FavoriteButton
-                        cleanerId={favorite.cleaner.id}
+                        cleanerId={favorite.pro.id}
                         initialFavorited={true}
                         size="md"
                       />
@@ -148,13 +156,13 @@ export default function CustomerFavoritesPage() {
 
                     {/* Badges */}
                     <div className="absolute bottom-3 left-3 flex gap-2">
-                      {favorite.cleaner.instant_booking && (
+                      {favorite.pro.instant_booking && (
                         <span className="bg-green-500 text-white text-xs px-2 py-1 rounded-full flex items-center gap-1">
                           <Sparkles className="h-3 w-3" />
                           Instant Book
                         </span>
                       )}
-                      {favorite.cleaner.insurance_verified && (
+                      {favorite.pro.insurance_verified && (
                         <span className="bg-blue-500 text-white text-xs px-2 py-1 rounded-full flex items-center gap-1">
                           <Shield className="h-3 w-3" />
                           Insured
@@ -166,34 +174,34 @@ export default function CustomerFavoritesPage() {
                   {/* Content Section */}
                   <div className="p-4">
                     <Link
-                      href={`/cleaner/${favorite.cleaner.business_slug}`}
+                      href={`/cleaner/${favorite.pro.business_slug}`}
                       className="block"
                     >
                       <h3 className="font-semibold text-lg text-gray-900 hover:text-blue-600 transition-colors">
-                        {favorite.cleaner.business_name}
+                        {favorite.pro.business_name}
                       </h3>
                     </Link>
 
                     {/* Location */}
-                    {favorite.cleaner.users?.city && (
+                    {favorite.pro.users?.city && (
                       <p className="text-sm text-gray-600 flex items-center gap-1 mt-1">
                         <MapPin className="h-4 w-4" />
-                        {favorite.cleaner.users.city}, {favorite.cleaner.users.state}
+                        {favorite.pro.users.city}, {favorite.pro.users.state}
                       </p>
                     )}
 
                     {/* Rating */}
                     <div className="flex items-center gap-2 mt-2">
-                      {favorite.cleaner.average_rating ? (
+                      {favorite.pro.average_rating ? (
                         <>
                           <div className="flex items-center gap-1">
                             <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
                             <span className="font-medium">
-                              {favorite.cleaner.average_rating.toFixed(1)}
+                              {favorite.pro.average_rating.toFixed(1)}
                             </span>
                           </div>
                           <span className="text-sm text-gray-500">
-                            ({favorite.cleaner.total_reviews} {favorite.cleaner.total_reviews === 1 ? 'review' : 'reviews'})
+                            ({favorite.pro.total_reviews} {favorite.pro.total_reviews === 1 ? 'review' : 'reviews'})
                           </span>
                         </>
                       ) : (
@@ -203,15 +211,15 @@ export default function CustomerFavoritesPage() {
 
                     {/* Services */}
                     <p className="text-sm text-gray-600 mt-2">
-                      {formatServices(favorite.cleaner.services)}
+                      {formatServices(favorite.pro.services)}
                     </p>
 
                     {/* Price and Action */}
                     <div className="flex items-center justify-between mt-4 pt-4 border-t">
-                      {favorite.cleaner.hourly_rate ? (
+                      {favorite.pro.hourly_rate ? (
                         <div>
                           <span className="text-lg font-bold text-gray-900">
-                            ${favorite.cleaner.hourly_rate}
+                            ${favorite.pro.hourly_rate}
                           </span>
                           <span className="text-sm text-gray-500">/hr</span>
                         </div>
@@ -220,7 +228,7 @@ export default function CustomerFavoritesPage() {
                       )}
 
                       <Link
-                        href={`/cleaner/${favorite.cleaner.business_slug}`}
+                        href={`/cleaner/${favorite.pro.business_slug}`}
                         className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
                       >
                         View Profile


### PR DESCRIPTION
## Summary

Aligns the customer Favorites page (`app/dashboard/customer/favorites/page.tsx`) with BOC's locked multi-service-marketplace positioning by renaming user-facing copy, the local TypeScript interface, and helper variables from \`cleaner\` -> \`pro\`.

- \`interface FavoriteCleaner\` -> \`interface FavoritePro\`
- Local field \`cleaner\` -> \`pro\` (remapped on load — the API still keys the joined row as \`cleaner\` via the Supabase \`cleaner:cleaners(...)\` alias, which is out of scope for this ticket)
- \`handleRemoveFavorite(cleanerId)\` -> \`handleRemoveFavorite(proId)\`
- Header: "My Favorite Cleaners" -> "My Favorite Pros"
- Count line: "X cleaners saved" -> "X pros saved" (singular/plural respected)
- Empty state copy: "Save your favorite pros...", "Click the heart icon on any pro's profile..."
- CTA: "Find Cleaners" -> "Find Pros"
- Default \`formatServices\` fallback "General cleaning" -> "General services"

## URL decision (deferred per board direction)

Per the comment on DLD-463, the URL migration (\`/cleaner/[slug]\` -> \`/pros/[slug]\`) is deferred to a Phase E SEO ticket. The \`/pros/[slug]\` route does not exist yet, so flipping internal links now would 404. The two internal \`href={\`/cleaner/\${...}\`}\` links remain in this file pending the dedicated URL/route migration ticket.

## Out of scope (intentionally untouched)

- \`/app/api/customer/favorites/route.ts\` — API still returns the joined row as \`cleaner\` (Supabase alias). Renaming the API contract would ripple into every other consumer of \`customer_favorites\` and belongs in a separate ticket.
- \`components/FavoriteButton.tsx\` — public prop name \`cleanerId\` is consumed by other call sites; out of scope.
- \`/cleaner/[slug]\` route itself — URL migration deferred to Phase E.

## Verification

- TypeScript baseline: **55 errors before, 55 errors after** (no regression). Zero new errors in the favorites page.
- Remaining "cleaner" occurrences in the file are all justified: one explanatory comment, the API-shape remap, the \`FavoriteButton\` prop name, and the two \`/cleaner/[slug]\` href values.

## Test plan

- [ ] \`npm run dev\` -> visit \`/dashboard/customer/favorites\` as a customer; header reads "My Favorite Pros"
- [ ] Saved-count line shows "1 pro saved" / "N pros saved" correctly
- [ ] Empty state copy uses "pro/pros" language
- [ ] Cards render with name, location, rating, services, price; heart icon still works
- [ ] "Find Pros" CTA from empty state navigates to \`/search\`

## Ticket

[DLD-463](/DLD/issues/DLD-463) — promoted to Phase D Sprint Round 1.