### PR TITLE
fix(DLD-505 follow-up): align portfolio pro_id with RLS auth.uid()

### DIFF
--- a/app/api/cleaner/portfolio/route.ts
+++ b/app/api/cleaner/portfolio/route.ts
@@ -58,7 +58,7 @@ export async function GET(_request: NextRequest) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
 
-    // Get pro profile (the pros.id is the pro_id used in portfolio_photos)
+    // Confirm pro profile exists (RLS uses auth.uid() directly via user.id)
     const { data: cleaner, error: cleanerError } = await supabase
       .from('pros')
       .select('id')
@@ -70,10 +70,11 @@ export async function GET(_request: NextRequest) {
     }
 
     // Get portfolio photos using REAL DB columns
+    // pro_id stores auth user id (matches RLS: pro_id = auth.uid())
     const { data: photos, error: photosError } = await supabase
       .from('portfolio_photos')
       .select('id, pro_id, url, caption, display_order, created_at, updated_at')
-      .eq('pro_id', cleaner.id)
+      .eq('pro_id', user.id)
       .order('display_order', { ascending: true });
 
     if (photosError) {
@@ -117,11 +118,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Cleaner profile not found' }, { status: 404 });
     }
 
-    // Count existing photos to enforce the cap
+    // Count existing photos to enforce the cap (RLS: pro_id = auth.uid())
     const { count: currentCount } = await supabase
       .from('portfolio_photos')
       .select('id', { count: 'exact', head: true })
-      .eq('pro_id', cleaner.id);
+      .eq('pro_id', user.id);
 
     const body = await request.json();
     const { photos } = body as { photos: { image_url: string; caption?: string }[] };
@@ -142,7 +143,7 @@ export async function POST(request: NextRequest) {
     const { data: maxOrderData } = await supabase
       .from('portfolio_photos')
       .select('display_order')
-      .eq('pro_id', cleaner.id)
+      .eq('pro_id', user.id)
       .order('display_order', { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -150,8 +151,9 @@ export async function POST(request: NextRequest) {
     let nextOrder = (maxOrderData?.display_order ?? -1) + 1;
 
     // Insert using REAL DB columns (url, pro_id)
+    // pro_id stores auth user id to satisfy RLS policy pro_id = auth.uid()
     const photosToInsert = photos.map((photo) => ({
-      pro_id: cleaner.id,
+      pro_id: user.id,
       url: photo.image_url,
       caption: photo.caption || null,
       display_order: nextOrder++,
@@ -223,7 +225,7 @@ export async function PATCH(request: NextRequest) {
             .from('portfolio_photos')
             .update({ display_order: photo.display_order })
             .eq('id', photo.id)
-            .eq('pro_id', cleaner.id);
+            .eq('pro_id', user.id);
 
           if (error) {
             logger.error('Error reordering photo', { function: 'PATCH', photoId: photo.id }, error);
@@ -242,7 +244,7 @@ export async function PATCH(request: NextRequest) {
           .from('portfolio_photos')
           .update({ caption: caption || null })
           .eq('id', photoId)
-          .eq('pro_id', cleaner.id);
+          .eq('pro_id', user.id);
 
         if (error) {
           logger.error('Error updating caption', { function: 'PATCH' }, error);
@@ -306,7 +308,7 @@ export async function DELETE(request: NextRequest) {
       .from('portfolio_photos')
       .select('id, url')
       .eq('id', photoId)
-      .eq('pro_id', cleaner.id)
+      .eq('pro_id', user.id)
       .single();
 
     if (fetchError || !photo) {
@@ -318,7 +320,7 @@ export async function DELETE(request: NextRequest) {
       .from('portfolio_photos')
       .delete()
       .eq('id', photoId)
-      .eq('pro_id', cleaner.id);
+      .eq('pro_id', user.id);
 
     if (deleteError) {
       logger.error('Error deleting portfolio photo', { function: 'DELETE' }, deleteError);

--- a/app/cleaner/[slug]/page.tsx
+++ b/app/cleaner/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { BadgeDisplay, BadgeList } from '@/components/badges/BadgeDisplay';
 // NOTE: business_phone intentionally omitted — PII gated behind lead acceptance (DLD-457).
 interface CleanerProfile {
   id: string;
+  user_id: string;
   business_name: string;
   business_slug: string;
   business_description: string;
@@ -67,6 +68,7 @@ interface Review {
 // Explicit allowlist excluding business_phone (PII — gated by lead acceptance, DLD-457).
 const PUBLIC_PROFILE_COLUMNS = `
   id,
+  user_id,
   business_name,
   business_slug,
   business_description,
@@ -133,14 +135,15 @@ async function getCleanerReviews(cleanerId: string): Promise<Review[]> {
   return data || [];
 }
 
-async function getCleanerPortfolio(cleanerId: string): Promise<PortfolioPhoto[]> {
+async function getCleanerPortfolio(proUserId: string): Promise<PortfolioPhoto[]> {
   const supabase = await createClient();
 
   // Query REAL DB columns (pro_id, url), shim to PortfolioPhoto shape for the UI
+  // pro_id stores auth user id to match RLS policy pro_id = auth.uid()
   const { data } = await supabase
     .from('portfolio_photos')
     .select('id, url, caption, display_order')
-    .eq('pro_id', cleanerId)
+    .eq('pro_id', proUserId)
     .order('display_order', { ascending: true });
 
   return ((data || []) as Array<{ id: string; url: string; caption: string | null; display_order: number | null }>).map(
@@ -184,7 +187,7 @@ export default async function CleanerProfilePage({ params }: { params: Promise<{
   }
 
   const reviews = await getCleanerReviews(cleaner.id);
-  const portfolioPhotos = await getCleanerPortfolio(cleaner.id);
+  const portfolioPhotos = await getCleanerPortfolio(cleaner.user_id);
 
   // Calculate badges based on cleaner metrics
   const earnedBadges = getCleanerBadges({

--- a/app/dashboard/pro/portfolio/page.tsx
+++ b/app/dashboard/pro/portfolio/page.tsx
@@ -53,11 +53,11 @@ export default function CleanerPortfolioPage() {
       setCleanerId(cleaner.id);
 
       // Get portfolio photos using REAL DB columns (pro_id, url)
-      // Shim to UI shape (cleaner_id, image_url, etc.) for component compatibility
+      // pro_id stores auth user id to match RLS policy pro_id = auth.uid()
       const { data: portfolioPhotos, error: photosError } = await supabase
         .from('portfolio_photos')
         .select('id, pro_id, url, caption, display_order, created_at')
-        .eq('pro_id', cleaner.id)
+        .eq('pro_id', user.id)
         .order('display_order', { ascending: true });
 
       if (photosError) {


### PR DESCRIPTION
## Problem

PR #37 fixed the column name mismatch (cleaner_id → pro_id) but a second-layer bug remained. Postgres log captured the smoking gun after PR #37 deployed:

```
ERROR: new row violates row-level security policy for table 'portfolio_photos'
```

The RLS policy requires `pro_id = auth.uid()`, but the code was storing `pros.id` (a different UUID, linked to auth via `pros.user_id`).

| | UUID |
|---|---|
| Magic Clean's `pros.id` | cf941b2f-00f0-47dd-a21e-243d25335a17 |
| Magic Clean's `auth.uid()` (= pros.user_id) | e4cb4edb-2442-453b-bf7a-4f2d15a7d4ee |

Different values — RLS rejected every insert.

## Fix

All portfolio_photos operations now use `user.id` (auth uid) instead of `cleaner.id` (pros table id).

Storage semantics: `portfolio_photos.pro_id` holds the auth user id — column name is slightly misleading but consistent with the RLS policy. No DB migration needed (table empty in production).

## Files Changed

| File | Change |
|---|---|
| `app/api/cleaner/portfolio/route.ts` | GET/POST/PATCH/DELETE all use `user.id` (5 query sites + 1 insert) |
| `app/dashboard/pro/portfolio/page.tsx` | Query uses `user.id` |
| `app/cleaner/[slug]/page.tsx` | Added `user_id` to PUBLIC_PROFILE_COLUMNS; portfolio query uses `cleaner.user_id` |

**+20 / -15 lines across 3 files.**

## Verification

- ✅ `npm run build` passes, exit 0, all 3 portfolio routes compiled
- ✅ DB confirmed: portfolio_photos table empty (no migration / data fix needed)
- ✅ RLS policy confirmed: `pro_id = auth.uid()`
- ✅ Magic Clean test account confirmed in pros table

## Lesson

PR #33 was wrong because the agent never reproduced the bug. PR #37 (mine) was partial because I matched only the column name without checking the RLS policy semantics. **Always check RLS policies when schema changes.** Postgres logs are the authoritative source — they showed the new error within seconds of deploy.

## Test Plan (after merge)

1. Sign in as Magic Clean (`beautifulknowledge72@gmail.com`)
2. Pro Dashboard → Portfolio → drop 2 photos → click Upload
3. Expect: 200 OK, photos appear, no RLS errors in Postgres logs