### PR TITLE
fix(DLD-501): remove is_certified column from pro profile SELECT

### DIFF
--- a/app/cleaner/[slug]/page.tsx
+++ b/app/cleaner/[slug]/page.tsx
@@ -35,7 +35,7 @@ interface CleanerProfile {
   insurance_verified: boolean;
   license_verified: boolean;
   background_check: boolean;
-  is_certified: boolean;
+  is_certified?: boolean;
   instant_booking: boolean;
   subscription_tier: string;
   profile_image_url: string;
@@ -85,7 +85,6 @@ const PUBLIC_PROFILE_COLUMNS = `
   insurance_verified,
   license_verified,
   background_check,
-  is_certified,
   instant_booking,
   subscription_tier,
   profile_image_url,


### PR DESCRIPTION
## 🚨 CRITICAL FIX — All pro profile pages were 404'ing

`app/cleaner/[slug]/page.tsx` line 88 referenced `is_certified` in the SELECT — a column that **does not exist** on the `pros` table. Every customer who clicked a pro from search got a 404 instead of the profile.

## Root cause confirmed via direct SQL
```sql
SELECT is_certified FROM pros WHERE business_slug = 'magic-clean';
-- ERROR: 42703: column "is_certified" does not exist
```

## Fix
- Remove `is_certified,` from `PUBLIC_PROFILE_COLUMNS` SELECT list
- Mark `is_certified` optional (`?`) in CleanerProfile interface
- Existing JSX guards `{cleaner.is_certified && (...)}` will silently render nothing (correct — we don't have certification yet)

## Verification
- **TS baseline: 55 errors before → 55 after** (zero new errors)
- Magic Clean DB record verified: `business_slug = 'magic-clean'`, `approval_status = 'approved'`
- After deploy, `https://bossofclean.com/cleaner/magic-clean` should return Magic Clean's actual profile

## Diff
1 file, +1 -2 lines

Resolves DLD-501.