### PR TITLE
fix(DLD-502): CRITICAL — customer dashboard Overview null-safe formatters + types

### DIFF
--- a/app/dashboard/customer/page.tsx
+++ b/app/dashboard/customer/page.tsx
@@ -14,21 +14,25 @@ import Link from 'next/link';
 
 interface QuoteRequest {
   id: string;
-  cleaner_id: string;
+  cleaner_id: string | null;
   service_type: string;
-  service_date: string;
-  service_time: string;
+  // DLD-502: service_date/service_time/status are nullable in the DB.
+  // Pending marketplace quotes have no claimed pro and no scheduled time
+  // until a pro responds. The previous non-null types caused runtime
+  // crashes in formatTime/formatDate.
+  service_date: string | null;
+  service_time: string | null;
   address: string;
   city: string;
   zip_code: string;
-  description: string;
-  status: 'pending' | 'responded' | 'accepted' | 'completed' | 'cancelled';
-  quoted_price?: number;
-  response_message?: string;
+  description: string | null;
+  status: 'pending' | 'responded' | 'accepted' | 'completed' | 'cancelled' | null;
+  quoted_price?: number | null;
+  response_message?: string | null;
   created_at: string;
   cleaner: {
     business_name: string;
-    business_phone: string;
+    business_phone: string | null;
   } | null;
 }
 
@@ -197,7 +201,7 @@ export default function CustomerDashboard() {
     .filter(c => !c.redeemed && new Date(c.expires_at) > new Date())
     .reduce((sum, c) => sum + c.amount_cents, 0);
 
-  const getStatusColor = (status: string) => {
+  const getStatusColor = (status: string | null | undefined) => {
     switch (status) {
       case 'pending': return 'text-yellow-600 bg-yellow-100';
       case 'responded': return 'text-blue-600 bg-blue-100';
@@ -208,7 +212,7 @@ export default function CustomerDashboard() {
     }
   };
 
-  const getStatusIcon = (status: string) => {
+  const getStatusIcon = (status: string | null | undefined) => {
     switch (status) {
       case 'pending': return <Clock className="h-5 w-5" />;
       case 'responded': return <MessageSquare className="h-5 w-5" />;
@@ -219,7 +223,18 @@ export default function CustomerDashboard() {
     }
   };
 
-  const formatDate = (dateString: string) => {
+  // DLD-502: quote_requests.status is nullable. Default to 'Pending' for
+  // legacy rows without a status. Prevents .charAt() crash on the badge.
+  const formatStatusLabel = (status: string | null | undefined) => {
+    if (!status) return 'Pending';
+    return status.charAt(0).toUpperCase() + status.slice(1);
+  };
+
+  const formatDate = (dateString: string | null | undefined) => {
+    // DLD-502: quote_requests.service_date is nullable for pending marketplace
+    // quotes (pro hasn't responded with a date yet). new Date(null) yields
+    // "Invalid Date" not a crash, but guard explicitly for clarity.
+    if (!dateString) return 'TBD';
     return new Date(dateString).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
@@ -227,7 +242,11 @@ export default function CustomerDashboard() {
     });
   };
 
-  const formatTime = (timeString: string) => {
+  const formatTime = (timeString: string | null | undefined) => {
+    // DLD-502: quote_requests.service_time is nullable for pending marketplace
+    // quotes. The previous unguarded `.split(':')` threw on null and crashed
+    // the entire Overview render, taking out the dashboard.
+    if (!timeString) return 'TBD';
     const [hours, minutes] = timeString.split(':');
     const hour = parseInt(hours);
     const ampm = hour >= 12 ? 'PM' : 'AM';
@@ -305,7 +324,7 @@ export default function CustomerDashboard() {
                 <div>
                   <p className="text-sm text-gray-600">Active</p>
                   <p className="text-2xl font-bold text-green-600">
-                    {quotes.filter(q => ['responded', 'accepted'].includes(q.status)).length}
+                    {quotes.filter(q => q.status === 'responded' || q.status === 'accepted').length}
                   </p>
                 </div>
                 <CheckCircle className="h-8 w-8 text-green-600" />
@@ -423,7 +442,7 @@ export default function CustomerDashboard() {
                                 </h3>
                                 <span className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm ${getStatusColor(quote.status)}`}>
                                   {getStatusIcon(quote.status)}
-                                  {quote.status.charAt(0).toUpperCase() + quote.status.slice(1)}
+                                  {formatStatusLabel(quote.status)}
                                 </span>
                               </div>
                               
@@ -489,9 +508,9 @@ export default function CustomerDashboard() {
                                     <p className="font-medium">Contact:</p>
                                     <p>{quote.cleaner?.business_phone || 'N/A'}</p>
                                   </div>
-                                  {!confirmedQuotes.has(quote.id) ? (
+                                  {!confirmedQuotes.has(quote.id) && quote.cleaner_id ? (
                                     <button
-                                      onClick={() => handleConfirmHire(quote.id, quote.cleaner_id)}
+                                      onClick={() => handleConfirmHire(quote.id, quote.cleaner_id!)}
                                       disabled={confirmingHire === quote.id}
                                       className="flex items-center gap-1 bg-emerald-600 text-white px-3 py-1.5 rounded-md hover:bg-emerald-700 disabled:bg-emerald-400 transition duration-300 text-xs font-medium"
                                     >


### PR DESCRIPTION
## Summary

Critical launch-blocker. Customer dashboard Overview tab threw an unhandled error for **every customer with a pending marketplace quote**, locking them out of the dashboard entirely. The error.tsx fallback's "Back" and "Try Again" buttons both navigate to the same broken page, so the only escape was a code fix.

## Root cause (NOT what the ticket hypothesized)

The ticket's Suspect #1 (FK auto-resolution failure on the `cleaner:pros(...)` embed after [DLD-461](/PAP/issues/DLD-461)) was a red herring. Verified via `information_schema` and live SQL:

- `quote_requests_cleaner_id_fkey` → `pros(id)` is intact, single FK
- PostgREST embed `cleaner:pros(business_name, business_phone)` resolves cleanly
- Test customer's quotes have non-null `cleaner_id` references that resolve

The **actual** root cause: `quote_requests.service_time`, `service_date`, and `status` are nullable in the schema (pending marketplace quotes are created before any pro responds with a scheduled time). The customer page declared these as non-null `string` and called:

- `formatTime(timeString)` → `timeString.split(':')` — **crashes on null with TypeError**
- `formatDate(dateString)` → `new Date(dateString)` — yields "Invalid Date"
- `quote.status.charAt(0)...` inline in JSX — **crashes on null**

Confirmed against the live BOC2 DB: customer `7af0b0cd-c530-4ea4-9903-056b893e9f26` has 2 pending quotes with `service_time = null` — exactly the crash condition.

## Fix (one file, 35+/16- lines)

- `formatTime(string | null | undefined)` → returns `'TBD'` for null
- `formatDate(string | null | undefined)` → returns `'TBD'` for null
- New `formatStatusLabel(status | null)` helper, defaults to `'Pending'` for null. Replaces the unsafe inline `quote.status.charAt(0)...`
- `QuoteRequest` interface updated to reflect actual DB nullability: `service_date`, `service_time`, `status`, `description`, `quoted_price`, `response_message`, `cleaner.business_phone`, and `cleaner_id` all marked nullable
- Confirm Hire button gated on `quote.cleaner_id` being non-null (can't hire-confirm a pro that hasn't claimed yet)

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | **53 errors**, all pre-existing on main. Zero new errors. |
| `next build` | ✅ 89 pages generated |
| `cleaner:pros(...)` embed | Verified working (live SQL test against the FK) |
| Test-customer repro condition | Confirmed via SQL: 2 pending quotes with null `service_time` |

## What this does NOT change

- No embed query syntax changes (it was never the bug)
- No DB schema changes
- `error.tsx` boundary unchanged — its "Back" + "Try Again" buttons become functional automatically once the underlying crash no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)