### PR TITLE
DLD-458: hydrate search filter + onboarding labels from service_categories

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -18,6 +18,7 @@ import type {
 } from '@/components/search/SearchFilters';
 import type { ProviderCardProps } from '@/components/search/ProviderCard';
 import { useSearchHistory } from '@/lib/hooks/useSearchHistory';
+import { useServiceCategories } from '@/lib/hooks/useServiceCategories';
 import { haversineDistance, type ZipCoordinates } from '@/lib/utils/distance';
 import { createLogger } from '@/lib/utils/logger';
 
@@ -59,6 +60,7 @@ export default function SearchPage() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [page, setPage] = useState(1);
   const { recentSearches, addSearch, removeSearch, clearHistory } = useSearchHistory();
+  const { categories: serviceCategories } = useServiceCategories();
 
   // Parse URL params for initial filter state
   const initialFilters = useMemo((): SearchFiltersState => ({
@@ -272,7 +274,11 @@ export default function SearchPage() {
       // Save to recent searches
       if (!append && (filters.selectedZip || filters.location || filters.selectedService)) {
         const parts: string[] = [];
-        if (filters.selectedService) parts.push(filters.selectedService);
+        if (filters.selectedService) {
+          // selectedService is a category slug (DLD-458) — render as display name.
+          const match = serviceCategories.find((c) => c.slug === filters.selectedService);
+          parts.push(match?.display_name ?? filters.selectedService);
+        }
         if (filters.location) parts.push(`in ${filters.location}`);
         else if (filters.selectedZip) parts.push(`near ${filters.selectedZip}`);
         const label = parts.join(' ') || 'Search';
@@ -291,7 +297,7 @@ export default function SearchPage() {
       setLoading(false);
       setLoadingMore(false);
     }
-  }, [filters, supabase, addSearch]);
+  }, [filters, supabase, addSearch, serviceCategories]);
 
   // Initial load and filter changes
   useEffect(() => {

--- a/components/onboarding/ReviewSubmitForm.tsx
+++ b/components/onboarding/ReviewSubmitForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { StepProps, SERVICE_TYPES, DOCUMENT_TYPES } from './types'
+import { useServiceCategories } from '@/lib/hooks/useServiceCategories'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
@@ -26,6 +27,7 @@ export default function ReviewSubmitForm({
 }: ReviewSubmitFormProps) {
   const [agreedToTerms, setAgreedToTerms] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { categories: serviceCategories } = useServiceCategories()
 
   const documents = data.documents || []
   const services = data.services || []
@@ -33,6 +35,11 @@ export default function ReviewSubmitForm({
   const portfolioImages = data.portfolio_images || []
 
   const getServiceLabel = (value: string) => {
+    // DLD-458: prefer DB display_name so the 9 new categories from DLD-442
+    // (handyman, hvac, plumbing, etc.) render correctly. Fall back to the
+    // legacy onboarding constant for backwards compatibility, then raw slug.
+    const dbMatch = serviceCategories.find((c) => c.slug === value)
+    if (dbMatch) return dbMatch.display_name
     return SERVICE_TYPES.find((s) => s.value === value)?.label || value
   }
 

--- a/components/search/EmptySearchState.tsx
+++ b/components/search/EmptySearchState.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { MapPin, Sparkles, ArrowRight, Mail, CheckCircle2 } from 'lucide-react';
+import { useServiceCategories } from '@/lib/hooks/useServiceCategories';
 
 interface EmptySearchStateProps {
   searchLocation?: string;
@@ -13,6 +14,12 @@ export function EmptySearchState({ searchLocation, searchService }: EmptySearchS
   const [email, setEmail] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const { categories } = useServiceCategories();
+
+  // searchService is now a slug (DLD-458) — resolve to display name for UI copy.
+  const serviceLabel = searchService
+    ? categories.find((c) => c.slug === searchService)?.display_name ?? searchService
+    : '';
 
   const handleNotifyMe = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,12 +49,12 @@ export function EmptySearchState({ searchLocation, searchService }: EmptySearchS
     }
   };
 
-  const contextMessage = searchLocation && searchService
-    ? `for ${searchService} in ${searchLocation}`
+  const contextMessage = searchLocation && serviceLabel
+    ? `for ${serviceLabel} in ${searchLocation}`
     : searchLocation
       ? `in ${searchLocation}`
-      : searchService
-        ? `for ${searchService}`
+      : serviceLabel
+        ? `for ${serviceLabel}`
         : 'in your area';
 
   return (

--- a/components/search/SearchBar.tsx
+++ b/components/search/SearchBar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { Search, MapPin, ChevronDown } from 'lucide-react';
-import { SERVICE_TYPES } from '@/lib/data/service-types';
+import { useServiceCategories } from '@/lib/hooks/useServiceCategories';
 
 interface SearchBarProps {
   initialService?: string;
@@ -13,6 +13,7 @@ interface SearchBarProps {
 export function SearchBar({ initialService, initialZip, onSearch }: SearchBarProps) {
   const [service, setService] = useState(initialService || '');
   const [zip, setZip] = useState(initialZip || '');
+  const { categories, loading: categoriesLoading } = useServiceCategories();
 
   useEffect(() => {
     if (initialService !== undefined) setService(initialService);
@@ -57,11 +58,12 @@ export function SearchBar({ initialService, initialZip, onSearch }: SearchBarPro
                   onChange={(e) => setService(e.target.value)}
                   className="w-full pl-12 pr-10 py-4 bg-brand-cream rounded-xl text-brand-dark font-medium text-sm appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-gold/50 transition-shadow"
                   aria-label="Select service type"
+                  disabled={categoriesLoading}
                 >
-                  <option value="">All Services</option>
-                  {SERVICE_TYPES.map((st) => (
-                    <option key={st.slug} value={st.shortName}>
-                      {st.shortName}
+                  <option value="">{categoriesLoading ? 'Loading services…' : 'All Services'}</option>
+                  {categories.map((c) => (
+                    <option key={c.slug} value={c.slug}>
+                      {c.display_name}
                     </option>
                   ))}
                 </select>

--- a/components/search/SearchFilters.tsx
+++ b/components/search/SearchFilters.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { SlidersHorizontal, X, ChevronDown } from 'lucide-react';
-import { SERVICE_TYPES } from '@/lib/data/service-types';
+import { useServiceCategories } from '@/lib/hooks/useServiceCategories';
 
 export type AvailabilityFilter = 'any' | 'today' | 'this_week' | 'next_week';
 export type SortByOption = 'relevance' | 'newest' | 'name_az';
@@ -52,6 +52,7 @@ export function SearchFilters({
   isLoading,
 }: SearchFiltersProps) {
   const [showMobileFilters, setShowMobileFilters] = useState(false);
+  const { categories, loading: categoriesLoading } = useServiceCategories();
 
   const updateFilter = <K extends keyof SearchFiltersState>(
     key: K,
@@ -95,12 +96,13 @@ export function SearchFilters({
             id="filter-service"
             value={filters.selectedService}
             onChange={(e) => updateFilter('selectedService', e.target.value)}
-            className="w-full px-4 py-3 bg-brand-cream border border-gray-200 rounded-xl text-brand-dark text-sm appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-gold/50 transition-shadow"
+            disabled={categoriesLoading}
+            className="w-full px-4 py-3 bg-brand-cream border border-gray-200 rounded-xl text-brand-dark text-sm appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-gold/50 transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <option value="">All Services</option>
-            {SERVICE_TYPES.map((st) => (
-              <option key={st.slug} value={st.shortName}>
-                {st.shortName}
+            <option value="">{categoriesLoading ? 'Loading services…' : 'All Services'}</option>
+            {categories.map((c) => (
+              <option key={c.slug} value={c.slug}>
+                {c.display_name}
               </option>
             ))}
           </select>

--- a/lib/hooks/useServiceCategories.ts
+++ b/lib/hooks/useServiceCategories.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { ServiceCategory } from '@/lib/types/service-category'
+
+interface UseServiceCategoriesResult {
+  categories: ServiceCategory[]
+  loading: boolean
+  error: string | null
+}
+
+let cachedCategories: ServiceCategory[] | null = null
+let inflight: Promise<ServiceCategory[]> | null = null
+
+async function fetchServiceCategories(): Promise<ServiceCategory[]> {
+  if (cachedCategories) return cachedCategories
+  if (inflight) return inflight
+
+  inflight = (async () => {
+    const response = await fetch('/api/service-categories')
+    if (!response.ok) {
+      inflight = null
+      throw new Error(`Failed to load service categories (${response.status})`)
+    }
+    const json = (await response.json()) as { categories: ServiceCategory[] }
+    cachedCategories = json.categories ?? []
+    inflight = null
+    return cachedCategories
+  })()
+
+  return inflight
+}
+
+/**
+ * DLD-458 — DB-hydrated source of truth for service-type dropdowns.
+ * Filters out aliases (alias_for !== null) so the legacy `pool_cleaning`
+ * and `mobile_car_detailing` rows don't double-render alongside the
+ * canonical `pool_service` / `mobile_detailing` slugs.
+ */
+export function useServiceCategories(): UseServiceCategoriesResult {
+  const [categories, setCategories] = useState<ServiceCategory[]>(
+    cachedCategories ? cachedCategories.filter((c) => c.alias_for === null) : []
+  )
+  const [loading, setLoading] = useState(cachedCategories === null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchServiceCategories()
+      .then((rows) => {
+        if (cancelled) return
+        setCategories(rows.filter((c) => c.alias_for === null))
+        setLoading(false)
+      })
+      .catch((err: Error) => {
+        if (cancelled) return
+        setError(err.message)
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { categories, loading, error }
+}


### PR DESCRIPTION
Replaces the static SERVICE_TYPES dropdown source in /search and the
onboarding review summary with a DB-hydrated `useServiceCategories`
hook backed by /api/service-categories (DLD-449). Surfaces all 24
active categories from the service_categories taxonomy (DLD-442),
including the 9 new categories: handyman, hvac, plumbing, electrical,
pest_control, gutter_cleaning, junk_removal, pool_service,
mobile_detailing.

Also fixes a pre-existing filter bug: SearchBar/SearchFilters were
emitting `shortName` ("House Cleaning") while the search query calls
`.contains('services', [value])` against cleaners.services which stores
slugs. Dropdown values now emit canonical slugs so `handyman` actually
matches handyman pros. EmptySearchState and recent-search labels still
display human-readable display_name via the hook.

- lib/hooks/useServiceCategories.ts: new module-cached hook,
  filters alias rows so legacy mobile_car_detailing / pool_cleaning
  don't double-render alongside canonical mobile_detailing / pool_service.
- components/search/SearchBar.tsx, SearchFilters.tsx: hook-hydrated
  dropdowns; value = slug, label = display_name.
- components/search/EmptySearchState.tsx: resolve slug -> display_name
  for "for X in Y" copy.
- app/search/page.tsx: map slug -> display_name when building
  recent-search label.
- components/onboarding/ReviewSubmitForm.tsx: getServiceLabel prefers
  DB display_name (falls back to legacy onboarding constant).

TS error count unchanged at 55 (baseline 56).

Co-Authored-By: Paperclip <noreply@paperclip.ing>
