### PR TITLE
feat(customer-dashboard): DLD-464 Phase D.1 (rebase) — standalone Profile + Help pages

### DIFF
--- a/app/dashboard/customer/help/page.tsx
+++ b/app/dashboard/customer/help/page.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+import { useState, useEffect, FormEvent } from 'react';
+import { useAuth } from '@/lib/context/AuthContext';
+import { ProtectedRoute } from '@/lib/auth/protected-route';
+import { createClient } from '@/lib/supabase/client';
+import {
+  HelpCircle, ChevronDown, Mail, MessageSquare, CheckCircle, XCircle,
+  Loader2, Phone, Send, Clock
+} from 'lucide-react';
+
+interface ContactSubmission {
+  id: string;
+  subject: string;
+  message: string;
+  created_at: string;
+  is_read?: boolean | null;
+}
+
+const customerFaqs = [
+  {
+    q: 'How do I find a cleaner?',
+    a: 'Go to the Search page, enter your ZIP code, and filter by service type. Each listing shows reviews, pricing, and Boss-Verified badges so you can choose with confidence.',
+  },
+  {
+    q: 'How does payment work?',
+    a: 'Payments are processed securely through Stripe. Your payment is held until the job is completed to your satisfaction. Saving a payment method is coming soon.',
+  },
+  {
+    q: 'What if I need to cancel a booking?',
+    a: 'Cancel at no charge if you do so at least 24 hours before the scheduled service. Cancellations within 24 hours may be subject to a fee at the professional’s discretion.',
+  },
+  {
+    q: 'How do I leave a review?',
+    a: 'After a job is marked completed, you will receive an email with a review link. You can also leave reviews from My Bookings in your dashboard.',
+  },
+  {
+    q: 'What does Boss-Verified mean?',
+    a: 'Boss-Verified professionals have passed a background check, have valid business insurance on file, and maintain a 4.5+ star rating. It is our highest trust badge.',
+  },
+  {
+    q: 'How do I earn account credits?',
+    a: 'Confirm a hire from an accepted quote and you will earn a $10 credit. Credits show under Credits on your Overview page and expire 90 days after issue.',
+  },
+];
+
+function FaqItem({ question, answer }: { question: string; answer: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between gap-4 p-4 text-left hover:bg-gray-50 transition-colors"
+      >
+        <span className="font-medium text-gray-900">{question}</span>
+        <ChevronDown
+          className={`h-5 w-5 text-gray-400 flex-shrink-0 transition-transform duration-200 ${
+            open ? 'rotate-180' : ''
+          }`}
+        />
+      </button>
+      {open && (
+        <div className="px-4 pb-4">
+          <p className="text-gray-600 leading-relaxed">{answer}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function CustomerHelpPage() {
+  const { user } = useAuth();
+  const supabase = createClient();
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [subject, setSubject] = useState('customer_support');
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitMsg, setSubmitMsg] = useState('');
+
+  const [history, setHistory] = useState<ContactSubmission[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(true);
+
+  useEffect(() => {
+    if (user) {
+      setEmail(user.email || '');
+      const metaName = (user.user_metadata?.full_name as string | undefined) || '';
+      if (metaName) setName(metaName);
+      loadHistory();
+    }
+  }, [user]);
+
+  const loadHistory = async () => {
+    setHistoryLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('contact_submissions')
+        .select('id, subject, message, created_at, is_read')
+        .eq('email', user?.email)
+        .order('created_at', { ascending: false })
+        .limit(10);
+
+      if (error) {
+        // Likely RLS blocks customer reads — render empty state, not an error.
+        setHistory([]);
+      } else {
+        setHistory((data || []) as ContactSubmission[]);
+      }
+    } catch {
+      setHistory([]);
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim() || !email.trim() || !message.trim()) {
+      setSubmitMsg('Error: Please fill out all required fields.');
+      setTimeout(() => setSubmitMsg(''), 4000);
+      return;
+    }
+
+    setSubmitting(true);
+    setSubmitMsg('');
+
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, subject, message }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to send message');
+      }
+
+      setSubmitMsg('Message sent! Our team will get back to you within 24 hours.');
+      setMessage('');
+      loadHistory();
+      setTimeout(() => setSubmitMsg(''), 6000);
+    } catch (err) {
+      setSubmitMsg(err instanceof Error ? `Error: ${err.message}` : 'Error sending message.');
+      setTimeout(() => setSubmitMsg(''), 6000);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const subjectLabels: Record<string, string> = {
+    general: 'General Inquiry',
+    customer_support: 'Customer Support',
+    list_business: 'List My Business',
+    partnership: 'Partnership',
+    other: 'Other',
+  };
+
+  const formatDate = (s: string) =>
+    new Date(s).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+  return (
+    <ProtectedRoute requireRole="customer">
+      <div className="min-h-screen bg-gray-50">
+        {/* Header */}
+        <div className="bg-white shadow-sm border-b">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center justify-between py-6">
+              <div className="flex items-center gap-3">
+                <HelpCircle className="h-6 w-6 text-blue-600" />
+                <h1 className="text-xl font-semibold text-gray-900">Help & Support</h1>
+              </div>
+              <a
+                href="tel:407-461-6039"
+                className="hidden sm:flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
+              >
+                <Phone className="h-4 w-4" />
+                407-461-6039
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+          {/* FAQ */}
+          <section className="bg-white border rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Frequently Asked Questions</h2>
+            <div className="space-y-3">
+              {customerFaqs.map((item) => (
+                <FaqItem key={item.q} question={item.q} answer={item.a} />
+              ))}
+            </div>
+          </section>
+
+          {/* Contact Form */}
+          <section className="bg-white border rounded-lg p-6">
+            <div className="flex items-center gap-2 mb-2">
+              <Mail className="h-5 w-5 text-blue-600" />
+              <h2 className="text-lg font-semibold text-gray-900">Contact Support</h2>
+            </div>
+            <p className="text-sm text-gray-600 mb-6">
+              Cannot find what you need? Send us a message and our team will respond within 24 hours.
+            </p>
+
+            {submitMsg && (
+              <div
+                className={`mb-4 p-3 rounded-md text-sm ${
+                  submitMsg.startsWith('Error')
+                    ? 'bg-red-50 text-red-700 border border-red-200'
+                    : 'bg-green-50 text-green-700 border border-green-200'
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  {submitMsg.startsWith('Error') ? (
+                    <XCircle className="h-4 w-4" />
+                  ) : (
+                    <CheckCircle className="h-4 w-4" />
+                  )}
+                  {submitMsg}
+                </div>
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="help-name">
+                    Name <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    id="help-name"
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    required
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="Your name"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="help-email">
+                    Email <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    id="help-email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="you@example.com"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="help-subject">
+                  Topic
+                </label>
+                <select
+                  id="help-subject"
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                >
+                  <option value="customer_support">Customer Support</option>
+                  <option value="general">General Inquiry</option>
+                  <option value="partnership">Partnership</option>
+                  <option value="other">Other</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="help-message">
+                  Message <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  id="help-message"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  required
+                  rows={5}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Tell us how we can help..."
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={submitting}
+                className="bg-blue-600 text-white px-5 py-2.5 rounded-md hover:bg-blue-700 disabled:bg-blue-400 transition duration-300 flex items-center gap-2 font-medium"
+              >
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                {submitting ? 'Sending...' : 'Send Message'}
+              </button>
+            </form>
+          </section>
+
+          {/* Recent Tickets */}
+          <section className="bg-white border rounded-lg p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <MessageSquare className="h-5 w-5 text-blue-600" />
+              <h2 className="text-lg font-semibold text-gray-900">Recent Messages</h2>
+            </div>
+
+            {historyLoading ? (
+              <div className="text-center py-6 text-gray-500 text-sm">
+                <Loader2 className="h-5 w-5 animate-spin mx-auto mb-2" />
+                Loading...
+              </div>
+            ) : history.length === 0 ? (
+              <div className="text-center py-8">
+                <MessageSquare className="h-10 w-10 text-gray-300 mx-auto mb-3" />
+                <p className="text-sm text-gray-500">
+                  You have not contacted support yet. Use the form above to reach out.
+                </p>
+              </div>
+            ) : (
+              <ul className="divide-y divide-gray-200">
+                {history.map((t) => (
+                  <li key={t.id} className="py-4">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="text-sm font-medium text-gray-900">
+                            {subjectLabels[t.subject] || t.subject}
+                          </span>
+                          {t.is_read ? (
+                            <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">
+                              Reviewed
+                            </span>
+                          ) : (
+                            <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-50 text-yellow-700">
+                              Pending
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm text-gray-600 line-clamp-2 whitespace-pre-wrap">
+                          {t.message}
+                        </p>
+                      </div>
+                      <div className="text-xs text-gray-500 flex items-center gap-1 flex-shrink-0">
+                        <Clock className="h-3 w-3" />
+                        {formatDate(t.created_at)}
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/app/dashboard/customer/layout.tsx
+++ b/app/dashboard/customer/layout.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import { DashboardSidebar, type SidebarLink } from '@/components/dashboard/DashboardSidebar';
-import { LayoutDashboard, Calendar, Heart, MessageSquare, Bell } from 'lucide-react';
+import { LayoutDashboard, User, Calendar, Heart, MessageSquare, Bell, HelpCircle } from 'lucide-react';
 
 const customerLinks: SidebarLink[] = [
   { href: '/dashboard/customer', label: 'Overview', icon: LayoutDashboard },
+  { href: '/dashboard/customer/profile', label: 'Profile', icon: User },
   { href: '/dashboard/customer/bookings', label: 'My Bookings', icon: Calendar },
   { href: '/dashboard/customer/favorites', label: 'Favorites', icon: Heart },
   { href: '/dashboard/messages', label: 'Messages', icon: MessageSquare },
   { href: '/dashboard/customer/notifications', label: 'Notifications', icon: Bell },
+  { href: '/dashboard/customer/help', label: 'Help', icon: HelpCircle },
 ];
 
 export default function CustomerDashboardLayout({ children }: { children: React.ReactNode }) {

--- a/app/dashboard/customer/page.tsx
+++ b/app/dashboard/customer/page.tsx
@@ -5,9 +5,9 @@ import { useAuth } from '@/lib/context/AuthContext';
 import { ProtectedRoute } from '@/lib/auth/protected-route';
 import { createClient } from '@/lib/supabase/client';
 import {
-  User, Settings, FileText, Clock, CheckCircle,
+  Settings, FileText, Clock, CheckCircle,
   XCircle, AlertCircle, Calendar, MapPin, DollarSign,
-  MessageSquare, Star, Home, Phone, Mail, Save, Bell,
+  MessageSquare, Star, Home,
   Gift, ThumbsUp, Loader2
 } from 'lucide-react';
 import Link from 'next/link';
@@ -32,16 +32,6 @@ interface QuoteRequest {
   } | null;
 }
 
-interface CustomerProfile {
-  id: string;
-  full_name: string;
-  phone: string;
-  address?: string;
-  city?: string;
-  zip_code?: string;
-  email: string;
-}
-
 interface CustomerCredit {
   id: string;
   amount_cents: number;
@@ -55,24 +45,21 @@ interface CustomerCredit {
 export default function CustomerDashboard() {
   const { user } = useAuth();
   const [quotes, setQuotes] = useState<QuoteRequest[]>([]);
-  const [profile, setProfile] = useState<CustomerProfile | null>(null);
   const [credits, setCredits] = useState<CustomerCredit[]>([]);
   const [confirmedQuotes, setConfirmedQuotes] = useState<Set<string>>(new Set());
   const [confirmingHire, setConfirmingHire] = useState<string | null>(null);
   const [acceptingQuote, setAcceptingQuote] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [activeTab, setActiveTab] = useState('quotes');
-  const [editingProfile, setEditingProfile] = useState(false);
   const [message, setMessage] = useState('');
   const supabase = createClient();
 
   useEffect(() => {
     if (user) {
       loadQuotes();
-      loadProfile();
       // DLD-460: loadCredits() disabled until loyalty/referral program ships.
       // loadCredits();
+      // DLD-464: loadProfile() moved to /dashboard/customer/profile standalone page.
       loadHireConfirmations();
     }
   }, [user]);
@@ -98,71 +85,6 @@ export default function CustomerDashboard() {
     } finally {
       setLoading(false);
     }
-  };
-
-  const loadProfile = async () => {
-    try {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, full_name, phone, address, city, zip_code, email')
-        .eq('id', user?.id)
-        .single();
-
-      if (error && error.code !== 'PGRST116') throw error;
-      
-      if (data) {
-        setProfile(data);
-      } else {
-        // Create default profile if none exists
-        const defaultProfile = {
-          id: user?.id || '',
-          full_name: '',
-          phone: '',
-          address: '',
-          city: '',
-          zip_code: '',
-          email: user?.email || ''
-        };
-        setProfile(defaultProfile);
-      }
-    } catch (error) {
-      // Error loading profile - silently fail for client component
-    }
-  };
-
-  const handleProfileSave = async () => {
-    if (!profile) return;
-    
-    setSaving(true);
-    try {
-      const { error } = await supabase
-        .from('users')
-        .update({
-          full_name: profile.full_name,
-          phone: profile.phone,
-          address: profile.address,
-          city: profile.city,
-          zip_code: profile.zip_code,
-          updated_at: new Date().toISOString()
-        })
-        .eq('id', user?.id);
-
-      if (error) throw error;
-      
-      setMessage('Profile updated successfully!');
-      setEditingProfile(false);
-      setTimeout(() => setMessage(''), 3000);
-    } catch (error) {
-      // Error saving profile - display error message to user
-      setMessage('Error saving profile');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleProfileChange = (field: keyof CustomerProfile, value: string) => {
-    if (!profile) return;
-    setProfile({ ...profile, [field]: value });
   };
 
   const loadCredits = async () => {
@@ -463,16 +385,6 @@ export default function CustomerDashboard() {
                     My Credits
                   </button>
                 )}
-                <button
-                  onClick={() => setActiveTab('profile')}
-                  className={`px-6 py-3 font-medium border-b-2 transition duration-300 ${
-                    activeTab === 'profile'
-                      ? 'border-blue-600 text-blue-600'
-                      : 'border-transparent text-gray-600 hover:text-gray-900'
-                  }`}
-                >
-                  My Profile
-                </button>
               </nav>
             </div>
 
@@ -682,200 +594,6 @@ export default function CustomerDashboard() {
                 </div>
               )}
 
-              {activeTab === 'profile' && (
-                <div className="max-w-4xl">
-                  {message && (
-                    <div className={`mb-6 p-4 rounded-md ${
-                      message.includes('Error') 
-                        ? 'bg-red-50 text-red-700 border border-red-200'
-                        : 'bg-green-50 text-green-700 border border-green-200'
-                    }`}>
-                      <div className="flex items-center gap-2">
-                        {message.includes('Error') ? (
-                          <XCircle className="h-5 w-5" />
-                        ) : (
-                          <CheckCircle className="h-5 w-5" />
-                        )}
-                        {message}
-                      </div>
-                    </div>
-                  )}
-
-                  <div className="flex justify-between items-center mb-6">
-                    <h3 className="text-lg font-semibold text-gray-900">Profile Information</h3>
-                    <div className="flex gap-2">
-                      {editingProfile ? (
-                        <>
-                          <button
-                            onClick={() => setEditingProfile(false)}
-                            className="px-4 py-2 text-gray-600 hover:text-gray-800 font-medium"
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            onClick={handleProfileSave}
-                            disabled={saving}
-                            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-blue-400 transition duration-300 flex items-center gap-2"
-                          >
-                            <Save className="h-4 w-4" />
-                            {saving ? 'Saving...' : 'Save Changes'}
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          onClick={() => setEditingProfile(true)}
-                          className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition duration-300"
-                        >
-                          Edit Profile
-                        </button>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="bg-white border rounded-lg p-6">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                      {/* Personal Information */}
-                      <div>
-                        <h4 className="text-md font-semibold text-gray-900 mb-4 flex items-center gap-2">
-                          <User className="h-5 w-5" />
-                          Personal Information
-                        </h4>
-                        
-                        <div className="space-y-4">
-                          <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
-                              Full Name
-                            </label>
-                            {editingProfile ? (
-                              <input
-                                type="text"
-                                value={profile?.full_name || ''}
-                                onChange={(e) => handleProfileChange('full_name', e.target.value)}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                placeholder="Enter your full name"
-                              />
-                            ) : (
-                              <p className="text-gray-900">{profile?.full_name || 'Not provided'}</p>
-                            )}
-                          </div>
-
-                          <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
-                              Email Address
-                            </label>
-                            <p className="text-gray-900">{profile?.email}</p>
-                            <p className="text-xs text-gray-500 mt-1">
-                              Contact support to change your email address
-                            </p>
-                          </div>
-
-                          <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
-                              Phone Number
-                            </label>
-                            {editingProfile ? (
-                              <input
-                                type="tel"
-                                value={profile?.phone || ''}
-                                onChange={(e) => handleProfileChange('phone', e.target.value)}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                placeholder="(555) 123-4567"
-                              />
-                            ) : (
-                              <p className="text-gray-900">{profile?.phone || 'Not provided'}</p>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Address Information */}
-                      <div>
-                        <h4 className="text-md font-semibold text-gray-900 mb-4 flex items-center gap-2">
-                          <MapPin className="h-5 w-5" />
-                          Address Information
-                        </h4>
-                        
-                        <div className="space-y-4">
-                          <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
-                              Street Address
-                            </label>
-                            {editingProfile ? (
-                              <input
-                                type="text"
-                                value={profile?.address || ''}
-                                onChange={(e) => handleProfileChange('address', e.target.value)}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                placeholder="123 Main Street"
-                              />
-                            ) : (
-                              <p className="text-gray-900">{profile?.address || 'Not provided'}</p>
-                            )}
-                          </div>
-
-                          <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
-                              City
-                            </label>
-                            {editingProfile ? (
-                              <input
-                                type="text"
-                                value={profile?.city || ''}
-                                onChange={(e) => handleProfileChange('city', e.target.value)}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                placeholder="Orlando"
-                              />
-                            ) : (
-                              <p className="text-gray-900">{profile?.city || 'Not provided'}</p>
-                            )}
-                          </div>
-
-                          <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
-                              ZIP Code
-                            </label>
-                            {editingProfile ? (
-                              <input
-                                type="text"
-                                value={profile?.zip_code || ''}
-                                onChange={(e) => handleProfileChange('zip_code', e.target.value)}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                placeholder="32801"
-                              />
-                            ) : (
-                              <p className="text-gray-900">{profile?.zip_code || 'Not provided'}</p>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Additional Options */}
-                    <div className="mt-8 pt-6 border-t border-gray-200">
-                      <h4 className="text-md font-semibold text-gray-900 mb-4">Account Settings</h4>
-                      <div className="space-y-3">
-                        <Link
-                          href="/dashboard/customer/notifications"
-                          className="text-blue-600 hover:text-blue-700 font-medium flex items-center gap-2"
-                        >
-                          <Bell className="h-4 w-4" />
-                          Notification Preferences
-                        </Link>
-                        <Link
-                          href="/forgot-password"
-                          className="text-blue-600 hover:text-blue-700 font-medium flex items-center gap-2"
-                        >
-                          <Settings className="h-4 w-4" />
-                          Change Password
-                        </Link>
-                        <div className="text-gray-600 text-sm">
-                          Last updated: {profile ? new Date().toLocaleDateString() : 'Never'}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
             </div>
           </div>
         </div>

--- a/app/dashboard/customer/profile/page.tsx
+++ b/app/dashboard/customer/profile/page.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/lib/context/AuthContext';
+import { ProtectedRoute } from '@/lib/auth/protected-route';
+import { createClient } from '@/lib/supabase/client';
+import {
+  User, MapPin, Save, Bell, Settings, CheckCircle, XCircle, Loader2
+} from 'lucide-react';
+import Link from 'next/link';
+
+interface CustomerProfile {
+  id: string;
+  full_name: string;
+  phone: string;
+  address?: string;
+  city?: string;
+  zip_code?: string;
+  email: string;
+}
+
+export default function CustomerProfilePage() {
+  const { user } = useAuth();
+  const [profile, setProfile] = useState<CustomerProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [message, setMessage] = useState('');
+  const supabase = createClient();
+
+  useEffect(() => {
+    if (user) {
+      loadProfile();
+    }
+  }, [user]);
+
+  const loadProfile = async () => {
+    setLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('id, full_name, phone, address, city, zip_code, email')
+        .eq('id', user?.id)
+        .single();
+
+      if (error && error.code !== 'PGRST116') throw error;
+
+      if (data) {
+        setProfile(data);
+      } else {
+        setProfile({
+          id: user?.id || '',
+          full_name: '',
+          phone: '',
+          address: '',
+          city: '',
+          zip_code: '',
+          email: user?.email || '',
+        });
+      }
+    } catch {
+      // silently fail for client component
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleProfileSave = async () => {
+    if (!profile) return;
+
+    setSaving(true);
+    try {
+      const { error } = await supabase
+        .from('users')
+        .update({
+          full_name: profile.full_name,
+          phone: profile.phone,
+          address: profile.address,
+          city: profile.city,
+          zip_code: profile.zip_code,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', user?.id);
+
+      if (error) throw error;
+
+      setMessage('Profile updated successfully!');
+      setEditingProfile(false);
+      setTimeout(() => setMessage(''), 3000);
+    } catch {
+      setMessage('Error saving profile');
+      setTimeout(() => setMessage(''), 3000);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleProfileChange = (field: keyof CustomerProfile, value: string) => {
+    if (!profile) return;
+    setProfile({ ...profile, [field]: value });
+  };
+
+  return (
+    <ProtectedRoute requireRole="customer">
+      <div className="min-h-screen bg-gray-50">
+        {/* Header */}
+        <div className="bg-white shadow-sm border-b">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center justify-between py-6">
+              <div className="flex items-center gap-3">
+                <User className="h-6 w-6 text-blue-600" />
+                <h1 className="text-xl font-semibold text-gray-900">My Profile</h1>
+              </div>
+              <div className="flex gap-2">
+                {editingProfile ? (
+                  <>
+                    <button
+                      onClick={() => {
+                        setEditingProfile(false);
+                        loadProfile();
+                      }}
+                      className="px-4 py-2 text-gray-600 hover:text-gray-800 font-medium"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleProfileSave}
+                      disabled={saving}
+                      className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-blue-400 transition duration-300 flex items-center gap-2"
+                    >
+                      {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                      {saving ? 'Saving...' : 'Save Changes'}
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    onClick={() => setEditingProfile(true)}
+                    disabled={loading || !profile}
+                    className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-blue-400 transition duration-300"
+                  >
+                    Edit Profile
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          {message && (
+            <div
+              className={`mb-6 p-4 rounded-md ${
+                message.includes('Error')
+                  ? 'bg-red-50 text-red-700 border border-red-200'
+                  : 'bg-green-50 text-green-700 border border-green-200'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                {message.includes('Error') ? (
+                  <XCircle className="h-5 w-5" />
+                ) : (
+                  <CheckCircle className="h-5 w-5" />
+                )}
+                {message}
+              </div>
+            </div>
+          )}
+
+          {loading ? (
+            <div className="bg-white border rounded-lg p-12 text-center">
+              <Loader2 className="h-8 w-8 animate-spin text-blue-600 mx-auto mb-3" />
+              <p className="text-gray-600">Loading profile...</p>
+            </div>
+          ) : (
+            <div className="bg-white border rounded-lg p-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {/* Personal Information */}
+                <div>
+                  <h4 className="text-md font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                    <User className="h-5 w-5" />
+                    Personal Information
+                  </h4>
+
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Full Name
+                      </label>
+                      {editingProfile ? (
+                        <input
+                          type="text"
+                          value={profile?.full_name || ''}
+                          onChange={(e) => handleProfileChange('full_name', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          placeholder="Enter your full name"
+                        />
+                      ) : (
+                        <p className="text-gray-900">{profile?.full_name || 'Not provided'}</p>
+                      )}
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Email Address
+                      </label>
+                      <p className="text-gray-900">{profile?.email}</p>
+                      <p className="text-xs text-gray-500 mt-1">
+                        Contact support to change your email address
+                      </p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Phone Number
+                      </label>
+                      {editingProfile ? (
+                        <input
+                          type="tel"
+                          value={profile?.phone || ''}
+                          onChange={(e) => handleProfileChange('phone', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          placeholder="(555) 123-4567"
+                        />
+                      ) : (
+                        <p className="text-gray-900">{profile?.phone || 'Not provided'}</p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Address Information */}
+                <div>
+                  <h4 className="text-md font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                    <MapPin className="h-5 w-5" />
+                    Address Information
+                  </h4>
+
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Street Address
+                      </label>
+                      {editingProfile ? (
+                        <input
+                          type="text"
+                          value={profile?.address || ''}
+                          onChange={(e) => handleProfileChange('address', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          placeholder="123 Main Street"
+                        />
+                      ) : (
+                        <p className="text-gray-900">{profile?.address || 'Not provided'}</p>
+                      )}
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        City
+                      </label>
+                      {editingProfile ? (
+                        <input
+                          type="text"
+                          value={profile?.city || ''}
+                          onChange={(e) => handleProfileChange('city', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          placeholder="Orlando"
+                        />
+                      ) : (
+                        <p className="text-gray-900">{profile?.city || 'Not provided'}</p>
+                      )}
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        ZIP Code
+                      </label>
+                      {editingProfile ? (
+                        <input
+                          type="text"
+                          value={profile?.zip_code || ''}
+                          onChange={(e) => handleProfileChange('zip_code', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          placeholder="32801"
+                        />
+                      ) : (
+                        <p className="text-gray-900">{profile?.zip_code || 'Not provided'}</p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Account Settings */}
+              <div className="mt-8 pt-6 border-t border-gray-200">
+                <h4 className="text-md font-semibold text-gray-900 mb-4">Account Settings</h4>
+                <div className="space-y-3">
+                  <Link
+                    href="/dashboard/customer/notifications"
+                    className="text-blue-600 hover:text-blue-700 font-medium flex items-center gap-2"
+                  >
+                    <Bell className="h-4 w-4" />
+                    Notification Preferences
+                  </Link>
+                  <Link
+                    href="/forgot-password"
+                    className="text-blue-600 hover:text-blue-700 font-medium flex items-center gap-2"
+                  >
+                    <Settings className="h-4 w-4" />
+                    Change Password
+                  </Link>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </ProtectedRoute>
+  );
+}


### PR DESCRIPTION
## Summary

Rebase of the original [PR #20](https://github.com/Danielson72/Boss-of_clean-2/pull/20) (which was closed due to a 3-way merge conflict in `customer/page.tsx` after PRs #19/#21/#23 landed in between branch-cut and merge-attempt).

Re-applies the original scope on top of current `main` with all three intervening merges preserved.

## Files (same 4 as the original commit)

| File | State | Delta |
|---|---|---|
| `app/dashboard/customer/help/page.tsx` | **NEW** | 361 LOC — FAQ + contact form (posts to existing `/api/contact`) + recent submission history |
| `app/dashboard/customer/profile/page.tsx` | **NEW** | 319 LOC — standalone Profile editor extracted from inline Overview tab |
| `app/dashboard/customer/layout.tsx` | modified | sidebar gains Profile + Help links (7 items, AC required ≥ 6) |
| `app/dashboard/customer/page.tsx` | modified | removes Profile tab + orphan state/handlers/imports |

## What was preserved from the 3 intervening PRs

- **DLD-456 / PR #23** — "Find Cleaners" → "Find Pros" wording (verified in remaining empty-state copy)
- **DLD-460 / PR #21** — Credits tab is still wrapped in `{false && (...)}`; the commented-out `loadCredits()` in `useEffect` is preserved
- **DLD-463 / PR #19** — favorites-side changes untouched (not in any of my 4 files)

The original branch's `loadProfile()` call in `useEffect` was **removed** (replaced with a comment) since Profile now loads on its own page.

## Verification

- `tsc --noEmit`: **53 errors total**, all pre-existing in `main` (matches post-PR-23 baseline). None in the 4 touched files. The original commit's "TS baseline 55" → "53" reflects errors that other PRs cleared, not anything I added.
- `next build`: **✅ 89 pages generated, no errors**. Both new routes register cleanly:
  - `/dashboard/customer/profile` → 5.28 kB
  - `/dashboard/customer/help` → 6.6 kB
- Compiled-with-warnings is the known Supabase realtime-js dependency-tracing warning, not my code.

## Per governance

Phase C — no auto-merge. Board reviews.

Linked: [DLD-464](/PAP/issues/DLD-464); Phase D.2 follow-ups already exist as [DLD-465](/PAP/issues/DLD-465) (Payment Methods, Stripe-on-hold) and [DLD-466](/PAP/issues/DLD-466) (Past Projects gallery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)