### PR TITLE
feat(DLD-519): brand restyle pro dashboard overview + shared sidebar (proof)

### DIFF
--- a/app/dashboard/pro/page.tsx
+++ b/app/dashboard/pro/page.tsx
@@ -183,27 +183,29 @@ export default function CleanerDashboard() {
 
   return (
     <ProtectedRoute requireRole="cleaner">
-      <div className="min-h-screen bg-gray-50">
-        {/* Header */}
-        <div className="bg-white shadow-sm border-b">
+      <div className="min-h-screen bg-brand-cream">
+        {/* Header — branded, mobile-responsive (DLD-519, matches customer template) */}
+        <div className="bg-brand-dark border-b border-brand-gold/20">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between items-center py-6">
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">
+            <div className="flex flex-col gap-4 py-5 sm:flex-row sm:items-center sm:justify-between sm:py-6">
+              <div className="min-w-0">
+                <h1 className="font-display text-2xl sm:text-3xl font-bold text-brand-cream truncate">
                   {profile?.business_name || 'Pro Dashboard'}
                 </h1>
+                <div className="mt-2 h-[3px] w-10 rounded-full bg-brand-gold" />
                 {profile?.approval_status === 'pending' && (
-                  <p className="text-sm text-yellow-600 mt-1">
+                  <p className="text-sm text-brand-gold mt-2">
                     Your profile is pending approval
                   </p>
                 )}
               </div>
-              <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2 sm:gap-3">
                 <Link
                   href="/dashboard/pro/profile"
-                  className="text-gray-600 hover:text-gray-900"
+                  className="flex items-center gap-2 px-2 py-2.5 text-brand-cream/80 transition hover:text-brand-cream"
                 >
-                  <Settings className="h-6 w-6" />
+                  <Settings className="h-5 w-5 text-brand-gold" />
+                  <span className="sm:hidden lg:inline">Settings</span>
                 </Link>
               </div>
             </div>
@@ -313,51 +315,51 @@ export default function CleanerDashboard() {
             </div>
           </div>
 
-          {/* Stats Overview */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-            <div className="bg-white rounded-lg shadow-sm p-6">
+          {/* Stats Overview — branded cards (DLD-519) */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-gold p-4 sm:p-6">
               <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-gray-600">Total Quotes</p>
-                  <p className="text-2xl font-bold text-gray-900">{quotes.length}</p>
+                <div className="min-w-0">
+                  <p className="text-sm text-gray-500">Total Quotes</p>
+                  <p className="font-display text-2xl sm:text-3xl font-bold text-brand-dark">{quotes.length}</p>
                 </div>
-                <FileText className="h-8 w-8 text-blue-600" />
+                <FileText className="h-7 w-7 sm:h-8 sm:w-8 flex-shrink-0 text-brand-gold" />
               </div>
             </div>
-            
-            <div className="bg-white rounded-lg shadow-sm p-6">
+
+            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-navy p-4 sm:p-6">
               <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-gray-600">Pending Quotes</p>
-                  <p className="text-2xl font-bold text-yellow-600">
+                <div className="min-w-0">
+                  <p className="text-sm text-gray-500">Pending Quotes</p>
+                  <p className="font-display text-2xl sm:text-3xl font-bold text-brand-navy">
                     {quotes.filter(q => q.status === 'pending').length}
                   </p>
                 </div>
-                <Clock className="h-8 w-8 text-yellow-600" />
+                <Clock className="h-7 w-7 sm:h-8 sm:w-8 flex-shrink-0 text-brand-navy" />
               </div>
             </div>
-            
-            <div className="bg-white rounded-lg shadow-sm p-6">
+
+            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-gold p-4 sm:p-6">
               <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-gray-600">Average Rating</p>
-                  <p className="text-2xl font-bold text-green-600">
+                <div className="min-w-0">
+                  <p className="text-sm text-gray-500">Average Rating</p>
+                  <p className="font-display text-2xl sm:text-3xl font-bold text-brand-dark">
                     {profile?.average_rating.toFixed(1) || '0.0'}
                   </p>
                 </div>
-                <Star className="h-8 w-8 text-green-600" />
+                <Star className="h-7 w-7 sm:h-8 sm:w-8 flex-shrink-0 text-brand-gold" />
               </div>
             </div>
-            
-            <div className="bg-white rounded-lg shadow-sm p-6">
+
+            <div className="bg-white rounded-xl shadow-sm border border-brand-dark/5 border-t-[3px] border-t-brand-navy p-4 sm:p-6">
               <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-gray-600">Total Jobs</p>
-                  <p className="text-2xl font-bold text-purple-600">
+                <div className="min-w-0">
+                  <p className="text-sm text-gray-500">Total Jobs</p>
+                  <p className="font-display text-2xl sm:text-3xl font-bold text-brand-navy">
                     {profile?.total_jobs || 0}
                   </p>
                 </div>
-                <TrendingUp className="h-8 w-8 text-purple-600" />
+                <TrendingUp className="h-7 w-7 sm:h-8 sm:w-8 flex-shrink-0 text-brand-gold" />
               </div>
             </div>
           </div>

--- a/components/dashboard/DashboardSidebar.tsx
+++ b/components/dashboard/DashboardSidebar.tsx
@@ -39,9 +39,9 @@ export function DashboardSidebar({ links }: DashboardSidebarProps) {
   const navContent = (
     <div className="flex flex-col h-full">
       {/* User info */}
-      <div className="p-4 border-b border-gray-200">
-        <p className="text-sm font-semibold text-gray-900 truncate">{userName}</p>
-        <p className="text-xs text-gray-500 truncate">{userEmail}</p>
+      <div className="p-4 border-b border-brand-gold/20">
+        <p className="text-sm font-semibold text-brand-cream truncate">{userName}</p>
+        <p className="text-xs text-brand-cream/60 truncate">{userEmail}</p>
       </div>
 
       {/* Nav links */}
@@ -56,8 +56,8 @@ export function DashboardSidebar({ links }: DashboardSidebarProps) {
               onClick={() => setMobileOpen(false)}
               className={`relative flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors mb-0.5 ${
                 active
-                  ? 'bg-brand-gold/10 text-brand-gold'
-                  : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'
+                  ? 'bg-brand-gold/15 text-brand-gold'
+                  : 'text-brand-cream/80 hover:bg-white/5 hover:text-brand-cream'
               }`}
             >
               <Icon className="h-4 w-4 flex-shrink-0" />
@@ -73,10 +73,10 @@ export function DashboardSidebar({ links }: DashboardSidebarProps) {
       </nav>
 
       {/* Sign Out — plain <a> to server route, no client JS needed */}
-      <div className="p-2 border-t border-gray-200">
+      <div className="p-2 border-t border-brand-gold/20">
         <a
           href="/logout"
-          className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm font-medium text-gray-600 hover:bg-red-50 hover:text-red-700 transition-colors"
+          className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm font-medium text-brand-cream/70 hover:bg-red-500/15 hover:text-red-300 transition-colors"
         >
           <LogOut className="h-4 w-4 flex-shrink-0" />
           Sign Out
@@ -109,16 +109,16 @@ export function DashboardSidebar({ links }: DashboardSidebarProps) {
 
       {/* Mobile sidebar */}
       <aside
-        className={`md:hidden fixed top-0 left-0 z-[55] h-full w-64 bg-white border-r border-gray-200 transform transition-transform duration-200 flex flex-col ${
+        className={`md:hidden fixed top-0 left-0 z-[55] h-full w-64 bg-brand-dark border-r border-brand-gold/20 transform transition-transform duration-200 flex flex-col ${
           mobileOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
         {/* Close button inside sidebar */}
-        <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200 flex-shrink-0">
-          <span className="text-sm font-semibold text-gray-900">Menu</span>
+        <div className="flex items-center justify-between h-16 px-4 border-b border-brand-gold/20 flex-shrink-0">
+          <span className="font-display text-sm font-semibold text-brand-cream">Menu</span>
           <button
             onClick={() => setMobileOpen(false)}
-            className="p-1.5 rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-700 transition-colors"
+            className="p-1.5 rounded-lg text-brand-cream/60 hover:bg-white/5 hover:text-brand-cream transition-colors"
             aria-label="Close sidebar"
           >
             <X className="h-5 w-5" />
@@ -130,7 +130,7 @@ export function DashboardSidebar({ links }: DashboardSidebarProps) {
       </aside>
 
       {/* Desktop sidebar */}
-      <aside className="hidden md:block w-64 flex-shrink-0 bg-white border-r border-gray-200 min-h-[calc(100vh-4rem)]">
+      <aside className="hidden md:block w-64 flex-shrink-0 bg-brand-dark border-r border-brand-gold/20 min-h-[calc(100vh-4rem)]">
         {navContent}
       </aside>
     </>


### PR DESCRIPTION
## Summary

Rolls the PR #39 customer-dashboard brand template to the **pro** side. Per the ticket's "slow is smooth — do the overview page first as a reviewable proof, then roll to sub-pages" guidance, this PR scopes to the **overview page + the shared DashboardSidebar**. Sub-pages (profile, portfolio, availability, service-areas) follow in a second PR once you approve this look.

## Changes

**`app/dashboard/pro/page.tsx`**
- Page bg `gray-50` → `brand-cream`
- Header: white bar → `brand-dark` navy with `brand-gold/20` border, `font-display` serif title in `brand-cream`, gold underline accent, and the mobile-responsive `flex-col → sm:flex-row` stack (matches customer). Pending-approval note recolored to `brand-gold`.
- Stat cards: `rounded-lg` → `rounded-xl`, added `border-t-[3px]` gold/navy accent stripe, serif `text-2xl sm:text-3xl` numbers, brand-colored icons with `flex-shrink-0`, `grid-cols-2` on mobile + `p-4 sm:p-6` (same mobile-safe pattern from DLD-520).

**`components/dashboard/DashboardSidebar.tsx`** (shared — pro + customer)
- Navy (`brand-dark`) background on both desktop aside and mobile drawer, `brand-gold/20` borders
- Links: `brand-cream/80` text, hover `white/5`; active `bg-brand-gold/15 text-brand-gold` (pops on navy)
- User-info + Sign Out recolored for the dark surface
- **All responsive drawer logic untouched** — hamburger, backdrop, `translate-x` transitions, z-index, `md:` breakpoint are pure color changes only, so the existing mobile drawer behavior is preserved per the ticket constraint

## Note on the shared sidebar

Since the customer dashboard now also uses `DashboardSidebar` (via its layout), this navy restyle applies to both pro and customer sidebars — which is the desired consistency. Flagging explicitly because the ticket called out "carefully, it's shared."

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | 53 errors (matches main baseline, zero new) |
| `next build` | ✅ 89 pages generated |

Daniel reviews on phone + desktop. Once approved, I'll roll the same tokens to the pro sub-pages (profile/portfolio/availability/service-areas headers + cards) in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)