### PR TITLE
fix(pricing): DLD-455 auth-aware tier CTAs + Stripe checkout flow

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -40,16 +40,16 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Get user's cleaner profile
-    const { data: cleaner } = await supabase
-      .from('cleaners')
+    // Get user's pro profile (DLD-444 — `cleaners` is a backwards-compat view of `pros`)
+    const { data: pro } = await supabase
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single()
 
-    if (!cleaner) {
+    if (!pro) {
       return NextResponse.json(
-        { error: 'Cleaner profile required' },
+        { error: 'Pro profile required' },
         { status: 400 }
       )
     }
@@ -59,6 +59,7 @@ export async function POST(request: NextRequest) {
     const priceId = STRIPE_PRICES[plan]
 
     // Create Stripe checkout session (with MCP integration)
+    // NOTE: metadata key `cleaner_id` is preserved for webhook + existing subscription compatibility.
     const session = await createCheckoutSession({
       priceId,
       mode: isPerLead ? 'payment' : 'subscription',
@@ -67,12 +68,12 @@ export async function POST(request: NextRequest) {
       customerEmail: user.email,
       metadata: {
         user_id: user.id,
-        cleaner_id: cleaner.id,
+        cleaner_id: pro.id,
         plan: plan,
       },
       subscriptionMetadata: isPerLead ? undefined : {
         user_id: user.id,
-        cleaner_id: cleaner.id,
+        cleaner_id: pro.id,
         tier: plan,
       },
     })

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,6 +1,8 @@
 import { Check, ArrowRight, Crown, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 import { generatePageMetadata } from '@/lib/seo/metadata';
+import { createClient } from '@/lib/supabase/server';
+import { PricingCTA, type PricingAuthState, type PricingPlanId } from '@/components/pricing/PricingCTA';
 
 export const metadata = generatePageMetadata({
   title: 'Pricing',
@@ -29,8 +31,21 @@ const PRO_CATEGORIES = [
   'Pressure washing',
 ];
 
-const plans = [
+interface Plan {
+  planId: PricingPlanId;
+  name: string;
+  price: string;
+  period: string;
+  description: string;
+  features: string[];
+  cta: string;
+  ctaHref: string;
+  highlighted: boolean;
+}
+
+const plans: Plan[] = [
   {
+    planId: 'free',
     name: 'Free',
     price: '$0',
     period: '/mo',
@@ -47,6 +62,7 @@ const plans = [
     highlighted: false,
   },
   {
+    planId: 'basic',
     name: 'Basic',
     price: '$79',
     period: '/mo',
@@ -65,6 +81,7 @@ const plans = [
     highlighted: false,
   },
   {
+    planId: 'pro',
     name: 'Pro',
     price: '$199',
     period: '/mo',
@@ -112,7 +129,29 @@ const faqs = [
   },
 ];
 
-export default function PricingPage() {
+async function resolveAuthState(): Promise<PricingAuthState> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return 'anonymous';
+
+  const { data: userData } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  const role = userData?.role || user.user_metadata?.role || 'customer';
+  // The DB role for service pros is 'cleaner' (legacy name); 'admin' is treated as pro for billing UX.
+  if (role === 'cleaner' || role === 'admin') return 'pro';
+  return 'customer';
+}
+
+export default async function PricingPage() {
+  const authState = await resolveAuthState();
+
   return (
     <div className="min-h-screen bg-white">
       {/* Hero */}
@@ -185,16 +224,13 @@ export default function PricingPage() {
                 ))}
               </ul>
 
-              <Link
-                href={plan.ctaHref}
-                className={`block w-full text-center py-3.5 rounded-xl font-semibold text-sm transition-all duration-200 min-h-[44px] ${
-                  plan.highlighted
-                    ? 'bg-brand-gold text-white hover:bg-brand-gold-light shadow-lg hover:shadow-xl'
-                    : 'bg-brand-dark text-white hover:bg-brand-navy'
-                }`}
-              >
-                {plan.cta}
-              </Link>
+              <PricingCTA
+                planId={plan.planId}
+                ctaHref={plan.ctaHref}
+                ctaLabel={plan.cta}
+                highlighted={plan.highlighted}
+                authState={authState}
+              />
             </div>
           ))}
         </div>

--- a/components/pricing/PricingCTA.tsx
+++ b/components/pricing/PricingCTA.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { redirectToCheckout } from '@/lib/stripe/client';
+import { createLogger } from '@/lib/utils/logger';
+
+const logger = createLogger({ file: 'components/pricing/PricingCTA' });
+
+export type PricingAuthState = 'anonymous' | 'pro' | 'customer';
+export type PricingPlanId = 'free' | 'basic' | 'pro';
+
+interface PricingCTAProps {
+  planId: PricingPlanId;
+  ctaHref: string;
+  ctaLabel: string;
+  highlighted: boolean;
+  authState: PricingAuthState;
+}
+
+const baseClasses =
+  'block w-full text-center py-3.5 rounded-xl font-semibold text-sm transition-all duration-200 min-h-[44px]';
+const highlightedClasses =
+  'bg-brand-gold text-white hover:bg-brand-gold-light shadow-lg hover:shadow-xl';
+const standardClasses = 'bg-brand-dark text-white hover:bg-brand-navy';
+
+export function PricingCTA({
+  planId,
+  ctaHref,
+  ctaLabel,
+  highlighted,
+  authState,
+}: PricingCTAProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const buttonClasses = `${baseClasses} ${highlighted ? highlightedClasses : standardClasses}`;
+
+  // Anonymous users keep the existing /signup conversion funnel.
+  if (authState === 'anonymous') {
+    return (
+      <Link href={ctaHref} className={buttonClasses}>
+        {ctaLabel}
+      </Link>
+    );
+  }
+
+  // Customers can't subscribe to pro plans — direct them to the right place.
+  if (authState === 'customer') {
+    return (
+      <div className="space-y-2">
+        <Link href="/dashboard/customer" className={buttonClasses}>
+          Go to Customer Dashboard
+        </Link>
+        <p className="text-xs text-gray-500 text-center">
+          These plans are for service pros. You&apos;re signed in with a customer account.
+        </p>
+      </div>
+    );
+  }
+
+  // Signed-in pro on the Free tier → already on Free, send to dashboard.
+  if (planId === 'free') {
+    return (
+      <Link href="/dashboard/pro" className={buttonClasses}>
+        Go to Dashboard
+      </Link>
+    );
+  }
+
+  // Signed-in pro on Basic or Pro → live Stripe checkout.
+  const handleCheckout = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await redirectToCheckout(planId);
+    } catch (err) {
+      logger.error('Pricing CTA checkout failed', { planId }, err);
+      setError(
+        err instanceof Error ? err.message : 'Could not start checkout. Please try again.'
+      );
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={handleCheckout}
+        disabled={loading}
+        className={`${buttonClasses} ${loading ? 'opacity-70 cursor-wait' : ''}`}
+      >
+        {loading ? 'Redirecting to Stripe…' : ctaLabel}
+      </button>
+      {error && (
+        <p className="text-xs text-red-600 text-center" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Pricing page tier buttons now detect auth state server-side and route
signed-in pros directly to Stripe checkout instead of bouncing them
through /signup (where the middleware kicks them back to /dashboard/pro).

- New components/pricing/PricingCTA.tsx (client) handles three states:
  - anonymous → existing /signup link
  - signed-in pro → POST /api/stripe/checkout via redirectToCheckout()
  - signed-in customer → "pros only" message + customer dashboard link
- app/pricing/page.tsx resolves authState from users.role and passes
  it to each tier card. Plan list now carries an explicit planId.
- app/api/stripe/checkout/route.ts: from('cleaners') → from('pros')
  per DLD-444 rename. cleaner_id metadata key preserved for webhook
  + existing subscription compatibility.

TS error count holds at 55 (≤ baseline 56). Production build passes.

Co-Authored-By: Paperclip <noreply@paperclip.ing>
