### PR TITLE
chore(oauth): remove diagnostic logging — auth path verified healthy

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -64,48 +64,16 @@ export async function GET(request: NextRequest) {
   // because Supabase already exchanged it server-side), fall through and check
   // for an existing session instead of erroring out.
   if (code) {
-    const { data: exchangeData, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
-
-    // [OAUTH-DIAG] temporary — remove after diagnosis
-    logger.warn('[OAUTH-DIAG] code exchange attempt', {
-      function: 'GET',
-      hadCode: true,
-      exchangeSucceeded: !exchangeError,
-      exchangeErrorName: exchangeError?.name ?? null,
-      exchangeErrorStatus: (exchangeError as { status?: number } | null)?.status ?? null,
-      exchangeErrorMsg: exchangeError?.message ?? null,
-      sessionReturned: !!exchangeData?.session,
-      userFromExchange: exchangeData?.user?.email ?? null,
-    })
+    const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
 
     if (exchangeError) {
       logger.error('OAuth code exchange error (may be already exchanged)', { function: 'GET' }, exchangeError)
     }
-  } else {
-    // [OAUTH-DIAG] temporary — remove after diagnosis
-    logger.warn('[OAUTH-DIAG] callback hit with NO code param', {
-      function: 'GET',
-      hadCode: false,
-      allParams: Array.from(requestUrl.searchParams.keys()),
-    })
   }
 
   // Check for an active session — works whether code exchange just succeeded,
   // was already exchanged by Supabase, or user arrived with existing cookies.
   const { data: { user } } = await supabase.auth.getUser()
-
-  // [OAUTH-DIAG] temporary — remove after diagnosis. What cookies exist right now,
-  // and did getUser resolve a user? This tells us if the session landed.
-  logger.warn('[OAUTH-DIAG] post-exchange state', {
-    function: 'GET',
-    getUserResolved: !!user,
-    getUserEmail: user?.email ?? null,
-    authCookieNames: cookieStore.getAll()
-      .map((c) => c.name)
-      .filter((n) => n.includes('auth') || n.includes('sb-')),
-    pendingCookieNames: pendingCookies.map((c) => c.name),
-    pendingCookieCount: pendingCookies.length,
-  })
 
   if (!user) {
     // No session at all — redirect to login


### PR DESCRIPTION
## Summary
- Removed the temporary `[OAUTH-DIAG]` warn-level diagnostic logging from `app/auth/callback/route.ts`.
- Kept OAuth behavior unchanged: code exchange, error logging, `getUser()`, redirects, and cookie handling are untouched.

## OAuth verification
- Confirmed production Netlify deploy is on commit `e71a2493486a6750eb6470f58080554947b650de`, which contains the warn-level diagnostics from PR #49.
- Pulled recent production function logs with Netlify CLI for site `bossofclean2`; the CLI did not surface any `[OAUTH-DIAG]` lines in the last 60 minutes.
- Per the closeout instruction, proceeding because human real-world testing confirmed Google OAuth worked first-try on two production accounts.

## Validation
- `npm run build` passed with 0 TypeScript/compile errors.
- `rg "\\[OAUTH-DIAG\\]" app/auth/callback/route.ts` returns zero matches.
