### PR TITLE
fix(DLD-520): tighten customer dashboard stat cards for small mobile

### DIFF
--- a/app/dashboard/customer/page.tsx
+++ b/app/dashboard/customer/page.tsx
@@ -288,49 +288,49 @@ export default function CustomerDashboard() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Stats Overview */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-gold p-6">
+            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-gold p-4 sm:p-6">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-500">Total Quotes</p>
-                  <p className="font-display text-3xl font-bold text-brand-dark">{quotes.length}</p>
+                  <p className="font-display text-2xl sm:text-3xl font-bold text-brand-dark">{quotes.length}</p>
                 </div>
-                <FileText className="h-8 w-8 text-brand-gold" />
+                <FileText className="h-7 w-7 sm:h-8 sm:w-8 flex-shrink-0 text-brand-gold" />
               </div>
             </div>
             
-            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-navy p-6">
+            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-navy p-4 sm:p-6">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-500">Pending</p>
-                  <p className="font-display text-3xl font-bold text-brand-navy">
+                  <p className="font-display text-2xl sm:text-3xl font-bold text-brand-navy">
                     {quotes.filter(q => q.status === 'pending').length}
                   </p>
                 </div>
-                <Clock className="h-8 w-8 text-brand-navy" />
+                <Clock className="h-7 w-7 sm:h-8 sm:w-8 flex-shrink-0 text-brand-navy" />
               </div>
             </div>
             
-            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-gold p-6">
+            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-gold p-4 sm:p-6">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-500">Active</p>
-                  <p className="font-display text-3xl font-bold text-brand-dark">
+                  <p className="font-display text-2xl sm:text-3xl font-bold text-brand-dark">
                     {quotes.filter(q => ['responded', 'accepted'].includes(q.status)).length}
                   </p>
                 </div>
-                <CheckCircle className="h-8 w-8 text-brand-gold" />
+                <CheckCircle className="h-7 w-7 sm:h-8 sm:w-8 flex-shrink-0 text-brand-gold" />
               </div>
             </div>
             
-            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-navy p-6">
+            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-navy p-4 sm:p-6">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-500">Completed</p>
-                  <p className="font-display text-3xl font-bold text-brand-navy">
+                  <p className="font-display text-2xl sm:text-3xl font-bold text-brand-navy">
                     {quotes.filter(q => q.status === 'completed').length}
                   </p>
                 </div>
-                <Star className="h-8 w-8 text-brand-navy" />
+                <Star className="h-7 w-7 sm:h-8 sm:w-8 flex-shrink-0 text-brand-navy" />
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

Daniel reported lingering mobile overlap on the customer dashboard after PR #39 (restyle) and PR #42 (quote-card row). I audited every candidate from the ticket — the only one still crowding at 320–375px was the **stats overview grid**.

## Root cause

The `grid-cols-2` stat cards are ~136px wide at 320px. Inside, `p-6` padding + a `text-3xl` Playfair serif number + an `h-8` icon (laid out `justify-between`) competed for space and crowded.

## Fix (4 stat cards only)

- `p-6` → `p-4 sm:p-6` — less padding on small screens
- icon `h-8 w-8` → `h-7 w-7 sm:h-8 sm:w-8` + `flex-shrink-0` — icon never squeezes or pushes the number
- number `text-3xl` → `text-2xl sm:text-3xl`

## Already-handled candidates (verified, not touched)

| Element | Status |
|---|---|
| Header | `flex-col gap-4 sm:flex-row` — PR #39 |
| Quote card top row (name + badge) | `flex-col sm:flex-row` + `flex-wrap` + `min-w-0` — PR #42 |
| Quote card action area (Accept/Confirm) | `w-full sm:w-auto`, stacks on mobile |
| Tabs row | single visible tab (Credits hidden via `{false &&}`), no overflow |

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | 53 errors (matches main baseline, zero new) |
| `next build` | ✅ 89 pages generated |

Daniel will verify on his actual phone. If anything else still overlaps, point me at the specific element and I'll tighten it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)