### PR TITLE
DLD-515 / A7 Slice 1: make quote acceptance persist (service-role accept + decouple + idempotency + end_time clamp)

### DIFF
--- a/app/api/quotes/[id]/accept/route.ts
+++ b/app/api/quotes/[id]/accept/route.ts
@@ -49,64 +49,147 @@ export async function POST(
     return NextResponse.json({ error: 'No cleaner assigned to this quote' }, { status: 400 });
   }
 
-  // Update quote status to 'accepted'
-  const { error: updateError } = await supabase
+  // A7 Slice 1 — persist the accept with the service-role client.
+  //
+  // RLS on quote_requests intentionally restricts a customer's own UPDATE to
+  // status='pending' (live policy quote_requests_customers_update_own:
+  // USING customer_id = auth.uid() AND status = 'pending'). Once a pro responds
+  // the row is 'responded', so a customer-credentialed UPDATE matches ZERO rows
+  // — no error, phantom success, quote frozen. Ownership and the 'responded'
+  // precondition are already enforced above (lines 36-46); we re-assert BOTH in
+  // the .eq() filters here as a TOCTOU guard and require the row to actually
+  // change, so we can never report phantom success. RLS itself stays untouched.
+  const admin = createServiceRoleClient();
+  const nowIso = new Date().toISOString();
+  const { data: accepted, error: updateError } = await admin
     .from('quote_requests')
     .update({
       status: 'accepted',
-      updated_at: new Date().toISOString(),
+      accepted_at: nowIso,
+      updated_at: nowIso,
     })
-    .eq('id', quoteId);
+    .eq('id', quoteId)
+    .eq('customer_id', user.id)   // re-assert ownership at write time
+    .eq('status', 'responded')    // re-assert precondition (blocks double-accept)
+    .select('id')
+    .maybeSingle();
 
   if (updateError) {
     logger.error('Error accepting quote', { function: 'POST' }, updateError);
     return NextResponse.json({ error: 'Failed to accept quote' }, { status: 500 });
   }
 
-  // Create a booking from the accepted quote
+  if (!accepted) {
+    // Zero rows changed => the row was not (owner, 'responded') at write time,
+    // e.g. a concurrent accept already moved it. Surface it instead of pretending.
+    return NextResponse.json(
+      { error: 'Quote could not be accepted; it may have already been accepted.' },
+      { status: 409 }
+    );
+  }
+
+  // Create a booking from the accepted quote.
   const bookingDate = quote.service_date || quote.preferred_date || new Date().toISOString().split('T')[0];
   const startTime = quote.service_time || quote.preferred_time || '09:00';
   const estimatedHours = quote.estimated_hours || 3;
-  const endHour = parseInt(startTime.split(':')[0]) + estimatedHours;
-  const endTime = `${String(Math.min(endHour, 23)).padStart(2, '0')}:${startTime.split(':')[1] || '00'}`;
 
-  const { data: booking, error: bookingError } = await supabase
+  // end_time = start + estimatedHours, clamped so the bookings CHECK
+  // valid_booking_time (end_time > start_time) can never fail on the equal edge.
+  // Naively capping the hour at 23 while keeping the start minutes can yield
+  // end_time === start_time (e.g. start 23:30 -> 23:30). Compute in minutes,
+  // cap at 23:59, and if that still isn't strictly after start, fall back to
+  // 23:59 / push start back by a minute so end > start always holds.
+  const [startH, startM] = startTime.split(':').map((n) => parseInt(n, 10) || 0);
+  const startTotal = startH * 60 + startM;
+  const DAY_MAX = 23 * 60 + 59; // 23:59
+  let endTotal = Math.min(startTotal + estimatedHours * 60, DAY_MAX);
+  let safeStartTotal = startTotal;
+  if (endTotal <= startTotal) {
+    // start is so late the window collapses; guarantee a 1-minute slot at EOD.
+    endTotal = DAY_MAX;
+    safeStartTotal = Math.min(startTotal, DAY_MAX - 1);
+  }
+  const fmt = (t: number) =>
+    `${String(Math.floor(t / 60)).padStart(2, '0')}:${String(t % 60).padStart(2, '0')}`;
+  const safeStartTime = fmt(safeStartTotal);
+  const endTime = fmt(endTotal);
+
+  // Slice 1b — idempotency: one booking per accepted quote. bookings has no
+  // quote_request_id column (no schema change in this slice), so we key off the
+  // deterministic natural tuple this quote produces. A retry of the same accept
+  // yields identical values and is a no-op instead of a duplicate booking.
+  // CAVEAT: two *distinct* quotes with identical cleaner+customer+date+start
+  // would also collapse to one booking — rare; the clean fix is a
+  // bookings.quote_request_id FK + unique index (follow-up, schema-touching).
+  const { data: existingBooking } = await admin
     .from('bookings')
-    .insert({
-      cleaner_id: quote.cleaner_id,
-      customer_id: user.id,
-      service_type: quote.service_type || 'residential',
-      property_type: quote.property_type || 'house',
-      bedrooms: 0,
-      bathrooms: 0,
-      booking_date: bookingDate,
-      start_time: startTime,
-      end_time: endTime,
-      zip_code: quote.zip_code || '',
-      address: quote.address || quote.city || '',
-      special_instructions: quote.description || quote.special_instructions || null,
-      estimated_price: quote.quoted_price || 0,
-      estimated_hours: estimatedHours,
-      status: 'confirmed',
-    })
     .select('id')
-    .single();
+    .eq('cleaner_id', quote.cleaner_id)
+    .eq('customer_id', user.id)
+    .eq('booking_date', bookingDate)
+    .eq('start_time', safeStartTime)
+    .maybeSingle();
 
-  if (bookingError) {
-    logger.error('Error creating booking from quote', { function: 'POST' }, bookingError);
-    // Revert quote status on booking failure
-    await supabase
-      .from('quote_requests')
-      .update({ status: 'responded', updated_at: new Date().toISOString() })
-      .eq('id', quoteId);
-
-    return NextResponse.json({ error: 'Failed to create booking' }, { status: 500 });
+  let booking = existingBooking;
+  let bookingError = null;
+  if (!existingBooking) {
+    const insertRes = await admin
+      .from('bookings')
+      .insert({
+        cleaner_id: quote.cleaner_id,
+        customer_id: user.id,
+        service_type: quote.service_type || 'residential',
+        property_type: quote.property_type || 'house',
+        bedrooms: 0,
+        bathrooms: 0,
+        booking_date: bookingDate,
+        start_time: safeStartTime,
+        end_time: endTime,
+        zip_code: quote.zip_code || '',
+        address: quote.address || quote.city || '',
+        special_instructions: quote.description || quote.special_requests || null,
+        estimated_price: quote.quoted_price || 0,
+        estimated_hours: estimatedHours,
+        status: 'confirmed',
+      })
+      .select('id')
+      .single();
+    booking = insertRes.data;
+    bookingError = insertRes.error;
   }
 
-  // Create notification for the cleaner
+  if (bookingError) {
+    // §3 DECOUPLE — the accept is already durably committed above. A booking
+    // hiccup must NEVER silently revert the acceptance (that was the old bug:
+    // a failed insert reverted status to 'responded'). Log, and return a
+    // non-fatal success so the quote stays 'accepted'.
+    //
+    // Distinguish the common, actionable case — a stale quote whose
+    // service_date has passed (bookings CHECK future_booking:
+    // booking_date >= CURRENT_DATE, Postgres error 23514) — from generic
+    // failures, so the UI can tell the pro to pick a new date.
+    const isPastDate = (bookingError as { code?: string }).code === '23514';
+    logger.error('Quote accepted but booking creation failed', {
+      function: 'POST',
+      quoteId,
+      isPastDate,
+    }, bookingError);
+
+    return NextResponse.json({
+      success: true,
+      bookingId: null,
+      bookingCreated: false,
+      warning: isPastDate
+        ? 'Quote accepted, but a booking was not created because the service date has passed — pick a new date.'
+        : 'Quote accepted, but the booking could not be created automatically.',
+      message: 'Quote accepted.',
+    });
+  }
+
+  // Booking exists (created now or already present from a prior accept). Reuse
+  // the `admin` client from the accept write — no second service client needed.
   try {
-    const adminSupabase = createServiceRoleClient();
-    await adminSupabase.from('notifications').insert({
+    await admin.from('notifications').insert({
       user_id: quote.cleaner.user_id,
       type: 'quote_accepted',
       title: 'Quote Accepted!',
@@ -117,16 +200,17 @@ export async function POST(
     logger.error('Failed to create cleaner notification', { function: 'POST' }, notifErr);
   }
 
-  logger.info('Quote accepted and booking created', {
+  logger.info('Quote accepted and booking confirmed', {
     function: 'POST',
     quoteId,
-    bookingId: booking.id,
+    bookingId: booking?.id ?? null,
     cleanerId: quote.cleaner_id,
   });
 
   return NextResponse.json({
     success: true,
-    bookingId: booking.id,
+    bookingId: booking?.id ?? null,
+    bookingCreated: true,
     message: 'Quote accepted and booking confirmed!',
   });
 }


### PR DESCRIPTION
**Draft — do not merge from CI. Daniel's keyboard for the merge.**

## Root cause (verified live, read-only, against BOC DB `jisjxdsrflheosvodoxk`)
Customer "Accept Quote" was a **phantom success**. The live RLS policy `quote_requests_customers_update_own` is:

```
USING (customer_id = auth.uid() AND status = 'pending')
```

Once a pro responds, the row is `status='responded'`, so a customer-credentialed `UPDATE` matches **zero rows** — Postgres reports success with 0 rows affected, no error. Result: the API returned success, `status` stayed frozen at `responded`, and `accepted_at` was never written (nothing wrote it anyway). A booking *was* still created (separate INSERT policy), so the UX looked half-done.

## The four changes (all in `app/api/quotes/[id]/accept/route.ts` — one file, no schema, no RLS, no migration)

1. **Accept UPDATE via service-role (approach b).** Ownership (`customer_id === user.id`) and the `status==='responded'` precondition are already enforced in-route; the UPDATE now runs on the service-role client (which bypasses RLS) with both re-asserted as `.eq()` filters (TOCTOU guard), writes `accepted_at = now()`, and returns **409** if zero rows change. No phantom success. **RLS is untouched** — the customer's own direct write privileges are exactly as tight as before; the privileged write only happens behind a server route that already proved ownership + correct prior state.

2. **Decouple booking failure from acceptance (§3).** Previously a failed booking INSERT *reverted* `status` back to `responded` — the silent-undo path. Now the accept is durably committed first; a booking failure returns a **non-fatal success + warning** instead of reverting. Past-date quotes (bookings CHECK `future_booking`, SQLSTATE `23514`) get a **specific** "service date has passed — pick a new date" message vs. a generic failure.

3. **Idempotency (Slice 1b).** One booking per accepted quote, keyed off the deterministic natural tuple `(cleaner_id, customer_id, booking_date, start_time)` — `bookings` has no `quote_request_id` column and this slice adds no schema. A retry of the same accept is a no-op, never double-books.

4. **end_time clamp.** Computed in minutes, capped at 23:59, guaranteed `end_time > start_time` so the bookings CHECK `valid_booking_time` can't fail on the equal edge (e.g. start `23:30`).

Also corrected the special-instructions source: `quote.special_requests` (real column) — was `quote.special_instructions`, which does not exist on `quote_requests` (silently always-null before).

## Scope boundary — what this does NOT do
- **NO payment gate.** Accepting still auto-creates a `'confirmed'` booking. The **pro-pays-for-lead** flow (insert `lead_acceptances` → Stripe lead-fee charge → PII reveal) is **out of scope** — that's **A9 / DLD-517**. This slice only makes the accept *persist correctly*.
- **Idempotency is a composite-key stopgap.** Caveat: two *distinct* quotes with identical `cleaner+customer+date+start` would collapse to one booking (rare). The clean fix is a `bookings.quote_request_id` FK + unique index — **schema-touching follow-up**, intentionally not in this slice.
- **Schema drift left as-is:** live `bookings.service_type` is TEXT (schema file declares the enum). Noted, not fixed here.

## Verification (Node 20)
- `npm run lint`: zero findings on the changed file; totals unchanged from `main` baseline (5 pre-existing out-of-scope errors / 17 warnings, none new).
- `npm run build`: pass. `/api/quotes/[id]/accept` compiles.

## Still required before this is "done" (cannot be done from the agent session)
- (a) **Browser E2E** — customer accepts a responded quote → success, no phantom. *(Daniel's browser.)*
- (b) **Data confirmation** — quote row `status='accepted'` AND `accepted_at` populated (was NULL). *(chat-Claude's Supabase read.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)