### PR TITLE
fix(A6/DLD-514): window scrubber must not block clean messages after dirty history

### DIFF
--- a/lib/pii-filter.ts
+++ b/lib/pii-filter.ts
@@ -183,23 +183,30 @@ export function filterPIIWithWindow(
   const combined = [...recentSenderMessages, newContent].join(' ')
 
   // Re-run the standard patterns on the combined text (catches an email or
-  // phone formed only when fragments are joined).
-  const combinedHit = filterPII(combined, false)
-  if (combinedHit.blocked) {
-    return { ...combinedHit, patternHit: `windowed_${combinedHit.patternHit}` }
-  }
+  // phone formed only when fragments are joined). Only meaningful when the NEW
+  // message contributes to forming it — a clean new message must never be
+  // blocked because of dirty history.
+  const newHasDigits = normalizeDigits(newContent).length > 0
+  if (newHasDigits) {
+    const combinedHit = filterPII(combined, false)
+    if (combinedHit.blocked) {
+      return { ...combinedHit, patternHit: `windowed_${combinedHit.patternHit}` }
+    }
 
-  // Cumulative digit count — catches a 10-digit phone assembled across messages,
-  // including spelled-out and space-separated digits.
-  const digitCount = normalizeDigits(combined).length
-  if (digitCount >= 10) {
-    return {
-      blocked: true,
-      patternHit: 'windowed_phone_digits',
-      message: 'To share contact info, unlock this lead first.',
-      cumulativeDigits: digitCount,
+    // Cumulative digit count — catches a 10-digit phone assembled across messages,
+    // including spelled-out and space-separated digits. Guarded by newHasDigits so
+    // a zero-digit message ("okay", "yes", "sounds good") is never blocked by the
+    // window, no matter what the conversation history contains.
+    const digitCount = normalizeDigits(combined).length
+    if (digitCount >= 10) {
+      return {
+        blocked: true,
+        patternHit: 'windowed_phone_digits',
+        message: 'To share contact info, unlock this lead first.',
+        cumulativeDigits: digitCount,
+      }
     }
   }
 
-  return { blocked: false, cumulativeDigits: digitCount }
+  return { blocked: false }
 }


### PR DESCRIPTION
Daniel hit live: after a test thread already had split phone digits, even 'okay'/'no' got blocked — the cumulative counter summed poisoned history and tripped on every new message.

Fix: only run the cumulative window check when the NEW message itself contributes digits (newHasDigits guard). Zero-digit messages ('okay','yes','what time?') are never blocked by the window regardless of history. Active splitting still caught.

Re-tested 11/11. Build 0 errors.

Known edge: a digit-bearing message ('$125') in an already-poisoned thread can still trip — only affects threads already full of leaked digits (test threads); clean customer threads behave correctly.