### PR TITLE
DLD-535 + DLD-537: message bubble wrap fix + Stripe dead-code cleanup

### DIFF
--- a/components/messaging/MessageThread.tsx
+++ b/components/messaging/MessageThread.tsx
@@ -87,9 +87,9 @@ export function MessageThread({ messages, isCustomer, currentUserId }: MessageTh
               </div>
             )}
             <div className={`flex ${isSent ? 'justify-end' : 'justify-start'} group`}>
-              <div className="relative">
+              <div className="relative max-w-[75%]">
                 <div
-                  className={`max-w-[75%] rounded-2xl px-4 py-2 ${
+                  className={`rounded-2xl px-4 py-2 ${
                     isSent
                       ? 'bg-blue-600 text-white rounded-br-md'
                       : 'bg-gray-100 text-gray-900 rounded-bl-md'

--- a/lib/stripe/invoices.ts
+++ b/lib/stripe/invoices.ts
@@ -187,18 +187,3 @@ export async function getUpcomingInvoice(
     return null;
   }
 }
-
-/**
- * Send invoice to customer via email
- */
-export async function sendInvoice(invoiceId: string): Promise<boolean> {
-  const stripe = getStripe();
-
-  try {
-    await stripe.invoices.sendInvoice(invoiceId);
-    return true;
-  } catch (error) {
-    logger.error('Error sending invoice:', {}, error);
-    return false;
-  }
-}

--- a/lib/stripe/mcp.ts
+++ b/lib/stripe/mcp.ts
@@ -145,30 +145,6 @@ export async function findCustomerByEmail(email: string): Promise<CustomerListRe
 }
 
 /**
- * Get available pricing information
- * Useful for debugging and validation
- */
-export async function listPrices(limit = 10) {
-  if (shouldUseMCP()) {
-    try {
-      // Try MCP first
-      const mcpStripeTool = getMCPStripeTool();
-      const mcpResult = await mcpStripeTool?.list_prices?.({ limit })
-      if (mcpResult) {
-        logger.debug('Prices retrieved via MCP')
-        return mcpResult
-      }
-    } catch (error) {
-      logger.warn('MCP price listing failed, falling back to SDK:', {}, error)
-    }
-  }
-
-  // SDK fallback
-  const stripe = getStripe()
-  return await stripe.prices.list({ limit })
-}
-
-/**
  * Check MCP connectivity (for debugging)
  */
 export async function testMCPConnection(): Promise<{ available: boolean; error?: string }> {


### PR DESCRIPTION
## What changed

### DLD-535 — message bubbles wrapping mid-word/mid-number
- `components/messaging/MessageThread.tsx`: moved `max-w-[75%]` off the inner bubble div and onto the `relative` wrapper. The percentage max-width was being placed on a child of a shrink-to-fit parent, creating a circular sizing constraint that forced character-level breaks (e.g. `$200` → `$2/00`). Now it resolves against the flex row.
- 2-line change. No color/corner/menu-positioning changes.

### DLD-537 — dead Stripe code cleanup (conservative variant)
- `lib/stripe/mcp.ts`: removed `listPrices` (zero external importers).
- `lib/stripe/invoices.ts`: removed `sendInvoice` (zero external importers).
- Conservative scope only — `testMCPConnection` and `getInvoice` (bonus dead-code findings) were intentionally **left in place**, deferred.
- All live exports (`createCheckoutSession`, `createBillingPortalSession`, `findCustomerByEmail`, `getCustomerInvoices`, `getUpcomingInvoice`, `InvoiceData`) untouched.

## Verification
- `npm run build` passed (exit 0, no TypeScript errors).
- `grep -rn "listPrices\|sendInvoice"` → zero matches after removal.
- No Stripe account, env var, or webhook changes. No effect on the DLD-531 `rk_live_` scope.

## Handoff reports
- `docs/handoffs/dld-535-message-bubble-wrap-bug.md`
- `docs/handoffs/dld-537-dead-stripe-code-cleanup.md`