### PR TITLE
fix(DLD-508): restore dashboard sidebar on Messages routes

### DIFF
--- a/app/dashboard/messages/layout.tsx
+++ b/app/dashboard/messages/layout.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { DashboardSidebar, type SidebarLink } from '@/components/dashboard/DashboardSidebar';
+import { useAuth } from '@/lib/context/AuthContext';
+import {
+  LayoutDashboard, User, Calendar, Heart, MessageSquare, Bell, HelpCircle,
+  Inbox, FileText, DollarSign, Clock, Images, Star, MapPin, CreditCard, ShieldCheck,
+} from 'lucide-react';
+
+// DLD-508: /dashboard/messages and /dashboard/messages/[conversationId]
+// previously had no layout, so the dashboard sidebar disappeared the moment
+// the user clicked into a conversation. This layout restores the sidebar by
+// picking the appropriate set of links based on the signed-in user's role.
+//
+// Link arrays intentionally duplicated from app/dashboard/{pro,customer}/layout.tsx
+// instead of factoring into a shared module — the lists are short and the
+// duplication makes role-specific sidebar changes locally obvious. If this
+// trio grows in lockstep, extract to `lib/dashboard/sidebarLinks.ts`.
+
+const customerLinks: SidebarLink[] = [
+  { href: '/dashboard/customer', label: 'Overview', icon: LayoutDashboard },
+  { href: '/dashboard/customer/profile', label: 'Profile', icon: User },
+  { href: '/dashboard/customer/bookings', label: 'My Bookings', icon: Calendar },
+  { href: '/dashboard/customer/favorites', label: 'Favorites', icon: Heart },
+  { href: '/dashboard/messages', label: 'Messages', icon: MessageSquare },
+  { href: '/dashboard/customer/notifications', label: 'Notifications', icon: Bell },
+  { href: '/dashboard/customer/help', label: 'Help', icon: HelpCircle },
+];
+
+const proLinks: SidebarLink[] = [
+  { href: '/dashboard/pro', label: 'Overview', icon: LayoutDashboard },
+  { href: '/dashboard/pro/profile', label: 'My Profile', icon: User },
+  { href: '/dashboard/pro/documents', label: 'Documents', icon: ShieldCheck },
+  { href: '/dashboard/pro/notifications', label: 'Notifications', icon: Bell },
+  { href: '/dashboard/messages', label: 'Messages', icon: MessageSquare },
+  { href: '/dashboard/pro/leads', label: 'Leads', icon: Inbox },
+  { href: '/dashboard/pro/quote-requests', label: 'Quote Requests', icon: FileText },
+  { href: '/dashboard/pro/bookings', label: 'Bookings', icon: Calendar },
+  { href: '/dashboard/pro/earnings', label: 'Earnings', icon: DollarSign },
+  { href: '/dashboard/pro/availability', label: 'Availability', icon: Clock },
+  { href: '/dashboard/pro/portfolio', label: 'Portfolio', icon: Images },
+  { href: '/dashboard/pro/reviews', label: 'Reviews', icon: Star },
+  { href: '/dashboard/pro/service-areas', label: 'Service Areas', icon: MapPin },
+  { href: '/dashboard/pro/billing', label: 'Billing', icon: CreditCard },
+];
+
+export default function MessagesLayout({ children }: { children: React.ReactNode }) {
+  const { isCustomer } = useAuth();
+  const links = isCustomer ? customerLinks : proLinks;
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)]">
+      <DashboardSidebar links={links} />
+      <main className="flex-1 min-w-0 pt-14 md:pt-0 px-2 md:px-0 overflow-x-hidden">{children}</main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

`/dashboard/messages` and `/dashboard/messages/[conversationId]` had no layout, so the dashboard sidebar disappeared the moment a user clicked into a conversation. Only a "Back" button remained. Pro and customer dashboards each have their own layout, but neither covers the shared `/dashboard/messages/...` subtree (there's no root `/dashboard/layout.tsx` either).

## Fix (one new file, +57 LOC)

Added `app/dashboard/messages/layout.tsx` that picks the appropriate sidebar link set based on `useAuth().isCustomer`, then composes with the existing `DashboardSidebar` component the pro and customer layouts already use.

Link arrays are intentionally duplicated from `app/dashboard/{pro,customer}/layout.tsx` rather than refactored into a shared module — the lists are short and the duplication keeps role-specific sidebar changes locally obvious. If this trio grows in lockstep, extract to `lib/dashboard/sidebarLinks.ts` in a follow-up.

## Independence from DLD-507

DLD-507 (unread badges) is on a separate branch — its badge props are intentionally NOT included in this layout. Once both land, a small follow-up PR can wire badge counts into the messages sidebar too. This keeps the two PRs mergeable in either order with no conflicts.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | 53 errors (matches main baseline, zero new) |
| `next build` | ✅ 89 pages generated |
| `/dashboard/messages` | now 1.73 kB (was layout-less) |
| `/dashboard/messages/[conversationId]` | now 5.01 kB |

Both routes still render under `ProtectedRoute` as before — layout composes outside, page content composes inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)