### PR TITLE
fix(DLD-506): distance filter no longer permanently grey-locked

### DIFF
--- a/components/search/SearchFilters.tsx
+++ b/components/search/SearchFilters.tsx
@@ -111,6 +111,12 @@ export function SearchFilters({
       </div>
 
       {/* Distance/Radius */}
+      {/* DLD-506: always selectable. Previously `disabled={!filters.selectedZip}`
+          permanently grey-locked the dropdown because the ZIP field lives in
+          the SearchBar hero (separate component) and users didn't make the
+          connection. Distance-without-ZIP is a no-op in the search backend
+          (filtered out when distanceMap is empty), so leaving the dropdown
+          selectable is safe — the hint below clarifies what's needed. */}
       <div>
         <label htmlFor="filter-distance" className="block text-sm font-semibold text-brand-dark mb-2">
           Distance
@@ -120,8 +126,7 @@ export function SearchFilters({
             id="filter-distance"
             value={filters.distance}
             onChange={(e) => updateFilter('distance', e.target.value as DistanceOption)}
-            disabled={!filters.selectedZip}
-            className="w-full px-4 py-3 bg-brand-cream border border-gray-200 rounded-xl text-brand-dark text-sm appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-gold/50 transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full px-4 py-3 bg-brand-cream border border-gray-200 rounded-xl text-brand-dark text-sm appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-gold/50 transition-shadow"
           >
             {DISTANCE_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -131,8 +136,10 @@ export function SearchFilters({
           </select>
           <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
         </div>
-        {!filters.selectedZip && (
-          <p className="text-xs text-gray-400 mt-1">Enter a ZIP code to filter by distance</p>
+        {filters.distance && !filters.selectedZip && (
+          <p className="text-xs text-amber-600 mt-1">
+            Enter a ZIP code in the search bar above to apply distance filtering.
+          </p>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

The Distance dropdown on `/search` was disabled via `disabled={!filters.selectedZip}`, which permanently grey-locked it because the ZIP input lives in the SearchBar hero (a separate component above the filter sidebar). Users didn't make the connection and reported it as "blanked out / unselectable."

## Fix (one file, +11/−4)

Removed the `disabled` attribute on the Distance `<select>`. The `DISTANCE_OPTIONS` list already includes "Any Distance" as the default, plus 5/10/25/50 mile options — so the dropdown is functional out of the box.

Sharpened the hint text:
- **Before**: shown whenever ZIP is empty, in grey: "Enter a ZIP code to filter by distance"
- **After**: shown **only** when the user has actively selected a specific distance without a ZIP, in **amber**: "Enter a ZIP code in the search bar above to apply distance filtering."

The amber color + the explicit "in the search bar above" pointer should close the discoverability gap that caused the bug report.

## Why this is safe

Searching without a ZIP is already a no-op for distance filtering in the backend (`loadCleaners` only computes `distanceMap` when there's a valid search location; the distance-filter branch short-circuits when the map is empty). So a customer who picks "Within 25 miles" without entering a ZIP gets the same results as "Any Distance" — no surprise data issues, just the amber hint nudging them to add a ZIP for the filter to actually apply.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | 53 errors (matches main baseline, zero new) |
| `next build` | ✅ 89 pages generated |

## Resolution choice

The ticket offered two paths: (A) make it work, (B) remove it. This PR is closest to (A) without requiring PostGIS or geolocation — distance filtering still works when a ZIP is present (existing haversine logic on `lib/utils/distance`), and the UI now never falsely advertises a feature as "broken."

🤖 Generated with [Claude Code](https://claude.com/claude-code)