### PR TITLE
fix(DLD-505): portfolio photo upload — raise size cap from 1MB to 5MB

### DIFF
--- a/app/api/cleaner/portfolio/upload/route.ts
+++ b/app/api/cleaner/portfolio/upload/route.ts
@@ -4,7 +4,11 @@ import { createLogger } from '@/lib/utils/logger';
 
 const logger = createLogger({ file: 'api/cleaner/portfolio/upload/route' });
 
-const MAX_FILE_SIZE = 1024 * 1024; // 1MB
+// DLD-505: previously 1MB, which silently rejected most modern phone photos
+// even after the client-side compression pass (which targets 1MB but isn't
+// guaranteed for high-detail sources). Aligned with the `portfolio-photos`
+// bucket file_size_limit (5MB).
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB — matches bucket limit
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 export async function POST(request: NextRequest) {
@@ -60,7 +64,7 @@ export async function POST(request: NextRequest) {
 
       // Validate file size
       if (file.size > MAX_FILE_SIZE) {
-        errors.push(`${file.name}: File too large. Maximum size is 1MB`);
+        errors.push(`${file.name}: File too large. Maximum size is 5MB`);
         continue;
       }
 

--- a/app/dashboard/pro/portfolio/page.tsx
+++ b/app/dashboard/pro/portfolio/page.tsx
@@ -94,7 +94,13 @@ export default function CleanerPortfolioPage() {
 
     if (!uploadResponse.ok) {
       const errorData = await uploadResponse.json();
-      throw new Error(errorData.error || 'Upload failed');
+      // DLD-505: prefer per-file details from the server (e.g. "image.jpg:
+      // File too large. Maximum size is 5MB") over the generic envelope
+      // message, so the user can fix the file rather than retry blindly.
+      const detail = Array.isArray(errorData.details) && errorData.details.length > 0
+        ? errorData.details.join('; ')
+        : errorData.error || 'Upload failed';
+      throw new Error(detail);
     }
 
     const uploadResult = await uploadResponse.json();

--- a/components/portfolio/PhotoUploader.tsx
+++ b/components/portfolio/PhotoUploader.tsx
@@ -7,7 +7,13 @@ import { createLogger } from '@/lib/utils/logger';
 
 const logger = createLogger({ file: 'components/portfolio/PhotoUploader.tsx' });
 
-const MAX_FILE_SIZE = 1024 * 1024; // 1MB
+// DLD-505: validation cap matches the `portfolio-photos` bucket file_size_limit
+// (5MB) and the server route. Photos over the COMPRESSION_TARGET get re-encoded
+// client-side to keep public-profile bandwidth reasonable, but anything between
+// 1MB and 5MB now uploads successfully even if compression doesn't drive it
+// below 1MB (which q=0.7 isn't guaranteed to do for high-detail sources).
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB — hard reject above this
+const COMPRESSION_TARGET = 1024 * 1024; // 1MB — compress to roughly this size
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 interface PhotoUploaderProps {
@@ -70,8 +76,8 @@ export function PhotoUploader({
               return;
             }
 
-            // If still over 1MB, reduce quality further
-            if (blob.size > MAX_FILE_SIZE) {
+            // If still over compression target, reduce quality further
+            if (blob.size > COMPRESSION_TARGET) {
               canvas.toBlob(
                 (smallerBlob) => {
                   if (!smallerBlob) {
@@ -109,6 +115,10 @@ export function PhotoUploader({
     if (!ACCEPTED_TYPES.includes(file.type)) {
       return `Invalid file type: ${file.type}. Accepted types: JPEG, PNG, WebP`;
     }
+    if (file.size > MAX_FILE_SIZE) {
+      const sizeMb = (file.size / 1024 / 1024).toFixed(1);
+      return `File too large (${sizeMb}MB). Maximum size is 5MB.`;
+    }
     return null;
   };
 
@@ -133,9 +143,9 @@ export function PhotoUploader({
       }
 
       try {
-        // Compress image if needed
+        // Compress image if it would be wasteful to send at original size
         let processedFile = file;
-        if (file.size > MAX_FILE_SIZE) {
+        if (file.size > COMPRESSION_TARGET) {
           processedFile = await compressImage(file);
         }
 
@@ -215,7 +225,13 @@ export function PhotoUploader({
       setPreviewFiles([]);
     } catch (err) {
       logger.error('Error uploading files', { function: 'handleUpload' }, err);
-      setError('Failed to upload photos. Please try again.');
+      // DLD-505: surface the server-side error message when present
+      // (e.g. "File too large") instead of always showing a generic toast.
+      const message =
+        err instanceof Error && err.message && err.message !== 'Upload failed'
+          ? err.message
+          : 'Failed to upload photos. Please try again.';
+      setError(message);
     } finally {
       setIsUploading(false);
     }


### PR DESCRIPTION
## Summary

Pros couldn't upload portfolio photos. Drag-and-drop preview worked, then Upload returned "Failed to upload photos. Please try again." for essentially every modern phone photo.

## Root cause

- Storage bucket `portfolio-photos` has `file_size_limit = 5242880` (**5MB**)
- Storage RLS policies verified correct (INSERT/UPDATE/DELETE gated on `(storage.foldername(name))[1] = auth.uid()`, matching the route's `${user.id}/...` filename)
- **But the server route capped at `MAX_FILE_SIZE = 1MB`** — well below the bucket limit
- And the client compression pass targeted 1MB at quality 0.7, which isn't guaranteed to drive high-detail phone photos under 1MB

Result: server returns 400 with `details: ["image.jpg: File too large..."]`, client component swallows the per-file detail and shows the generic "Failed to upload" toast.

The DLD-461 sweep was **not** involved — verified storage policies reference `auth.uid()` directly, not the `pros`/`cleaners` table.

## Fix (3 files, +35/−9)

**`app/api/cleaner/portfolio/upload/route.ts`**
- `MAX_FILE_SIZE`: 1MB → 5MB (matches bucket limit)
- Error message text: 1MB → 5MB

**`components/portfolio/PhotoUploader.tsx`**
- Split `MAX_FILE_SIZE` (5MB hard validation gate) from `COMPRESSION_TARGET` (1MB — re-encode for public-profile bandwidth)
- Compression now triggers above `COMPRESSION_TARGET`, not the hard gate
- Added client-side size validation in `validateFile` so users see the size error before drag-drop preview, not after Upload
- `handleUpload` catch now surfaces the server's actual message ("File too large", etc.) instead of always showing the generic toast

**`app/dashboard/pro/portfolio/page.tsx`**
- Upload error response now picks up the per-file `details` array rather than only the envelope `error` message, so the toast says `image.jpg: File too large. Maximum size is 5MB` instead of `All uploads failed`

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | 53 errors (matches main baseline, zero new) |
| `next build` | ✅ 89 pages generated |
| Storage bucket config | `portfolio-photos`, public, 5MB limit, image mimes |
| Storage RLS | INSERT/UPDATE/DELETE policies verified, bucket-aware, folder-aware on `auth.uid()` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)