### PR TITLE
feat(A6/DLD-514): rolling-window PII scrubber (catches split phone/email)

### DIFF
--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -5,7 +5,7 @@ import { sendNewMessageEmail } from '@/lib/email/new-message';
 import { rateLimitRoute, RATE_LIMITS } from '@/lib/middleware/rate-limit';
 import { createLogger } from '@/lib/utils/logger';
 import { notifyProNewMessage, notifyCustomerQuoteReceived, sendSMSIfEnabled } from '@/lib/sms/notifications';
-import { filterPII } from '@/lib/pii-filter';
+import { filterPII, filterPIIWithWindow } from '@/lib/pii-filter';
 
 const logger = createLogger({ file: 'api/messages/route' });
 
@@ -295,7 +295,28 @@ export async function POST(request: NextRequest) {
     }
     // Customers fall through with isUnlocked = false (no exceptions).
 
-    const piiResult = filterPII(content.trim(), isUnlocked)
+    // A6 (DLD-514): cumulative rolling-window scrubber. filterPII catches PII in
+    // this single message; filterPIIWithWindow also catches a phone/email split
+    // across the sender's recent messages (e.g. "407" / "461" / "6039"). We only
+    // pay for the extra read when the conversation is still locked.
+    let piiResult: ReturnType<typeof filterPII> = filterPII(content.trim(), isUnlocked)
+
+    if (!isUnlocked && !piiResult.blocked && actualConversationId) {
+      // Pull this sender's recent messages in this conversation (cumulative window).
+      const { data: recentRows } = await supabase
+        .from('messages')
+        .select('content, created_at')
+        .eq('conversation_id', actualConversationId)
+        .eq('sender_id', user.id)
+        .order('created_at', { ascending: false })
+        .limit(5)
+
+      const recentSenderMessages = (recentRows || [])
+        .map((r: { content: string | null }) => r.content || '')
+        .filter(Boolean)
+
+      piiResult = filterPIIWithWindow(recentSenderMessages, content.trim(), isUnlocked)
+    }
 
     if (piiResult.blocked) {
       // Audit log (service-role to bypass RLS).

--- a/lib/pii-filter.ts
+++ b/lib/pii-filter.ts
@@ -123,3 +123,83 @@ export async function hashContent(content: string): Promise<string> {
     return `len:${content.length}`
   }
 }
+
+/**
+ * Rolling-window (cumulative) PII scrubber — DLD-514 / A6.
+ *
+ * filterPII() catches PII inside a SINGLE message. But a determined sender can
+ * split a phone number across several messages, each individually under any
+ * threshold: "my number" / "is 407" / "461" / "6039". filterPIIWithWindow()
+ * closes that gap by concatenating the sender's recent messages in this
+ * conversation with the new one and re-checking the combined text — including
+ * a cumulative digit count that catches an assembled phone number.
+ *
+ * It also normalizes spelled-out digits ("four zero seven") and strips spacing
+ * tricks before counting, so "4 0 7 4 6 1 6 0 3 9" and "four oh seven..." are
+ * caught the same as "4074616039".
+ *
+ * Returns blocked:false immediately when isUnlocked is true.
+ */
+
+// Map spelled-out digits to numerals so "four zero seven" counts as digits.
+const WORD_DIGITS: Record<string, string> = {
+  zero: '0', oh: '0', one: '1', two: '2', three: '3', four: '4',
+  five: '5', six: '6', seven: '7', eight: '8', nine: '9',
+}
+
+function normalizeDigits(text: string): string {
+  // Replace spelled-out digit words with numerals.
+  const worded = text
+    .toLowerCase()
+    .replace(/\b(zero|oh|one|two|three|four|five|six|seven|eight|nine)\b/g, (m) => WORD_DIGITS[m] ?? m)
+  // Return digits only (collapses spaces/dashes/dots between them).
+  return worded.replace(/\D/g, '')
+}
+
+export interface WindowFilterResult extends PiiFilterResult {
+  cumulativeDigits?: number
+}
+
+/**
+ * @param recentSenderMessages text of the sender's last few messages in this
+ *   conversation (most-recent-first or any order — concatenation is order-free).
+ *   The caller pulls these (e.g. last 5 from the same sender in the same convo).
+ * @param newContent the message the sender is trying to send now.
+ * @param isUnlocked when true, the filter is off (paid lead).
+ */
+export function filterPIIWithWindow(
+  recentSenderMessages: string[],
+  newContent: string,
+  isUnlocked: boolean
+): WindowFilterResult {
+  if (isUnlocked) return { blocked: false }
+
+  // First, the new message alone must still pass the single-message filter.
+  const single = filterPII(newContent, isUnlocked)
+  if (single.blocked) return single
+
+  // Cumulative check: concatenate recent + new, then look for an assembled
+  // phone number that no single message revealed.
+  const combined = [...recentSenderMessages, newContent].join(' ')
+
+  // Re-run the standard patterns on the combined text (catches an email or
+  // phone formed only when fragments are joined).
+  const combinedHit = filterPII(combined, false)
+  if (combinedHit.blocked) {
+    return { ...combinedHit, patternHit: `windowed_${combinedHit.patternHit}` }
+  }
+
+  // Cumulative digit count — catches a 10-digit phone assembled across messages,
+  // including spelled-out and space-separated digits.
+  const digitCount = normalizeDigits(combined).length
+  if (digitCount >= 10) {
+    return {
+      blocked: true,
+      patternHit: 'windowed_phone_digits',
+      message: 'To share contact info, unlock this lead first.',
+      cumulativeDigits: digitCount,
+    }
+  }
+
+  return { blocked: false, cumulativeDigits: digitCount }
+}


### PR DESCRIPTION
## A6 — PII Wall, cumulative scrubber (DLD-514)

Closes the split-leak gap confirmed leaking on the live site during pro-dashboard testing: 'hey call me 407' + '4616 039' across two messages slipped past the single-message filter.

### What
`filterPIIWithWindow(recentSenderMessages, newContent, isUnlocked)` in lib/pii-filter.ts:
- single-message filterPII first (no regression)
- concatenates sender's recent messages + new, re-runs PII patterns on combined text
- cumulative digit count >= 10 = blocked; normalizes spelled-out digits ('four oh seven') and strips spacing ('4 0 7 ...')
- off when isUnlocked (paid lead)

Wired into app/api/messages/route.ts: locked convo + single-check passes -> pull sender's last 5 messages -> windowed check. Blocks log to pii_filter_log.

### Tested (9/9)
split phone across 3 msgs BLOCKED · spelled-out BLOCKED · space-separated BLOCKED · single full phone still BLOCKED · full email BLOCKED · normal chat ALLOWED ('what time works', '2 bed 3pm $125') · unlocked ALLOWED · accumulating normal info ALLOWED

Code-only, no DB change. Build 0 errors.

**Note:** text-filtering is the FALLBACK; the structural seal is A7/A8 (structured forms replace the free-text box — no field to leak into).