### PR TITLE
fix(DLD-502): null-safe formatTime/formatDate prevent customer dashboard crash

### DIFF
--- a/app/dashboard/customer/page.tsx
+++ b/app/dashboard/customer/page.tsx
@@ -16,8 +16,8 @@ interface QuoteRequest {
   id: string;
   cleaner_id: string;
   service_type: string;
-  service_date: string;
-  service_time: string;
+  service_date: string | null;
+  service_time: string | null;
   address: string;
   city: string;
   zip_code: string;
@@ -219,17 +219,22 @@ export default function CustomerDashboard() {
     }
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+  const formatDate = (dateString: string | null | undefined) => {
+    if (!dateString) return 'Flexible';
+    const d = new Date(dateString);
+    if (isNaN(d.getTime())) return 'Flexible';
+    return d.toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
       year: 'numeric'
     });
   };
 
-  const formatTime = (timeString: string) => {
+  const formatTime = (timeString: string | null | undefined) => {
+    if (!timeString) return 'Flexible';
     const [hours, minutes] = timeString.split(':');
     const hour = parseInt(hours);
+    if (isNaN(hour)) return 'Flexible';
     const ampm = hour >= 12 ? 'PM' : 'AM';
     const displayHour = hour % 12 || 12;
     return `${displayHour}:${minutes} ${ampm}`;


### PR DESCRIPTION
## 🚨 CRITICAL FIX — Customer Dashboard Overview crash

DevTools console caught the exact error from willpowermc test account:
```
TypeError: Cannot read properties of null (reading 'split')
    at formatTime (page-6426a327b1339843.js:86:3007)
    at Array.map (<anonymous>)
    at CustomerDashboard
```

## Root cause

`quote_requests.service_time` and `service_date` are nullable in the DB, but the QuoteRequest interface in `app/dashboard/customer/page.tsx` declared them as non-null strings. `formatTime()` called `.split(':')` directly on the value — null crashed the map.

Confirmed via SQL: willpowermc@gmail.com has 2 quotes, both with `service_time = null`.

## Fix

- QuoteRequest interface: `service_date` and `service_time` typed as `string | null`
- formatTime: returns 'Flexible' on null/undefined/unparseable
- formatDate: same null-safety treatment

## Verification

- TS baseline: 55 → 55 (zero new errors)
- 1 file, +10 / -5 lines

Resolves DLD-502.