### PR TITLE
fix(DLD-504): remove lead count promises from pricing copy (legal risk)

### DIFF
--- a/app/pricing/layout.tsx
+++ b/app/pricing/layout.tsx
@@ -2,7 +2,7 @@ import { generatePageMetadata } from '@/lib/seo/metadata';
 
 export const metadata = generatePageMetadata({
   title: 'Pricing Plans for Home Service Pros',
-  description: 'Boss of Clean is the marketplace for home service pros — cleaning, handyman, HVAC, plumbing, electrical, pest control, landscaping, pool, mobile detailing, and pressure washing. Free pay-per-lead, Basic $79/mo (up to 10 leads covered), Pro $199/mo (up to 20 leads covered). Founders Offer for the first 100 Pros.',
+  description: 'Boss of Clean is the marketplace for home service pros — cleaning, handyman, HVAC, plumbing, electrical, pest control, landscaping, pool, mobile detailing, and pressure washing. Free pay-per-lead, Basic $79/mo for priority routing, Pro $199/mo for top placement. Founders Offer for the first 100 Pros.',
   path: '/pricing',
   keywords: [
     'home services marketplace pricing',

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -69,8 +69,7 @@ const plans: Plan[] = [
     description: 'Steady lead flow without the heavy commit',
     features: [
       'Everything in Free',
-      'Up to 10 leads covered per month',
-      'Overflow leads $20/lead (only when you exceed 10)',
+      'Priority lead routing — you see qualified leads first',
       'Featured placement in category and city search',
       'Priority in customer notifications',
       'Verified pro badge and profile highlights',
@@ -88,8 +87,6 @@ const plans: Plan[] = [
     description: 'Best for established pros that want volume',
     features: [
       'Everything in Basic',
-      'Up to 20 leads covered per month',
-      'Overflow leads $15/lead (only when you exceed 20)',
       'Top placement in search results',
       'Featured on homepage and category hubs',
       'Priority support',
@@ -104,8 +101,8 @@ const plans: Plan[] = [
 
 const faqs = [
   {
-    question: 'What does "up to X leads covered" mean?',
-    answer: 'Your monthly subscription covers up to that number of qualified, exclusive leads sent to you — at no extra cost. Once you exceed the covered amount, overflow leads are billed at the per-lead overflow rate listed in your plan. We say "covered" instead of "included" so there is never any confusion about how lead routing actually works.',
+    question: 'How does lead routing work on Boss of Clean?',
+    answer: 'When a homeowner submits a request, qualified pros in the matching service area receive a notification and can accept the lead. Paid plans place you higher in the routing order, so you see qualified leads first. Lead volume depends on marketplace demand and your service area — we do not guarantee a specific number of leads per month.',
   },
   {
     question: 'Is Boss of Clean only for cleaning companies?',
@@ -121,7 +118,7 @@ const faqs = [
   },
   {
     question: 'How is this different from Thumbtack, Angi, or HomeAdvisor?',
-    answer: 'Every lead on Boss of Clean is exclusive to a single pro — never shared, never resold. Lead caps are transparent, overflow pricing is published up front, and we use plain "up to X leads covered" language so you always know what you are paying for.',
+    answer: 'Every lead on Boss of Clean is exclusive to a single pro — never shared, never resold. Your pricing is transparent and locked in at signup, with no hidden upcharges or bidding wars.',
   },
   {
     question: 'How do I get started?',
@@ -277,10 +274,10 @@ export default async function PricingPage() {
                 <div className="flex items-start gap-3">
                   <Sparkles className="h-5 w-5 text-brand-gold flex-shrink-0 mt-0.5" />
                   <div>
-                    <p className="font-semibold text-white">Up to 30 leads covered — for life</p>
+                    <p className="font-semibold text-white">Founders pricing — locked for life</p>
                     <p className="text-gray-400 text-sm mt-1">
-                      As long as you stay continuously subscribed, your Pro tier covers up to 30 leads
-                      every month. Locked at signup, never renegotiated.
+                      As long as you stay continuously subscribed, your Pro tier rate is locked at
+                      signup. No price increases. No renegotiations.
                     </p>
                   </div>
                 </div>
@@ -408,8 +405,8 @@ export default async function PricingPage() {
             </div>
           </div>
           <p className="text-gray-500 text-xs text-center mt-6">
-            Subscription plans cover the first leads each month at no extra cost. Overflow leads on
-            Basic are $20 each. Overflow leads on Pro are $15 each.
+            Paid plans provide priority routing and placement. Lead volume varies by service area
+            and marketplace demand.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## 🚨 LEGAL RISK FIX

Daniel flagged during May 17 testing: Stripe checkout shows 'Pro tier subscription includes 30 leads per month' / 'Basic tier subscription includes 10 leads per month'. Same promises also live in:
- /pricing page (features lists, FAQ, Founders Offer block, footer fine print)
- /pricing SEO meta description (indexed by Google)

Promising specific lead counts creates breach-of-contract risk if any pro doesn't receive the implied minimum.

## Changes

### app/pricing/page.tsx (-13 / +10 lines)
- **Basic tier features**: removed 'Up to 10 leads covered per month' + overflow line → replaced with 'Priority lead routing — you see qualified leads first'
- **Pro tier features**: removed 'Up to 20 leads covered per month' + overflow line
- **FAQ #1**: 'What does up to X leads covered mean?' → rewritten as 'How does lead routing work?' with explicit disclaimer: *'we do not guarantee a specific number of leads per month'*
- **FAQ #5**: removed 'Lead caps are transparent, overflow pricing is published up front' claim
- **Founders Offer**: 'Up to 30 leads covered — for life' → 'Founders pricing — locked for life' (price guarantee instead of lead guarantee)
- **Footer fine print**: 'Subscription plans cover the first leads each month at no extra cost' → 'Paid plans provide priority routing and placement. Lead volume varies by service area and marketplace demand'

### app/pricing/layout.tsx (-1 / +1 line)
- SEO meta description: 'Basic $79/mo (up to 10 leads covered), Pro $199/mo (up to 20 leads covered)' → 'Basic $79/mo for priority routing, Pro $199/mo for top placement'

## What this does NOT fix

**Stripe Dashboard product descriptions still say '30 leads per month' / '10 leads per month'.** Daniel must update these manually in Stripe Dashboard → Products → Basic/Pro tier → Edit description. This PR only fixes BOC-controlled copy.

## Verification

- TS baseline: 55 → 55 (zero new errors)
- Zero remaining promise text across app/ components/ lib/ (verified via grep)
- Only remaining match is the protective disclaimer

Resolves DLD-504.