### PR TITLE
diag(oauth): bump OAUTH-DIAG logging to warn so it emits in prod

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -67,7 +67,7 @@ export async function GET(request: NextRequest) {
     const { data: exchangeData, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
 
     // [OAUTH-DIAG] temporary — remove after diagnosis
-    logger.info('[OAUTH-DIAG] code exchange attempt', {
+    logger.warn('[OAUTH-DIAG] code exchange attempt', {
       function: 'GET',
       hadCode: true,
       exchangeSucceeded: !exchangeError,
@@ -83,7 +83,7 @@ export async function GET(request: NextRequest) {
     }
   } else {
     // [OAUTH-DIAG] temporary — remove after diagnosis
-    logger.info('[OAUTH-DIAG] callback hit with NO code param', {
+    logger.warn('[OAUTH-DIAG] callback hit with NO code param', {
       function: 'GET',
       hadCode: false,
       allParams: Array.from(requestUrl.searchParams.keys()),
@@ -96,7 +96,7 @@ export async function GET(request: NextRequest) {
 
   // [OAUTH-DIAG] temporary — remove after diagnosis. What cookies exist right now,
   // and did getUser resolve a user? This tells us if the session landed.
-  logger.info('[OAUTH-DIAG] post-exchange state', {
+  logger.warn('[OAUTH-DIAG] post-exchange state', {
     function: 'GET',
     getUserResolved: !!user,
     getUserEmail: user?.email ?? null,


### PR DESCRIPTION
Codex caught that PR #48's [OAUTH-DIAG] logging used logger.info, which lib/utils/logger.ts suppresses in production (only warn+error emit in prod). So the diagnostics never recorded.

Fix: flip all 3 OAUTH-DIAG calls info -> warn. Read-only, no behavior change, still temporary (remove after diagnosis).

Next: one Google login on prod -> read real logs -> confirm + remove logging.

Build: 0 errors.