### PR TITLE
DLD-517 A9 slice 2: pro lead-unlock UI + server-side hire gate

### DIFF
--- a/app/api/leads/[quoteId]/unlock/route.ts
+++ b/app/api/leads/[quoteId]/unlock/route.ts
@@ -55,6 +55,25 @@ export async function POST(
     );
   }
 
+  // 2a-bis. SERVER-SIDE HIRE GATE (A9 Slice 2 / DLD-517): the $30 prompt fires
+  //         only AFTER the customer confirms the hire, not on mere acceptance.
+  //         Require a hire_confirmations row for (quote, this pro) before we
+  //         create any lead_acceptances row or Stripe session. RLS policy
+  //         "Pros can view confirmations for their leads" scopes this read.
+  //         hire_confirmations.cleaner_id = pros.id (set from quote.cleaner_id).
+  const { data: hire } = await supabase
+    .from('hire_confirmations')
+    .select('id')
+    .eq('quote_request_id', quoteId)
+    .eq('cleaner_id', pro.id)
+    .maybeSingle();
+  if (!hire) {
+    return NextResponse.json(
+      { error: 'Lead not yet confirmed by customer.' },
+      { status: 403 }
+    );
+  }
+
   // 2b. Duplicate-unlock guard — return any existing pending/captured row instead
   //     of minting a second (no double-charge, no orphan rows).
   const { data: existing } = await supabase
@@ -123,8 +142,8 @@ export async function POST(
           },
         },
       ],
-      success_url: `${siteUrl}/dashboard/pro/quote-requests?unlocked=${quoteId}`,
-      cancel_url: `${siteUrl}/dashboard/pro/quote-requests?canceled=${quoteId}`,
+      success_url: `${siteUrl}/dashboard/pro/leads?unlocked=${quoteId}`,
+      cancel_url: `${siteUrl}/dashboard/pro/leads?canceled=${quoteId}`,
       customer_email: user.email ?? undefined,
       metadata: {
         type: 'lead_unlock', // REQUIRED — webhook gate

--- a/app/dashboard/pro/layout.tsx
+++ b/app/dashboard/pro/layout.tsx
@@ -4,7 +4,7 @@ import { DashboardSidebar, type SidebarLink } from '@/components/dashboard/Dashb
 import {
   LayoutDashboard, User, FileText, Calendar,
   DollarSign, Clock, Images, Star, MapPin, CreditCard, Bell, MessageSquare,
-  ShieldCheck,
+  ShieldCheck, Lock,
 } from 'lucide-react';
 import { usePendingDocumentActions } from '@/lib/hooks/usePendingDocumentActions';
 import { useProSidebarCounts } from '@/lib/hooks/useProSidebarCounts';
@@ -12,7 +12,7 @@ import { useProSidebarCounts } from '@/lib/hooks/useProSidebarCounts';
 export default function ProDashboardLayout({ children }: { children: React.ReactNode }) {
   const { rejectedCount } = usePendingDocumentActions();
   // DLD-507: unread badges on Messages, Notifications, and Leads.
-  const { unreadMessages, unreadNotifications, pendingLeads } = useProSidebarCounts();
+  const { unreadMessages, unreadNotifications, pendingLeads, actionNeededLeads } = useProSidebarCounts();
 
   const proLinks: SidebarLink[] = [
     { href: '/dashboard/pro', label: 'Overview', icon: LayoutDashboard },
@@ -21,6 +21,7 @@ export default function ProDashboardLayout({ children }: { children: React.React
     { href: '/dashboard/pro/notifications', label: 'Notifications', icon: Bell, badge: unreadNotifications },
     { href: '/dashboard/messages', label: 'Messages', icon: MessageSquare, badge: unreadMessages },
     { href: '/dashboard/pro/quote-requests', label: 'Quote Requests', icon: FileText, badge: pendingLeads },
+    { href: '/dashboard/pro/leads', label: 'Action Needed', icon: Lock, badge: actionNeededLeads },
     { href: '/dashboard/pro/bookings', label: 'Bookings', icon: Calendar },
     { href: '/dashboard/pro/earnings', label: 'Earnings', icon: DollarSign },
     { href: '/dashboard/pro/availability', label: 'Availability', icon: Clock },

--- a/app/dashboard/pro/leads/actions.ts
+++ b/app/dashboard/pro/leads/actions.ts
@@ -1,0 +1,142 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { createLogger } from '@/lib/utils/logger';
+
+const logger = createLogger({ file: 'dashboard/pro/leads/actions' });
+
+/**
+ * A9 Slice 2 (DLD-517): a confirmed-hire lead the pro still needs to pay $30 to
+ * unlock. PII-safe — first name + city/ZIP only, sourced from the
+ * quote_requests_pro_view security-barrier view (no email/phone/street address).
+ */
+export interface HiredLead {
+  /** quote_requests.id — the path param for POST /api/leads/{id}/unlock */
+  id: string;
+  service_type: string;
+  city: string;
+  zip_code: string;
+  customer_first_name: string | null;
+  /** the price this pro quoted and the customer accepted */
+  quoted_price: number | null;
+  /**
+   * 'pending' = a lead_acceptances row exists with an in-flight checkout →
+   * show "Resume payment". null = no acceptance yet → show "Unlock for $30".
+   * (captured leads are filtered out of this list entirely.)
+   */
+  acceptanceStatus: 'pending' | null;
+}
+
+/**
+ * Eligible = a lead the pro was HIRED for and has NOT yet unlocked:
+ *   quote_requests where cleaner_id = pros.id AND status = 'accepted'
+ *   INNER hire_confirmations on (quote_request_id, cleaner_id)   ← the hire trigger
+ *   ANTI-JOIN captured lead_acceptances                          ← hide unlocked
+ *   left-read pending lead_acceptances                           ← "Resume payment"
+ *
+ * Uses the pro's own user-client throughout (RLS already scopes every read:
+ * "Pros can view confirmations for their leads", "Pros can view own unlocks").
+ */
+export async function getHiredLeadsAwaitingUnlock(): Promise<{
+  success: boolean;
+  leads?: HiredLead[];
+  error?: string;
+}> {
+  const supabase = await createClient();
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'Not authenticated' };
+    }
+
+    const { data: pro } = await supabase
+      .from('pros')
+      .select('id, approval_status')
+      .eq('user_id', user.id)
+      .single();
+
+    if (!pro) {
+      return { success: false, error: 'Cleaner profile not found' };
+    }
+    if (pro.approval_status !== 'approved') {
+      return { success: false, error: 'Your account must be approved to view leads' };
+    }
+
+    // 1. Accepted quotes claimed by this pro, read PII-safe from the view.
+    type RawRow = {
+      id: string;
+      service_type: string;
+      city: string;
+      zip_code: string;
+      quoted_price: number | null;
+      customer_first_name: string | null;
+    };
+    const { data: accepted, error: acceptedErr } = await supabase
+      .from('quote_requests_pro_view')
+      .select('id, service_type, city, zip_code, quoted_price, customer_first_name')
+      .eq('cleaner_id', pro.id)
+      .eq('status', 'accepted')
+      .order('created_at', { ascending: false })
+      .limit(100)
+      .returns<RawRow[]>();
+
+    if (acceptedErr) {
+      logger.error('Error fetching accepted quotes', { function: 'getHiredLeadsAwaitingUnlock' }, acceptedErr);
+      return { success: false, error: 'Failed to load leads' };
+    }
+
+    const acceptedIds = (accepted || []).map((q) => q.id);
+    if (acceptedIds.length === 0) {
+      return { success: true, leads: [] };
+    }
+
+    // 2. INNER join hire_confirmations (the customer actually confirmed the hire)
+    //    and 3. read lead_acceptances to anti-join 'captured' and surface 'pending'.
+    const [hires, acceptances] = await Promise.all([
+      supabase
+        .from('hire_confirmations')
+        .select('quote_request_id')
+        .eq('cleaner_id', pro.id)
+        .in('quote_request_id', acceptedIds),
+      supabase
+        .from('lead_acceptances')
+        .select('quote_request_id, status')
+        .eq('cleaner_id', pro.id)
+        .in('quote_request_id', acceptedIds)
+        .in('status', ['pending', 'captured']),
+    ]);
+
+    if (hires.error) {
+      logger.error('Error fetching hire confirmations', { function: 'getHiredLeadsAwaitingUnlock' }, hires.error);
+      return { success: false, error: 'Failed to load leads' };
+    }
+    if (acceptances.error) {
+      logger.error('Error fetching lead acceptances', { function: 'getHiredLeadsAwaitingUnlock' }, acceptances.error);
+      return { success: false, error: 'Failed to load leads' };
+    }
+
+    const hiredSet = new Set((hires.data || []).map((h) => h.quote_request_id));
+    const acceptanceByQuote = new Map<string, 'pending' | 'captured'>();
+    for (const a of acceptances.data || []) {
+      acceptanceByQuote.set(a.quote_request_id, a.status as 'pending' | 'captured');
+    }
+
+    const leads: HiredLead[] = (accepted || [])
+      .filter((q) => hiredSet.has(q.id) && acceptanceByQuote.get(q.id) !== 'captured')
+      .map((q) => ({
+        id: q.id,
+        service_type: q.service_type,
+        city: q.city,
+        zip_code: q.zip_code,
+        customer_first_name: q.customer_first_name,
+        quoted_price: q.quoted_price,
+        acceptanceStatus: acceptanceByQuote.get(q.id) === 'pending' ? 'pending' : null,
+      }));
+
+    return { success: true, leads };
+  } catch (error) {
+    logger.error('Error in getHiredLeadsAwaitingUnlock', { function: 'getHiredLeadsAwaitingUnlock' }, error);
+    return { success: false, error: 'An unexpected error occurred' };
+  }
+}

--- a/app/dashboard/pro/leads/loading.tsx
+++ b/app/dashboard/pro/leads/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function HiredLeadsLoading() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header skeleton */}
+      <div className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center py-6 gap-4">
+            <Skeleton className="h-9 w-9 rounded-full" />
+            <div className="space-y-2">
+              <Skeleton className="h-7 w-56" />
+              <Skeleton className="h-4 w-72" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Lead card skeletons */}
+        <div className="space-y-4">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="bg-white rounded-lg shadow-sm p-5 sm:p-6 border-l-4 border-gray-200">
+              <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+                <div className="flex-1 space-y-3">
+                  <Skeleton className="h-5 w-32" />
+                  <Skeleton className="h-6 w-40" />
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-3 w-64" />
+                </div>
+                <Skeleton className="h-10 w-full lg:w-64 rounded-md" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/pro/leads/page.tsx
+++ b/app/dashboard/pro/leads/page.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/lib/context/AuthContext';
+import { ProtectedRoute } from '@/lib/auth/protected-route';
+import {
+  ArrowLeft,
+  MapPin,
+  DollarSign,
+  Lock,
+  Loader2,
+  Inbox,
+  CheckCircle,
+  XCircle,
+  PartyPopper,
+} from 'lucide-react';
+import Link from 'next/link';
+import { getHiredLeadsAwaitingUnlock, type HiredLead } from './actions';
+
+export default function HiredLeadsPage() {
+  const { user } = useAuth();
+  const [leads, setLeads] = useState<HiredLead[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // quoteId currently being sent to the unlock API (button spinner + lock)
+  const [unlockingId, setUnlockingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user) loadLeads();
+  }, [user]);
+
+  const loadLeads = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const result = await getHiredLeadsAwaitingUnlock();
+      if (result.success) {
+        setLeads(result.leads || []);
+      } else {
+        setError(result.error || 'Failed to load leads');
+      }
+    } catch {
+      setError('An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUnlock = async (quoteId: string) => {
+    setUnlockingId(quoteId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/leads/${quoteId}/unlock`, { method: 'POST' });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || 'Could not start checkout. Please try again.');
+        setUnlockingId(null);
+        return;
+      }
+
+      // Already paid (e.g. webhook landed between load and click) — just refresh.
+      if (data.alreadyUnlocked) {
+        await loadLeads();
+        setUnlockingId(null);
+        return;
+      }
+
+      // Fresh session or resumed in-flight checkout: hand the browser to Stripe.
+      if (data.url) {
+        window.location.href = data.url;
+        return; // keep the spinner — we're navigating away
+      }
+
+      setError('Could not start checkout. Please try again.');
+      setUnlockingId(null);
+    } catch {
+      setError('An unexpected error occurred. Please try again.');
+      setUnlockingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <ProtectedRoute requireRole="cleaner">
+        <div className="min-h-screen flex items-center justify-center bg-gray-50">
+          <div className="text-center">
+            <Loader2 className="h-12 w-12 text-blue-600 mx-auto mb-4 animate-spin" />
+            <p className="text-gray-600">Loading your hired leads...</p>
+          </div>
+        </div>
+      </ProtectedRoute>
+    );
+  }
+
+  return (
+    <ProtectedRoute requireRole="cleaner">
+      <div className="min-h-screen bg-gray-50">
+        {/* Header */}
+        <div className="bg-white shadow-sm border-b">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center py-6">
+              <Link
+                href="/dashboard/pro"
+                className="mr-4 p-2 hover:bg-gray-100 rounded-full transition"
+              >
+                <ArrowLeft className="h-5 w-5 text-gray-600" />
+              </Link>
+              <div>
+                <h1 className="text-2xl font-bold text-gray-900">Hired — Action Needed</h1>
+                <p className="text-sm text-gray-600 mt-1">
+                  Customers who confirmed your hire. Unlock their contact info to get to work.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          {error && (
+            <div className="rounded-lg p-4 mb-6 flex items-center gap-3 bg-red-50 border border-red-200 text-red-800">
+              <XCircle className="h-5 w-5 text-red-600 flex-shrink-0" />
+              <span className="text-sm font-medium">{error}</span>
+              <button onClick={() => setError(null)} className="ml-auto text-red-400 hover:text-red-600">&times;</button>
+            </div>
+          )}
+
+          {leads.length === 0 ? (
+            <div className="bg-white rounded-lg shadow-sm p-12 text-center">
+              <Inbox className="h-16 w-16 text-gray-400 mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-gray-900 mb-2">No leads need action right now</h3>
+              <p className="text-gray-600 max-w-md mx-auto">
+                When a customer confirms they want to hire you, the lead shows up here to unlock.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {leads.map((lead) => {
+                const isUnlocking = unlockingId === lead.id;
+                const isPending = lead.acceptanceStatus === 'pending';
+                return (
+                  <div
+                    key={lead.id}
+                    className="bg-white rounded-lg shadow-sm hover:shadow-md transition border-l-4 border-green-400"
+                  >
+                    <div className="p-5 sm:p-6">
+                      <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+                        {/* Left: lead details (PII-safe — first name + city/ZIP only) */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex flex-wrap items-center gap-2 mb-3">
+                            <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-medium rounded">
+                              {(lead.service_type || '').replace(/_/g, ' ')}
+                            </span>
+                            <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700">
+                              <PartyPopper className="h-3 w-3" />
+                              Hired
+                            </span>
+                          </div>
+
+                          <p className="text-lg font-semibold text-gray-900 mb-2">
+                            {lead.customer_first_name || 'Customer'}
+                          </p>
+
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-gray-600">
+                            <div className="flex items-center gap-2">
+                              <MapPin className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                              <span>{lead.city}, {lead.zip_code}</span>
+                            </div>
+                            {lead.quoted_price != null && (
+                              <div className="flex items-center gap-2">
+                                <DollarSign className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                                <span>Accepted at ${lead.quoted_price}</span>
+                              </div>
+                            )}
+                          </div>
+
+                          <p className="mt-3 text-xs text-gray-500">
+                            Full name, email, phone, and address unlock after the $30 lead fee.
+                          </p>
+                        </div>
+
+                        {/* Right: unlock CTA */}
+                        <div className="flex flex-col gap-2 lg:w-64 flex-shrink-0">
+                          <button
+                            onClick={() => handleUnlock(lead.id)}
+                            disabled={isUnlocking}
+                            className="flex items-center justify-center gap-2 bg-green-600 text-white px-4 py-2.5 rounded-md text-sm font-medium hover:bg-green-700 disabled:bg-green-400 transition"
+                          >
+                            {isUnlocking ? (
+                              <><Loader2 className="h-4 w-4 animate-spin" /> Starting checkout...</>
+                            ) : isPending ? (
+                              <><CheckCircle className="h-4 w-4" /> Resume payment</>
+                            ) : (
+                              <><Lock className="h-4 w-4" /> Unlock contact — $30</>
+                            )}
+                          </button>
+                          {isPending && (
+                            <p className="text-xs text-gray-500 text-center">
+                              You have a checkout in progress for this lead.
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/lib/hooks/useProSidebarCounts.ts
+++ b/lib/hooks/useProSidebarCounts.ts
@@ -7,6 +7,7 @@ interface UseProSidebarCountsResult {
   unreadMessages: number;
   unreadNotifications: number;
   pendingLeads: number;
+  actionNeededLeads: number;
   isLoading: boolean;
   error: Error | null;
 }
@@ -23,6 +24,10 @@ const POLL_INTERVAL_MS = 30_000;
  *   `read = false`.
  * - pendingLeads: marketplace + assigned quote_requests for this pro
  *   in `pending` status.
+ * - actionNeededLeads (DLD-517 A9 Slice 2): accepted quotes for this pro that
+ *   the customer has confirmed-hired (hire_confirmations row) but the pro has
+ *   not yet unlocked (no `captured` lead_acceptances). Powers the
+ *   "Action Needed" sidebar badge → /dashboard/pro/leads.
  *
  * Polls every 30s and re-fetches on window focus. Returns zeros
  * (no badge) for unauthenticated users, non-pro roles, or any error
@@ -32,6 +37,7 @@ export function useProSidebarCounts(): UseProSidebarCountsResult {
   const [unreadMessages, setUnreadMessages] = useState(0);
   const [unreadNotifications, setUnreadNotifications] = useState(0);
   const [pendingLeads, setPendingLeads] = useState(0);
+  const [actionNeededLeads, setActionNeededLeads] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -50,6 +56,7 @@ export function useProSidebarCounts(): UseProSidebarCountsResult {
           setUnreadMessages(0);
           setUnreadNotifications(0);
           setPendingLeads(0);
+          setActionNeededLeads(0);
           setError(null);
           return;
         }
@@ -66,6 +73,7 @@ export function useProSidebarCounts(): UseProSidebarCountsResult {
           setUnreadMessages(0);
           setUnreadNotifications(0);
           setPendingLeads(0);
+          setActionNeededLeads(0);
           setError(null);
           return;
         }
@@ -92,6 +100,48 @@ export function useProSidebarCounts(): UseProSidebarCountsResult {
         setUnreadMessages(messages.count ?? 0);
         setUnreadNotifications(notifications.count ?? 0);
         setPendingLeads(leads.count ?? 0);
+
+        // Action Needed: accepted quotes this pro was confirmed-hired for and
+        // has not yet unlocked (no `captured` lead_acceptances). Mirrors the
+        // getHiredLeadsAwaitingUnlock server action's eligibility.
+        const { data: accepted } = await supabase
+          .from('quote_requests')
+          .select('id')
+          .eq('cleaner_id', pro.id)
+          .eq('status', 'accepted')
+          .limit(100);
+        if (cancelled) return;
+
+        const acceptedIds = ((accepted || []) as { id: string }[]).map((q) => q.id);
+        if (acceptedIds.length === 0) {
+          setActionNeededLeads(0);
+        } else {
+          const [hires, captured] = await Promise.all([
+            supabase
+              .from('hire_confirmations')
+              .select('quote_request_id')
+              .eq('cleaner_id', pro.id)
+              .in('quote_request_id', acceptedIds),
+            supabase
+              .from('lead_acceptances')
+              .select('quote_request_id')
+              .eq('cleaner_id', pro.id)
+              .eq('status', 'captured')
+              .in('quote_request_id', acceptedIds),
+          ]);
+          if (cancelled) return;
+
+          const hiredSet = new Set(
+            ((hires.data || []) as { quote_request_id: string }[]).map((h) => h.quote_request_id)
+          );
+          const capturedSet = new Set(
+            ((captured.data || []) as { quote_request_id: string }[]).map((c) => c.quote_request_id)
+          );
+          setActionNeededLeads(
+            acceptedIds.filter((id) => hiredSet.has(id) && !capturedSet.has(id)).length
+          );
+        }
+
         setError(null);
       } catch (err) {
         if (cancelled) return;
@@ -100,6 +150,7 @@ export function useProSidebarCounts(): UseProSidebarCountsResult {
         setUnreadMessages(0);
         setUnreadNotifications(0);
         setPendingLeads(0);
+        setActionNeededLeads(0);
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -116,5 +167,5 @@ export function useProSidebarCounts(): UseProSidebarCountsResult {
     };
   }, []);
 
-  return { unreadMessages, unreadNotifications, pendingLeads, isLoading, error };
+  return { unreadMessages, unreadNotifications, pendingLeads, actionNeededLeads, isLoading, error };
 }


### PR DESCRIPTION
Wires the existing $30 lead-unlock backend to a pro-facing surface, plus a server-side hire gate. Before this, a pro hired by a customer saw nothing actionable and the pay step never fired (accepted quote + hire_confirmation but zero lead_acceptances).

## Files changed (6)
- `app/dashboard/pro/leads/actions.ts` (new) — `getHiredLeadsAwaitingUnlock()`: pros user-client (RLS-scoped); accepted quotes for this pro INNER `hire_confirmations`, anti-join `captured` `lead_acceptances`, left-read `pending` for resume state. PII-safe via `quote_requests_pro_view` (first name + city/ZIP only).
- `app/dashboard/pro/leads/page.tsx` (new) — "Hired — Action Needed" list; CTA POSTs the empty-body unlock request and redirects to the returned Stripe Checkout URL; pending rows show "Resume payment"; captured excluded.
- `app/dashboard/pro/leads/loading.tsx` (new) — skeleton matching the existing dashboard pattern.
- `app/dashboard/pro/layout.tsx` (edit) — one "Action Needed" sidebar link + count badge.
- `lib/hooks/useProSidebarCounts.ts` (edit) — `actionNeededLeads` count mirroring the action's eligibility.
- `app/api/leads/[quoteId]/unlock/route.ts` (edit, 2 only) — (a) server-side hire gate: 403 "Lead not yet confirmed by customer." unless a `hire_confirmations` row exists for (quote, pro), before any row/Stripe session is created; (b) `success_url`/`cancel_url` repointed to `/dashboard/pro/leads`.

## Verification
- `tsc --noEmit`: clean on all 6 files.
- `npm run lint`: no findings on the 6 files.
- `npm run build`: fails locally due to a pre-existing Node v25 + Turbopack incompatibility (fails identically on pristine `origin/main`), not this branch. Separate ticket to pin Node 20/22 LTS.

Do not merge / deploy without review.