### PR TITLE
fix(supabase): DLD-461 swap from('cleaners') -> from('pros') across 69 files

### DIFF
--- a/app/[city]/page.tsx
+++ b/app/[city]/page.tsx
@@ -64,7 +64,7 @@ export async function generateMetadata({ params }: CityPageProps): Promise<Metad
   // Get cleaner stats for this city
   const supabase = await createClient();
   const { count, data: cleaners } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('average_rating, services', { count: 'exact' })
     .in('approval_status', ['approved', 'pending'])
     .overlaps('service_areas', city.zipCodes);
@@ -106,7 +106,7 @@ export default async function CityPage({ params }: CityPageProps) {
   // Get cleaner data for this city
   const supabase = await createClient();
   const { count, data: cleaners } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select(
       `
       id,

--- a/app/api/admin/documents/[id]/route.ts
+++ b/app/api/admin/documents/[id]/route.ts
@@ -94,7 +94,7 @@ export async function PATCH(
   if (action === 'reject') {
     try {
       const { data: cleanerData } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('business_name, users(email, full_name)')
         .eq('id', doc.cleaner_id)
         .single();
@@ -131,12 +131,12 @@ export async function PATCH(
 
     if (allRequiredApproved) {
       await supabase
-        .from('cleaners')
+        .from('pros')
         .update({ approval_status: 'approved', approved_at: new Date().toISOString() })
         .eq('id', doc.cleaner_id);
 
       const { data: cleanerData } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('user_id, business_name, users(email, full_name)')
         .eq('id', doc.cleaner_id)
         .single();

--- a/app/api/admin/reviews/[id]/route.ts
+++ b/app/api/admin/reviews/[id]/route.ts
@@ -96,7 +96,7 @@ export async function PATCH(
           rating,
           comment,
           cleaner_id,
-          cleaner:cleaners(user_id, business_name),
+          cleaner:pros(user_id, business_name),
           customer:users!reviews_customer_id_fkey(full_name)
         `)
         .eq('id', id)

--- a/app/api/admin/reviews/pending/route.ts
+++ b/app/api/admin/reviews/pending/route.ts
@@ -43,7 +43,7 @@ export async function GET() {
         created_at,
         updated_at,
         customer:users!reviews_customer_id_fkey(id, full_name, email),
-        cleaner:cleaners(id, business_name, user_id)`,
+        cleaner:pros(id, business_name, user_id)`,
         { count: 'exact' }
       )
       .eq('is_published', false)

--- a/app/api/admin/reviews/route.ts
+++ b/app/api/admin/reviews/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest) {
           full_name,
           email
         ),
-        cleaner:cleaners(
+        cleaner:pros(
           id,
           business_name,
           user_id

--- a/app/api/bookings/[id]/photos/route.ts
+++ b/app/api/bookings/[id]/photos/route.ts
@@ -24,7 +24,7 @@ export async function POST(
 
     // Verify cleaner owns this booking
     const { data: cleaner } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
     .from('bookings')
     .select(`
       *,
-      cleaner:cleaners(
+      cleaner:pros(
         id,
         business_name,
         business_phone,

--- a/app/api/bookings/create/route.ts
+++ b/app/api/bookings/create/route.ts
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
 
   // Verify cleaner exists and has instant booking enabled
   const { data: cleaner, error: cleanerError } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('id, user_id, business_name, business_email, instant_booking, approval_status')
     .eq('id', cleanerId)
     .single();

--- a/app/api/cleaner/billing/cancel/route.ts
+++ b/app/api/cleaner/billing/cancel/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, stripe_subscription_id, subscription_tier')
       .eq('user_id', user.id)
       .single();

--- a/app/api/cleaner/billing/invoices/route.ts
+++ b/app/api/cleaner/billing/invoices/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
 
     // Get cleaner profile with Stripe customer ID
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, stripe_customer_id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/cleaner/billing/reactivate/route.ts
+++ b/app/api/cleaner/billing/reactivate/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, stripe_subscription_id, subscription_tier')
       .eq('user_id', user.id)
       .single();

--- a/app/api/cleaner/billing/route.ts
+++ b/app/api/cleaner/billing/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
 
     // Get cleaner profile with subscription info
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select(`
         id,
         subscription_tier,

--- a/app/api/cleaner/billing/upgrade/route.ts
+++ b/app/api/cleaner/billing/upgrade/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, stripe_customer_id, stripe_subscription_id, subscription_tier')
       .eq('user_id', user.id)
       .single();
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
 
           // Update cleaner tier in database
           await supabase
-            .from('cleaners')
+            .from('pros')
             .update({ subscription_tier: planId })
             .eq('id', cleaner.id);
 
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest) {
 
       // Update cleaner with customer ID
       await supabase
-        .from('cleaners')
+        .from('pros')
         .update({ stripe_customer_id: customerId })
         .eq('id', cleaner.id);
     }

--- a/app/api/cleaner/bookings/[id]/route.ts
+++ b/app/api/cleaner/bookings/[id]/route.ts
@@ -26,7 +26,7 @@ export async function PATCH(
 
   // Verify the user is the cleaner for this booking
   const { data: cleaner } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('id')
     .eq('user_id', user.id)
     .single();

--- a/app/api/cleaner/bookings/route.ts
+++ b/app/api/cleaner/bookings/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
 
   // Get the cleaner profile
   const { data: cleaner, error: cleanerError } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('id')
     .eq('user_id', user.id)
     .single();

--- a/app/api/cleaner/portfolio/route.ts
+++ b/app/api/cleaner/portfolio/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();
@@ -95,7 +95,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();
@@ -196,7 +196,7 @@ export async function PATCH(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();
@@ -393,7 +393,7 @@ export async function DELETE(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/cleaner/portfolio/upload/route.ts
+++ b/app/api/cleaner/portfolio/upload/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/cleaner/reviews/respond/route.ts
+++ b/app/api/cleaner/reviews/respond/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/cleaners/documents/route.ts
+++ b/app/api/cleaners/documents/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single()
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single()
@@ -127,7 +127,7 @@ export async function DELETE(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single()

--- a/app/api/customer/favorites/route.ts
+++ b/app/api/customer/favorites/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
       .select(`
         id,
         created_at,
-        cleaner:cleaners(
+        cleaner:pros(
           id,
           business_name,
           business_slug,
@@ -76,7 +76,7 @@ export async function POST(request: NextRequest) {
 
     // Check if cleaner exists
     const { data: cleaner } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('id', cleanerId)
       .single();

--- a/app/api/leads/available/route.ts
+++ b/app/api/leads/available/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/leads/refund/route.ts
+++ b/app/api/leads/refund/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/leads/unlock/route.ts
+++ b/app/api/leads/unlock/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, subscription_tier, stripe_customer_id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/leads/unlocked/route.ts
+++ b/app/api/leads/unlocked/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
 
     // Get cleaner profile
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/messages/[conversationId]/route.ts
+++ b/app/api/messages/[conversationId]/route.ts
@@ -32,7 +32,7 @@ export async function GET(
       customer_id,
       cleaner_id,
       customer:users!conversations_customer_id_fkey(id, full_name, email),
-      cleaner:cleaners!conversations_cleaner_id_fkey(id, business_name, user_id)
+      cleaner:pros!conversations_cleaner_id_fkey(id, business_name, user_id)
     `)
     .eq('id', conversationId)
     .single();
@@ -57,7 +57,7 @@ export async function GET(
 
   if (!isCustomer) {
     const { data: cleanerData } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();
@@ -135,7 +135,7 @@ export async function POST(
 
   if (!isCustomer) {
     const { data: cleanerData } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/api/messages/report/route.ts
+++ b/app/api/messages/report/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
 
   // Check if user is a participant (as customer or via cleaner record)
   const { data: cleanerRecord } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('id')
     .eq('user_id', user.id)
     .maybeSingle();

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -40,7 +40,7 @@ export async function GET() {
   let cleanerId: string | null = null;
   if (!isCustomer) {
     const { data: cleanerData } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();
@@ -59,7 +59,7 @@ export async function GET() {
       cleaner_unread_count,
       created_at,
       customer:users!conversations_customer_id_fkey(id, full_name, email),
-      cleaner:cleaners!conversations_cleaner_id_fkey(id, business_name, user_id)
+      cleaner:pros!conversations_cleaner_id_fkey(id, business_name, user_id)
     `)
     .order('last_message_at', { ascending: false, nullsFirst: false });
 
@@ -157,7 +157,7 @@ export async function POST(request: NextRequest) {
     if (isCustomer) {
       // Verify cleaner exists
       const { data: cleaner, error: cleanerError } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id, business_name, business_email, user_id')
         .eq('id', cleanerId)
         .single();
@@ -216,7 +216,7 @@ export async function POST(request: NextRequest) {
         customer_id,
         cleaner_id,
         customer:users!conversations_customer_id_fkey(email, full_name),
-        cleaner:cleaners!conversations_cleaner_id_fkey(business_name, business_email, user_id)
+        cleaner:pros!conversations_cleaner_id_fkey(business_name, business_email, user_id)
       `)
       .eq('id', conversationId)
       .single();
@@ -232,7 +232,7 @@ export async function POST(request: NextRequest) {
 
     if (!isCustomer) {
       const { data: cleanerData } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id')
         .eq('user_id', user.id)
         .single();
@@ -358,7 +358,7 @@ export async function POST(request: NextRequest) {
   if (isCustomer && cleanerId) {
     // Customer sent message to cleaner — notify the cleaner via SMS
     const { data: cleanerSms } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('business_phone, user_id')
       .eq('id', cleanerId)
       .single();

--- a/app/api/pro/documents/route.ts
+++ b/app/api/pro/documents/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
   }
 
   const { data: cleaner, error: cleanerError } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('id')
     .eq('user_id', user.id)
     .single();
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { data: cleaner, error: cleanerError } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('id, business_name')
     .eq('user_id', user.id)
     .single();

--- a/app/api/quote/route.ts
+++ b/app/api/quote/route.ts
@@ -139,7 +139,7 @@ export async function POST(request: NextRequest) {
 
     // First, fetch cleaner details including subscription_tier
     const { data: cleaner, error: cleanerError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, business_name, subscription_tier')
       .eq('id', body.cleaner_id)
       .single();
@@ -258,7 +258,7 @@ export async function POST(request: NextRequest) {
 
     // Fetch cleaner's phone and user_id for SMS
     const { data: cleanerSms } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('business_phone, user_id')
       .eq('id', body.cleaner_id)
       .single();

--- a/app/api/quotes/[id]/accept/route.ts
+++ b/app/api/quotes/[id]/accept/route.ts
@@ -24,7 +24,7 @@ export async function POST(
   // Fetch the quote request — must belong to this customer and be in 'responded' status
   const { data: quote, error: fetchError } = await supabase
     .from('quote_requests')
-    .select('*, cleaner:cleaners(id, user_id, business_name, approval_status)')
+    .select('*, cleaner:pros(id, user_id, business_name, approval_status)')
     .eq('id', quoteId)
     .single();
 

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
 
     // Get user's cleaner profile
     const { data: cleaner } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single()

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
 
     // Get user's cleaner profile to verify they have a subscription
     const { data: cleaner } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('subscription_tier')
       .eq('user_id', user.id)
       .single()

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -159,7 +159,7 @@ export async function GET(request: NextRequest) {
   // If pro signup via Google, create cleaners profile
   if (newRole === 'cleaner') {
     await supabase
-      .from('cleaners')
+      .from('pros')
       .insert({
         user_id: user.id,
         business_name: user.user_metadata?.full_name || user.user_metadata?.name || user.email?.split('@')[0] || 'My Business',

--- a/app/auth/select-role/page.tsx
+++ b/app/auth/select-role/page.tsx
@@ -72,7 +72,7 @@ export default function SelectRolePage() {
       // If cleaner role, create cleaner profile entry
       if (selectedRole === 'cleaner') {
         const { error: cleanerError } = await supabase
-          .from('cleaners')
+          .from('pros')
           .insert({
             user_id: user.id,
             business_name: user.user_metadata?.full_name || user.email?.split('@')[0] || 'My Cleaning Business',

--- a/app/book/[cleanerId]/page.tsx
+++ b/app/book/[cleanerId]/page.tsx
@@ -109,7 +109,7 @@ export default function BookCleanerPage() {
     async function fetchCleaner() {
       const supabase = createClient();
       const { data, error: fetchError } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select(
           'id, business_name, business_description, profile_image_url, hourly_rate, minimum_hours, average_rating, total_reviews, insurance_verified, services, instant_booking'
         )

--- a/app/cleaner/[slug]/page.tsx
+++ b/app/cleaner/[slug]/page.tsx
@@ -68,7 +68,7 @@ async function getCleanerBySlug(slug: string): Promise<CleanerProfile | null> {
   const supabase = await createClient();
 
   const { data, error } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select(`
       *,
       users(full_name, city, state, zip_code)
@@ -80,7 +80,7 @@ async function getCleanerBySlug(slug: string): Promise<CleanerProfile | null> {
   if (error || !data) {
     // Try by ID as fallback
     const { data: dataById, error: errorById } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select(`
         *,
         users(full_name, city, state, zip_code)

--- a/app/dashboard/admin/actions.ts
+++ b/app/dashboard/admin/actions.ts
@@ -40,7 +40,7 @@ async function verifyAdmin(): Promise<{ isAdmin: boolean; userId?: string; error
 async function getProContact(cleanerId: string): Promise<{ email: string; business_name: string; user_id: string } | null> {
   const supabase = await createClient()
   const { data } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('business_name, user_id, user:users(email)')
     .eq('id', cleanerId)
     .single()
@@ -312,7 +312,7 @@ export async function getCleanerDetails(cleanerId: string): Promise<ActionResult
 
   // Get cleaner with user info and documents
   const { data: cleaner, error: cleanerError } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select(`
       *,
       user:users(

--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -52,7 +52,7 @@ export default async function AdminDashboard() {
 
     // Fetch pending cleaners with completed onboarding
     const { data: cleanersData, error: cleanersError } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select(`
         *,
         user:users(
@@ -88,9 +88,9 @@ export default async function AdminDashboard() {
     // Get stats
     const [statsUsers, statsCleaners, statsPending, statsRejected, statsUnreadMessages] = await Promise.all([
       supabase.from('users').select('*', { count: 'exact', head: true }),
-      supabase.from('cleaners').select('*', { count: 'exact', head: true }).eq('approval_status', 'approved'),
-      supabase.from('cleaners').select('*', { count: 'exact', head: true }).eq('approval_status', 'pending'),
-      supabase.from('cleaners').select('*', { count: 'exact', head: true }).eq('approval_status', 'rejected'),
+      supabase.from('pros').select('*', { count: 'exact', head: true }).eq('approval_status', 'approved'),
+      supabase.from('pros').select('*', { count: 'exact', head: true }).eq('approval_status', 'pending'),
+      supabase.from('pros').select('*', { count: 'exact', head: true }).eq('approval_status', 'rejected'),
       supabase.from('contact_submissions').select('*', { count: 'exact', head: true }).eq('is_read', false),
     ])
 

--- a/app/dashboard/customer/bookings/page.tsx
+++ b/app/dashboard/customer/bookings/page.tsx
@@ -70,7 +70,7 @@ export default function CustomerBookingsPage() {
         .from('bookings')
         .select(`
           *,
-          cleaner:cleaners(
+          cleaner:pros(
             id,
             business_name,
             business_phone,

--- a/app/dashboard/customer/page.tsx
+++ b/app/dashboard/customer/page.tsx
@@ -82,7 +82,7 @@ export default function CustomerDashboard() {
         .from('quote_requests')
         .select(`
           *,
-          cleaner:cleaners(
+          cleaner:pros(
             business_name,
             business_phone
           )

--- a/app/dashboard/customer/reviews/new/page.tsx
+++ b/app/dashboard/customer/reviews/new/page.tsx
@@ -42,7 +42,7 @@ export default function NewReviewPage() {
         .select(`
           id,
           booking_date,
-          cleaner:cleaners(id, business_name)
+          cleaner:pros(id, business_name)
         `)
         .eq('customer_id', user.id)
         .eq('status', 'completed')

--- a/app/dashboard/pro/availability/page.tsx
+++ b/app/dashboard/pro/availability/page.tsx
@@ -61,7 +61,7 @@ export default function AvailabilityPage() {
     try {
       // Get cleaner ID and instant_booking setting
       const { data: cleaner, error: cleanerError } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id, instant_booking')
         .eq('user_id', user.id)
         .single();
@@ -114,7 +114,7 @@ export default function AvailabilityPage() {
     try {
       // Update instant_booking on cleaners table
       const { error: cleanerError } = await supabase
-        .from('cleaners')
+        .from('pros')
         .update({ instant_booking: instantBooking, updated_at: new Date().toISOString() })
         .eq('id', cleanerId);
 

--- a/app/dashboard/pro/bookings/page.tsx
+++ b/app/dashboard/pro/bookings/page.tsx
@@ -69,7 +69,7 @@ export default function CleanerBookingsPage() {
     try {
       // Get the cleaner profile first
       const { data: cleaner } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id')
         .eq('user_id', user.id)
         .single();

--- a/app/dashboard/pro/earnings/page.tsx
+++ b/app/dashboard/pro/earnings/page.tsx
@@ -47,7 +47,7 @@ export default function EarningsPage() {
     if (!user) return;
 
     const { data: cleaner, error } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id')
       .eq('user_id', user.id)
       .single();

--- a/app/dashboard/pro/page.tsx
+++ b/app/dashboard/pro/page.tsx
@@ -104,7 +104,7 @@ export default function CleanerDashboard() {
   const loadCleanerProfile = async () => {
     try {
       const { data, error } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('*')
         .eq('user_id', user?.id)
         .single();
@@ -132,7 +132,7 @@ export default function CleanerDashboard() {
   const loadQuotes = async () => {
     try {
       const { data: cleanerData } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id')
         .eq('user_id', user?.id)
         .single();

--- a/app/dashboard/pro/portfolio/page.tsx
+++ b/app/dashboard/pro/portfolio/page.tsx
@@ -38,7 +38,7 @@ export default function CleanerPortfolioPage() {
     try {
       // Get cleaner ID
       const { data: cleaner, error: cleanerError } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id')
         .eq('user_id', user.id)
         .single();

--- a/app/dashboard/pro/quote-requests/actions.ts
+++ b/app/dashboard/pro/quote-requests/actions.ts
@@ -51,7 +51,7 @@ export async function getMarketplaceQuotes(): Promise<{
 
     // Get cleaner profile
     const { data: cleaner } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, approval_status')
       .eq('user_id', user.id)
       .single();
@@ -161,7 +161,7 @@ export async function respondToQuote(
 
     // Get cleaner profile
     const { data: cleaner } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, business_name, approval_status')
       .eq('user_id', user.id)
       .single();

--- a/app/dashboard/pro/reviews/page.tsx
+++ b/app/dashboard/pro/reviews/page.tsx
@@ -47,7 +47,7 @@ export default function CleanerReviewsPage() {
     try {
       // Get the cleaner profile first
       const { data: cleaner } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id')
         .eq('user_id', user.id)
         .single();

--- a/app/dashboard/pro/service-areas/page.tsx
+++ b/app/dashboard/pro/service-areas/page.tsx
@@ -49,7 +49,7 @@ export default function ServiceAreasPage() {
     try {
       // First get the cleaner ID
       const { data: cleanerData, error: cleanerError } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id, service_areas')
         .eq('user_id', user?.id)
         .single();
@@ -123,7 +123,7 @@ export default function ServiceAreasPage() {
       const zipCodes = serviceAreas.map(area => area.zip_code);
       
       const { error } = await supabase
-        .from('cleaners')
+        .from('pros')
         .update({
           service_areas: zipCodes,
           updated_at: new Date().toISOString()

--- a/app/dashboard/pro/setup/page.tsx
+++ b/app/dashboard/pro/setup/page.tsx
@@ -127,7 +127,7 @@ export default function CleanerSetupPage() {
     
     try {
       const { error } = await supabase
-        .from('cleaners')
+        .from('pros')
         .insert({
           user_id: user?.id,
           business_name: formData.business_name,

--- a/app/professionals/page.tsx
+++ b/app/professionals/page.tsx
@@ -84,7 +84,7 @@ export default async function ProfessionalsPage({
   const supabase = await createClient();
 
   let query = supabase
-    .from('cleaners')
+    .from('pros')
     .select(
       `
       id, business_name, business_slug, business_description,

--- a/app/quote-request/actions.ts
+++ b/app/quote-request/actions.ts
@@ -152,7 +152,7 @@ export async function submitQuoteRequest(
       // Primary match: service_areas table (service-role: cross-customer read)
       const { data: areaMatches } = await adminSupabase
         .from('service_areas')
-        .select('cleaner_id, cleaner:cleaners!inner(id, business_name, user_id, approval_status, user:users!inner(email))')
+        .select('cleaner_id, cleaner:pros!inner(id, business_name, user_id, approval_status, user:users!inner(email))')
         .eq('zip_code', data.zip_code);
 
       if (areaMatches && areaMatches.length > 0) {
@@ -177,7 +177,7 @@ export async function submitQuoteRequest(
       // (early stage — not many pros have set up service areas yet)
       if (matchedPros.length === 0) {
         const { data: allApproved } = await adminSupabase
-          .from('cleaners')
+          .from('pros')
           .select('id, business_name, user_id, user:users!inner(email)')
           .eq('approval_status', 'approved');
 

--- a/app/review/[bookingId]/page.tsx
+++ b/app/review/[bookingId]/page.tsx
@@ -56,7 +56,7 @@ function ReviewPageContent() {
           customer_id,
           service_type,
           booking_date,
-          cleaner:cleaners!bookings_cleaner_id_fkey(
+          cleaner:pros!bookings_cleaner_id_fkey(
             id,
             business_name,
             profile_image_url

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -98,7 +98,7 @@ export default function SearchPage() {
 
       // Build query
       let query = supabase
-        .from('cleaners')
+        .from('pros')
         .select(`
           id, business_name, business_slug, business_description,
           services, service_areas, profile_image_url, instant_booking,

--- a/app/services/[serviceType]/ServicePageClient.tsx
+++ b/app/services/[serviceType]/ServicePageClient.tsx
@@ -79,7 +79,7 @@ export function ServicePageClient({ serviceType }: ServicePageClientProps) {
       // Build query to find cleaners offering this service type
       // Match against the shortName which is used in the services array
       const query = supabase
-        .from('cleaners')
+        .from('pros')
         .select(
           `
           *,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -111,7 +111,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   try {
     const { data: cleaners } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('business_slug, updated_at')
       .eq('approval_status', 'approved')
       .not('business_slug', 'is', null);

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -168,7 +168,7 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
           if (role === 'cleaner') {
             // Wait a moment for trigger to complete, then update with full details
             const { data: cleanerData } = await supabase
-              .from('cleaners')
+              .from('pros')
               .select('id')
               .eq('user_id', authData.user.id)
               .single()
@@ -176,7 +176,7 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
             if (cleanerData) {
               // Update with business details from the signup form
               await supabase
-                .from('cleaners')
+                .from('pros')
                 .update({
                   business_name: businessName || fullName || email.split('@')[0],
                 })
@@ -205,7 +205,7 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
             } else {
               // Fallback: trigger may not have fired yet, create cleaner profile directly
               const { data: newCleaner, error: cleanerError } = await supabase
-                .from('cleaners')
+                .from('pros')
                 .insert({
                   user_id: authData.user.id,
                   business_name: businessName || fullName || email.split('@')[0],

--- a/components/dashboard/CleanerProfileForm.tsx
+++ b/components/dashboard/CleanerProfileForm.tsx
@@ -92,7 +92,7 @@ export default function CleanerProfileForm({ cleanerData, userData, userId }: Cl
       if (cleanerData) {
         // Update existing profile
         const { error: cleanerError } = await supabase
-          .from('cleaners')
+          .from('pros')
           .update({
             business_name: formData.business_name,
             description: formData.description,
@@ -108,7 +108,7 @@ export default function CleanerProfileForm({ cleanerData, userData, userId }: Cl
       } else {
         // Create new profile
         const { error: cleanerError } = await supabase
-          .from('cleaners')
+          .from('pros')
           .insert({
             user_id: userId,
             business_name: formData.business_name,

--- a/lib/auth/auth-service.ts
+++ b/lib/auth/auth-service.ts
@@ -140,7 +140,7 @@ export class AuthService {
   async getCleanerProfile(userId: string) {
     try {
       const { data, error } = await this.supabase
-        .from('cleaners')
+        .from('pros')
         .select('*')
         .eq('user_id', userId)
         .single();

--- a/lib/hooks/usePendingDocumentActions.ts
+++ b/lib/hooks/usePendingDocumentActions.ts
@@ -42,7 +42,7 @@ export function usePendingDocumentActions(): UsePendingDocumentActionsResult {
         }
 
         const { data: cleaner } = await supabase
-          .from('cleaners')
+          .from('pros')
           .select('id')
           .eq('user_id', user.id)
           .single();

--- a/lib/services/admin-analytics.ts
+++ b/lib/services/admin-analytics.ts
@@ -88,7 +88,7 @@ export async function getAdminAnalytics(range: DateRange): Promise<AdminAnalytic
 
     // Total approved cleaners
     supabase
-      .from('cleaners')
+      .from('pros')
       .select('*', { count: 'exact', head: true })
       .eq('approval_status', 'approved'),
 
@@ -107,7 +107,7 @@ export async function getAdminAnalytics(range: DateRange): Promise<AdminAnalytic
 
     // Cleaner tiers for conversion rate
     supabase
-      .from('cleaners')
+      .from('pros')
       .select('subscription_tier')
       .eq('approval_status', 'approved'),
 
@@ -126,18 +126,18 @@ export async function getAdminAnalytics(range: DateRange): Promise<AdminAnalytic
     // Cleaners for signup trend
     rangeStart
       ? supabase
-          .from('cleaners')
+          .from('pros')
           .select('created_at')
           .gte('created_at', rangeStart.toISOString())
           .order('created_at', { ascending: true })
       : supabase
-          .from('cleaners')
+          .from('pros')
           .select('created_at')
           .order('created_at', { ascending: true }),
 
     // Top cleaners by reviews
     supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, business_name, total_reviews, average_rating, total_jobs, subscription_tier')
       .eq('approval_status', 'approved')
       .order('total_reviews', { ascending: false })
@@ -145,7 +145,7 @@ export async function getAdminAnalytics(range: DateRange): Promise<AdminAnalytic
 
     // Top cleaners by bookings
     supabase
-      .from('cleaners')
+      .from('pros')
       .select('id, business_name, total_reviews, average_rating, total_jobs, subscription_tier')
       .eq('approval_status', 'approved')
       .order('total_jobs', { ascending: false })

--- a/lib/services/admin-payments.ts
+++ b/lib/services/admin-payments.ts
@@ -67,7 +67,7 @@ export async function getPaymentMonitoringData(): Promise<PaymentMonitoringData>
         description,
         metadata,
         created_at,
-        cleaner:cleaners(
+        cleaner:pros(
           business_name,
           subscription_tier
         )
@@ -84,7 +84,7 @@ export async function getPaymentMonitoringData(): Promise<PaymentMonitoringData>
         status,
         monthly_price,
         updated_at,
-        cleaner:cleaners(
+        cleaner:pros(
           business_name
         )
       `)

--- a/lib/services/badges.ts
+++ b/lib/services/badges.ts
@@ -178,7 +178,7 @@ export async function updateCleanerResponseTime(
 
   if (avgResponseTime !== null) {
     await supabase
-      .from('cleaners')
+      .from('pros')
       .update({ response_time_hours: Math.round(avgResponseTime) })
       .eq('id', cleanerId);
   }

--- a/lib/services/quote-service.ts
+++ b/lib/services/quote-service.ts
@@ -110,7 +110,7 @@ export class QuoteService {
       .from('quote_requests')
       .select(`
         *,
-        cleaner:cleaners(business_name, business_phone, business_email, average_rating, hourly_rate)
+        cleaner:pros(business_name, business_phone, business_email, average_rating, hourly_rate)
       `)
       .eq('customer_id', customerId)
       .order('created_at', { ascending: false });
@@ -184,7 +184,7 @@ export class QuoteService {
       .select(`
         *,
         customer:users!customer_id(full_name, email, phone),
-        cleaner:cleaners(business_name, business_phone, business_email, average_rating)
+        cleaner:pros(business_name, business_phone, business_email, average_rating)
       `)
       .single();
 
@@ -210,7 +210,7 @@ export class QuoteService {
       .eq('customer_id', customerId)
       .select(`
         *,
-        cleaner:cleaners(business_name, business_phone, business_email)
+        cleaner:pros(business_name, business_phone, business_email)
       `)
       .single();
 
@@ -361,7 +361,7 @@ export class QuoteService {
       .select(`
         *,
         customer:users!customer_id(full_name, email, phone),
-        cleaner:cleaners(business_name, business_phone, business_email, average_rating, hourly_rate)
+        cleaner:pros(business_name, business_phone, business_email, average_rating, hourly_rate)
       `)
       .eq('id', quoteId)
       .single();

--- a/lib/services/search.ts
+++ b/lib/services/search.ts
@@ -188,7 +188,7 @@ export function buildSearchQuery(
   options: { offset: number; limit: number }
 ) {
   let query = supabase
-    .from('cleaners')
+    .from('pros')
     .select(
       `
       *,

--- a/lib/services/searchService.ts
+++ b/lib/services/searchService.ts
@@ -96,7 +96,7 @@ export class SearchService {
 
     // First, get the total count
     let countQuery = this.supabase
-      .from('cleaners')
+      .from('pros')
       .select('*', { count: 'exact', head: true })
       .eq('approval_status', 'approved');
 
@@ -131,7 +131,7 @@ export class SearchService {
 
     // Now get the actual data
     let query = this.supabase
-      .from('cleaners')
+      .from('pros')
       .select(`
         *,
         users!inner(full_name, phone, email, city, state, zip_code)
@@ -284,7 +284,7 @@ export class SearchService {
 
   async getCleanerById(id: string): Promise<Cleaner | null> {
     const { data, error } = await this.supabase
-      .from('cleaners')
+      .from('pros')
       .select(`
         *,
         users!inner(full_name, phone, email)
@@ -310,7 +310,7 @@ export class SearchService {
 
   async getFeaturedCleaners(limit: number = 6): Promise<Cleaner[]> {
     const { data, error } = await this.supabase
-      .from('cleaners')
+      .from('pros')
       .select(`
         *,
         users!inner(full_name, phone, email)
@@ -348,7 +348,7 @@ export class SearchService {
   // Get verified cleaners in a specific ZIP code (33801 - Lakeland, FL)
   async getVerifiedCleanersInZip33801(): Promise<Cleaner[]> {
     const { data, error } = await this.supabase
-      .from('cleaners')
+      .from('pros')
       .select(`
         *,
         users!inner(full_name, phone, email, city, zip_code),
@@ -374,7 +374,7 @@ export class SearchService {
   // Generic function to get verified cleaners in any ZIP code
   async getVerifiedCleanersInZipCode(zipCode: string): Promise<Cleaner[]> {
     const { data, error } = await this.supabase
-      .from('cleaners')
+      .from('pros')
       .select(`
         *,
         users!inner(full_name, phone, email, city, zip_code),

--- a/lib/stripe/disputes.ts
+++ b/lib/stripe/disputes.ts
@@ -70,7 +70,7 @@ export async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<voi
         : customerField.id;
 
       const { data: cleaner } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('id')
         .eq('stripe_customer_id', customerId)
         .single();
@@ -99,7 +99,7 @@ export async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<voi
 
   // Get cleaner details
   const { data: cleaner } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('business_name, user_id, dispute_count')
     .eq('id', cleanerId)
     .single();
@@ -142,7 +142,7 @@ export async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<voi
   // Flag the cleaner
   const newDisputeCount = (cleaner?.dispute_count || 0) + 1;
   await supabase
-    .from('cleaners')
+    .from('pros')
     .update({
       dispute_count: newDisputeCount,
       dispute_status: 'under_review',
@@ -213,13 +213,13 @@ export async function handleDisputeClosed(dispute: Stripe.Dispute): Promise<void
   const newDisputeStatus = (count && count > 0) ? 'under_review' : 'none';
 
   await supabase
-    .from('cleaners')
+    .from('pros')
     .update({ dispute_status: newDisputeStatus })
     .eq('id', disputeRecord.cleaner_id);
 
   // Get cleaner email for notification
   const { data: cleaner } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('business_name, user_id')
     .eq('id', disputeRecord.cleaner_id)
     .single();

--- a/lib/stripe/dunning.ts
+++ b/lib/stripe/dunning.ts
@@ -39,7 +39,7 @@ export async function processDunningEvent(
 
   // Get current cleaner state
   const { data: cleaner } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('payment_failed_count, business_name, grace_period_end, user_id, subscription_tier')
     .eq('id', cleanerId)
     .single();
@@ -76,7 +76,7 @@ export async function processDunningEvent(
     const gracePeriodEnd = new Date(now.getTime() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000);
 
     await supabase
-      .from('cleaners')
+      .from('pros')
       .update({
         grace_period_end: gracePeriodEnd.toISOString(),
       })
@@ -151,7 +151,7 @@ async function downgradeToFree(cleanerId: string): Promise<void> {
 
   // Update cleaner to free tier
   await supabase
-    .from('cleaners')
+    .from('pros')
     .update({
       subscription_tier: 'free',
       grace_period_end: null,
@@ -182,7 +182,7 @@ export async function getGracePeriodStatus(cleanerId: string): Promise<{
   const supabase = await createClient();
 
   const { data: cleaner } = await supabase
-    .from('cleaners')
+    .from('pros')
     .select('payment_failed_count, grace_period_end')
     .eq('id', cleanerId)
     .single();
@@ -218,7 +218,7 @@ export async function resetDunningState(cleanerId: string): Promise<void> {
   const supabase = await createClient();
 
   await supabase
-    .from('cleaners')
+    .from('pros')
     .update({
       payment_failed_count: 0,
       grace_period_end: null,

--- a/lib/stripe/subscription-service.ts
+++ b/lib/stripe/subscription-service.ts
@@ -68,7 +68,7 @@ export class SubscriptionService {
     // Check if cleaner already has a Stripe customer ID
     const supabase = await this.getSupabase();
     const { data: cleaner } = await supabase
-      .from('cleaners')
+      .from('pros')
       .select('stripe_customer_id, business_name')
       .eq('id', cleanerId)
       .single();
@@ -94,7 +94,7 @@ export class SubscriptionService {
 
     // Update cleaner with Stripe customer ID
     await supabase
-      .from('cleaners')
+      .from('pros')
       .update({ stripe_customer_id: customer.id })
       .eq('id', cleanerId);
 
@@ -137,7 +137,7 @@ export class SubscriptionService {
 
       // Update cleaner subscription info and billing dates
       await supabase
-        .from('cleaners')
+        .from('pros')
         .update({
           subscription_tier: tier,
           subscription_expires_at: periodEnd,
@@ -175,7 +175,7 @@ export class SubscriptionService {
 
       // Update cleaner subscription expiry and next billing date
       await supabase
-        .from('cleaners')
+        .from('pros')
         .update({
           subscription_expires_at: periodEnd,
           next_billing_date: periodEnd,
@@ -196,7 +196,7 @@ export class SubscriptionService {
       const supabase = await this.getSupabase();
       // Update cleaner to free tier and clear billing dates
       await supabase
-        .from('cleaners')
+        .from('pros')
         .update({
           subscription_tier: 'free',
           subscription_expires_at: null,
@@ -261,7 +261,7 @@ export class SubscriptionService {
 
         // Update last payment date, reset failed count, and reset monthly lead acceptance counter
         await supabase
-          .from('cleaners')
+          .from('pros')
           .update({
             last_payment_date: new Date().toISOString(),
             payment_failed_count: 0,
@@ -343,7 +343,7 @@ export class SubscriptionService {
     try {
       const supabase = await this.getSupabase();
       const { data: cleaner } = await supabase
-        .from('cleaners')
+        .from('pros')
         .select('stripe_subscription_id')
         .eq('id', cleanerId)
         .single();


### PR DESCRIPTION
Replaces all PostgREST table references to the legacy `cleaners` view with
the renamed `pros` base table (DLD-444). Includes embed syntax updates:
`cleaner:cleaners(...)` and FK-hinted variants
`cleaner:cleaners!conversations_cleaner_id_fkey(...)` swapped to
`cleaner:pros!...`. FK constraint names preserved on `bookings` and
`conversations` confirmed against live BOC Supabase schema.

Scope: literal table reference swap only. Variable rename (cleaner -> pro,
cleanerId -> proId) deferred to follow-up ticket; surface is broader than
DLD-461 description implied (320+ identifier occurrences vs 18 files).

Verification:
- TS error count: 55 (baseline 55, ticket said 56 - close match)
- next build: passes
- Zero remaining `from('cleaners')` or `cleaner:cleaners` in TS/JS
- Markdown specs (specs/, ralph/) left untouched (historical docs)

Co-Authored-By: Paperclip <noreply@paperclip.ing>
