### PR TITLE
fix(login): remove duplicate logo + brand the auth form

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import { AuthForm } from '@/components/auth/AuthForm'
 import { generatePageMetadata } from '@/lib/seo/metadata'
 
@@ -11,16 +10,8 @@ export const metadata = generatePageMetadata({
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen items-center justify-center bg-brand-cream px-4 py-12 sm:px-6 lg:px-8">
       <div className="flex flex-col items-center w-full max-w-md">
-        <Image
-          src="/boss-of-clean-logo.png"
-          alt="Boss of Clean"
-          width={80}
-          height={80}
-          className="rounded-lg mb-6"
-          priority
-        />
         <AuthForm mode="login" />
       </div>
     </div>

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -382,8 +382,8 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
             height={80}
             className="rounded-full"
           />
-          <h1 className="text-2xl font-bold mt-3">Boss of Clean</h1>
-          <p className="text-gray-500 text-sm">Purrfection is our Standard</p>
+          <h1 className="font-display text-2xl font-bold mt-3 text-brand-dark">Boss of Clean</h1>
+          <p className="text-brand-gold text-sm font-medium">Purrfection is our Standard</p>
         </div>
         <CardTitle>{mode === 'login' ? 'Sign In' : isCleaner ? 'Pro Account' : 'Create Account'}</CardTitle>
         <CardDescription>
@@ -536,7 +536,7 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
         <CardFooter className="flex flex-col space-y-4">
           <Button
             type="submit"
-            className="w-full"
+            className="w-full bg-brand-gold text-brand-dark font-semibold hover:bg-brand-gold-light disabled:opacity-50"
             disabled={loading || (isSignup && !tcpaConsented)}
           >
             {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}


### PR DESCRIPTION
Daniel login review #2 + #3:

**#2** Removed the duplicate top logo (kept the one on the form card) + unused Image import.

**#3** Branded the form: brand-cream bg, gold Sign In button (matches Find Pros CTA), Playfair serif title, gold tagline.

**#1 (OAuth double-sign-in) is NOT here** — handled separately with preview testing (callback cookie-propagation issue).

Build: 0 errors.