### PR TITLE
docs(audit): platform audit delta 2026-07 (read-only)

### DIFF
--- a/docs/AUDIT_2026-07.md
+++ b/docs/AUDIT_2026-07.md
@@ -1,0 +1,114 @@
+# Boss of Clean — Platform Audit DELTA (2026-07-02)
+
+**Read-only.** No files written, no commits, no migrations, no Stripe/Supabase calls. Baseline: `docs/AUDIT_2026-06.md` (@ `98fb7be`). Current: `main` @ `21bb870`, active branch `feat/lead-handoff-webhook` @ `fc1d049` (1 commit ahead of main). Method: direct read of the money path + three parallel read-only sweeps (security delta, traffic readiness, hygiene). Live RLS/Stripe dashboard state was **not** queried — items depending on it are marked *verify-live*.
+
+## Delta summary
+
+Since June, **one class of finding was genuinely fixed** (the DLD-452 ghost columns) and **the lead-unlock happy path got materially safer** (server-side hire gate, insert-first/link-before-return, idempotent payments insert). **Almost everything else from June is still open**, and the audit surfaced **one new CRITICAL**: the money-path capture is split across two branches — `main` takes the $30 but records no payment and delivers no contact.
+
+| Bucket | Count |
+|---|---|
+| Fixed / resolved | 3 (ghost columns, Slice-1 link race, hire-gate added) |
+| Still open (carried from June) | 11 |
+| New this audit | 6 |
+
+---
+
+## 1. SECURITY
+
+### CRITICAL
+
+**NEW-01 · Money-path split brain — `main` captures the $30 but records no payment and releases no contact.**
+`main`'s webhook (`app/api/webhooks/stripe/route.ts:64-105` on `main`) flips `lead_acceptances` `pending→captured` and writes `stripe_payment_intent_id`, but does **not** insert a `payments` row and does **not** send the contact email. Those two behaviors (the `payments` insert + `sendLeadContactEmail`) exist **only** on `feat/lead-handoff-webhook` (`fc1d049`, adds `lib/email/lead-unlock.ts` + 121 lines to the webhook) — `lib/email/lead-unlock.ts` is **absent from `main`**. Net on `main` today: a pro pays $30 → the lead flips captured and **disappears** from `/dashboard/pro/leads` (captured rows are anti-joined out, `app/dashboard/pro/leads/actions.ts:126`) → **no `payments` row, no contact delivered anywhere.** Money in, nothing recorded, nothing delivered. → **This is the `feat/lead-handoff-webhook` vs `main` status: the branch is the fix for this, still unmerged.**
+
+**SCH-01 · `claim_lead_with_credit` — STILL OPEN (unchanged).**
+`supabase/17-lead-credits.sql:12-95`, still `SECURITY DEFINER` (line 95), no internal `auth.uid()` check, no `REVOKE FROM PUBLIC`. No DROP migration anywhere; migrations end at `20260525105050_dld513`. **No "Phase C" role-change guard exists** — there is no trigger or policy on `users.role` anywhere in code or migrations. Anon-key-callable via PostgREST.
+
+**SEC-01 · Messaging API hands pros full name + email pre-payment — STILL OPEN.**
+`app/api/messages/route.ts:61` and `app/api/messages/[conversationId]/route.ts:34` both still `select('customer:users(id, full_name, email)')` and return it to pros before any unlock.
+
+**SEC-02 · Accept→booking exposes name+email+address free — STILL OPEN.**
+`app/api/quotes/[id]/accept/route.ts:143-148` still copies `zip_code`/`address`/`special_instructions` into `bookings`; `app/api/cleaner/bookings/route.ts:31-40` still joins `customer:users(id, full_name, email)`. The $30 gate remains bypassable for free through these two side doors.
+
+**SEC-15/16 / BUG-02 · Subscription, dunning, dispute writes still run as cookie/anon client in the webhook — STILL OPEN** *(verify-live; gated by Phase B going live).*
+`lib/stripe/subscription-service.ts:2`, `lib/stripe/dunning.ts:14`, `lib/stripe/disputes.ts:8` all still import `createClient` from `@/lib/supabase/server` (cookie client → anon in the sessionless webhook), **not** `createServiceRoleClient`. Writes are inside `try/catch` but individual inserts/updates are fire-and-forget (logged, not surfaced). Only the lead-unlock branch was moved to service-role. Live severity depends on `subscriptions`/`payments`/`disputes` RLS and on whether Stripe subscriptions are live yet (Phase B live-wiring is still pending — so this is armed, not yet firing).
+
+**Escalation — SEC-21 + SCH-01 combined = self-service admin escalation.**
+`app/auth/select-role/page.tsx:62-66` still runs `.from('users').update({ role })` from the **browser** client (`@/lib/supabase/client`, line 5). With no DB-level role guard (SCH-01 confirms none exists), if the live `users` UPDATE policy doesn't column-restrict `role`, any authenticated user can `update({role:'admin'})` from the console. **This is the June verify-first item and it is still unguarded.** *(verify-live: `users` UPDATE column scope — if unrestricted, this is CRITICAL and immediate.)*
+
+### HIGH
+
+- **NEW-02 · Post-payment contact delivery is email-only and fire-and-forget.** Even on the fixed branch, PII reaches the paid pro **only** via `sendLeadContactEmail` (`app/api/webhooks/stripe/route.ts:194-206`, `Promise.allSettled().catch()` — a mail failure is swallowed by design). There is no in-app contact-reveal reader, and the captured lead is removed from the leads list (`actions.ts:126`). If `business_email`/user email is missing or Resend fails, the pro paid $30 and sees the contact **nowhere**. The June "post-payment contact reader" recommendation was not built.
+- **NEW-03 · BUG-03 residual — webhook 0-row phantom + session-overwrite race persists** (partially mitigated). The capture still keys `.eq('stripe_checkout_session_id', session.id)` and checks only `error`, never row count (`app/api/webhooks/stripe/route.ts:89-102`) — a 0-row match is silent success. The unlock route resumes only when the prior session is `'open'` (`unlock/route.ts:96`); a **paid** session is `'complete'`, so it falls through, mints a new session, and overwrites `stripe_checkout_session_id` on the same row (`unlock/route.ts:174-179`). The delayed webhook for the paid session then matches 0 rows → stuck `pending`, and the second session is payable → possible $60. Mitigated (not closed) by the new duplicate-guard (`unlock/route.ts:79-89`) and idempotent payments insert. June's recommended fix (key by `metadata.lead_acceptance_id` + `.select()` + throw on 0 rows) was **not** applied.
+- **SEC-06 / SEC-07 · Unauthenticated admin-notification endpoints + HTML injection — STILL OPEN.** `app/api/admin/document-upload-notification/route.ts` and `app/api/admin/signup-notification/route.ts` — no auth/secret; body fields interpolated raw into admin email HTML (`generateInfoBox`, `lib/email/resend.ts:159`, `${item.value}` unescaped). Unauth email-injection to the admin inbox. Also unthrottled.
+- **SEC-08 · Booking-photos GET IDOR — STILL OPEN.** `app/api/bookings/[id]/photos/route.ts:177-207` GET checks only that a session exists, no ownership. Any authed user reads any booking's photos (+ `special_instructions`).
+
+### MEDIUM
+
+- **SEC-10 · Middleware trusts `user.user_metadata?.role`** fallback — STILL OPEN, `middleware.ts:97,149`. `user_metadata` is self-writable.
+- **FEAT-01 · `conversations.quote_request_id` is never written — STILL OPEN** (reclassified down). Grep confirms zero writes; the chat unlock branch (`app/api/messages/route.ts:271-296`) can never fire, so the in-app PII filter is permanently on. Now less severe *for delivery* because the money path delivers PII by email instead — but it means the whole chat-unlock mechanism is dead code, and PII still leaks free via SEC-01/02 regardless.
+- **SEC-11/SEC-04/SEC-05** (x-forwarded-host redirect, full name in pre-pay notifications, pii-filter bypass vectors — window still 5 messages, `app/api/messages/route.ts:312`) — unchanged.
+
+### LOW
+
+- **SEC-27 · No `server-only` guard** on `lib/supabase/service-role.ts` — STILL OPEN. `.gitignore` still covers only `.env` + `.env*.local`, **not** blanket `.env*` (`.env.production` would not be ignored).
+- **Secrets — CLEAN (confirmed).** No real `sk_live_`/`sk_test_`/`whsec_`/`rk_live_` values, no hardcoded service-role JWTs, no `eyJ…` tokens in tracked code. Only `.env.example` template.
+- **Webhook signature — CORRECT (confirmed).** `constructEvent` on raw body, `runtime='nodejs'`, idempotency via `record_webhook_event`. `apiVersion '2025-07-30.basil'` pinned (`lib/stripe/config.ts:16`).
+- **Input validation on new/changed files — CLEAN.** `leads/actions.ts` (read-only, auth+approval gated), `unlock/route.ts` (no body; `quoteId` parameterized; auth+ownership+hire-gate+status guards), webhook (signature-verified, metadata server-set).
+
+---
+
+## 2. MONEY PATH (end-to-end trace)
+
+Quote accept (`accept/route.ts`, sets `accepted` + creates booking — SEC-02 leak) → **customer confirms hire** (`hire_confirmations` insert, browser client, RLS `customer_id=auth.uid()` — *new gate*) → pro sees PII-safe lead (`leads/actions.ts`, via `quote_requests_pro_view`) → `POST /api/leads/[quoteId]/unlock` (requires `hire_confirmations` row `unlock/route.ts:70`; inserts `lead_acceptances` pending; creates Stripe session; **links session id via service-role, `.select()`, 0-row hard-fail** `unlock/route.ts:174-188`) → Stripe `checkout.session.completed` → webhook capture.
+
+**Gaps flagged:**
+1. **`main` branch capture is incomplete** — no `payments` insert, no contact email (NEW-01). `app/api/webhooks/stripe/route.ts` on `main`.
+2. **0-row phantom on capture** — no row-count guard (`route.ts:89-102`); session-overwrite race (`unlock/route.ts:174-179`) (NEW-03).
+3. **Delivery is email-only, fire-and-forget** — no in-app reveal; captured lead vanishes from UI (NEW-02).
+4. **`payment_status==='paid'` not checked** at capture (`route.ts:65`) — safe today (card-only) — BUG-11 unchanged.
+
+**Branch status:** `feat/lead-handoff-webhook` (`fc1d049`) is 1 commit ahead of `main`, adds the `payments` row + PII-release email. **It is the fix for NEW-01 and must merge before any live $30 flow.** Not pushed to a remote (no `origin` tracking detected).
+
+---
+
+## 3. TRAFFIC READINESS
+
+### HIGH
+- **N+1 on the messages inbox** — `app/api/messages/route.ts:82-91` runs one last-message query per conversation. N+1 round-trips every inbox load.
+- **Unbounded public directory** — `app/professionals/page.tsx:87` selects the entire approved-pro table (+users join), no `.limit`/pagination, on every request. Worst public offender.
+
+### MEDIUM
+- **Missing webhook-path indexes** — `lead_acceptances(stripe_checkout_session_id)` and `(stripe_payment_intent_id)` have **no index**; every `checkout.session.completed` and dispute lookup seq-scans (`route.ts:97,121`, `disputes.ts:40,53`). (Other hot paths — `service_areas(zip_code)`, `messages(conversation_id)`, `quote_requests(cleaner_id/status/zip)` — are covered; renamed `cleaners→pros` kept its indexes.)
+- **Unthrottled endpoints** — `/api/contact` has no rate limit; `RATE_LIMITS.auth` (5/min) is **defined but never referenced**, so login/signup are unthrottled. `lib/middleware/rate-limit.ts` also fails **open**.
+- **Zero ISR on public/SEO pages** — no page sets `export const revalidate`; `/professionals`, `/search`, `/[city]` all render dynamic via cookie-bound client. Plus `middleware.ts` runs `auth.getUser()` (a network round-trip) on **every** non-static route including the static home page — latency tax + defeats caching.
+- **Error boundaries missing** on `app/search/`, `app/quote-request/`, `app/professionals/`, `app/cleaner/[slug]/`, `app/[city]/`, `app/services/`, `app/book/[cleanerId]/`; no `app/global-error.tsx`; `middleware.ts:74` `auth.getUser()` is not wrapped in try/catch — a thrown (vs returned) error propagates.
+
+### Confirmed-good
+`next/image` used in 21 files, **zero raw `<img>`**; `images.remotePatterns` configured; unbounded-select otherwise limited; `leads/actions.ts:100-118` is a clean batched (`Promise.all` + `.in()` + `.limit(100)`) reference.
+
+---
+
+## 4. HYGIENE
+
+- **Ghost columns — RESOLVED (DLD-452 closed).** `app/dashboard/pro/leads/actions.ts` was rewritten; **zero `lead_credits_*` references** remain in it or anywhere repo-wide. It now reads real objects (`quote_requests_pro_view`, `hire_confirmations`, `lead_acceptances`, `pros`). Sole importer: `app/dashboard/pro/leads/page.tsx:18`. `lib/services/lead-credits.ts` still exists but has **zero importers** (safe-delete).
+- **Node pinning — STILL MISSING.** No `.nvmrc` at root; no `engines` in `package.json`. Node 20 is set only in `netlify.toml:6` + `netlify.toml.local:6` — not enforced locally.
+- **Dead code — all still present, zero live importers:** `app/api/cleaners/documents/route.ts`, `app/api/availability/[cleanerId]/route.ts` (also SEC-09), `app/api/pro/licenses/route.ts`, `lib/services/search.ts`, `lib/services/searchService.ts`, `lib/services/quote-service.ts`, `lib/supabase/middleware.ts`, `lib/auth/auth-service.ts`, `app/qa/quote-demo/page.tsx`, `pages/_document.tsx` + `pages/api/health.ts` (hybrid-routing smell), `middleware.ts.backup`. *(Note: the live `@/components/search` barrel is separate — do not confuse with dead `lib/services/search.ts`.)*
+- **TODO/FIXME — effectively zero.** One grep hit (`lib/sms/twilio.ts:43`) is a false positive in an E.164 docstring.
+- **Repo-root clutter — all present, none gitignored:** `screenshots/` (28 MB), `Boss of clean files/` (2.7 MB), `boc22/` + `boc22.zip`, `artifacts/`, `ralph/`, `agents/`, `specs/`. `tsconfig.json:25-26` includes `**/*.ts(x)` excluding only `node_modules`, pulling any stray `.ts` in those dirs into typechecking.
+- **5 lint errors persist** (all `react/no-unescaped-entities`): `service-areas/page.tsx:334`, `pro/setup/page.tsx:480`, `AuthForm.tsx:571`, `CleanerCapacityModal.tsx:50`, `TrainingModule.tsx:151`. `next.config.js` `eslint.ignoreDuringBuilds` + `typescript.ignoreBuildErrors` both still **on**, so they never block deploys.
+
+---
+
+## Recommended priority (unchanged from June's slicing where still open)
+
+1. **Merge `feat/lead-handoff-webhook` before any live $30 flow** (NEW-01) — or the money path on `main` takes cash and delivers nothing. ⚠ Stripe.
+2. **Close the capture race** (NEW-03): key by `metadata.lead_acceptance_id` + `.select()` + throw on 0 rows; stop overwriting a `complete` session's id (expire-then-replace). ⚠ Stripe.
+3. **Add an in-app post-payment contact reveal** so delivery doesn't hinge on a fire-and-forget email (NEW-02).
+4. **Strip PII from the free side doors** (SEC-01, SEC-02) — the paid gate is meaningless while these leak.
+5. **Verify-live, then lock `users.role`** (SEC-21 + SCH-01) — self-escalation risk; also `DROP claim_lead_with_credit`. ⚠ schema/RLS.
+6. Auth/escaping on the two notification endpoints (SEC-06/07); ownership on booking-photos GET (SEC-08).
+7. Perf: index `lead_acceptances(stripe_checkout_session_id, stripe_payment_intent_id)`; paginate `/professionals`; batch the messages-inbox preview; throttle `/api/contact` + auth.
+8. Hygiene batch: `.nvmrc` + `engines`, fix 5 lint errors, delete dead routes/modules, `.gitignore` clutter.
+
+**Nothing was changed during the audit.** Every ⚠ item touches schema, RLS, or live Stripe and needs Daniel's explicit sign-off.


### PR DESCRIPTION
## What

Adds `docs/AUDIT_2026-07.md` — a read-only delta audit against `docs/AUDIT_2026-06.md`. **Documentation only; no code, schema, or Stripe changes.**

## Headline findings

- **Fixed since June:** DLD-452 ghost columns fully removed (zero `lead_credits_*` refs repo-wide); lead-unlock Slice-1 link race closed; new server-side hire gate.
- **New CRITICAL (NEW-01):** on `main`, a pro's \$30 payment flips `lead_acceptances` to `captured` but records **no `payments` row** and **delivers no contact** — the payments-insert + PII-release-email code lives only on the unmerged `feat/lead-handoff-webhook` (`fc1d049`). Money in, nothing recorded, nothing delivered.
- **Still open (carried):** `claim_lead_with_credit` (no drop / no role guard), free PII side-doors (SEC-01 messages API, SEC-02 accept→booking), unauth admin-notification endpoints + HTML injection, booking-photos IDOR, `user_metadata.role` fallback, browser-side `users.role` write (self-escalation), anon-client subscription/dunning/dispute writes.
- **New this pass:** capture 0-row phantom + session-overwrite race residual, email-only fire-and-forget PII delivery, messages-inbox N+1, unbounded `/professionals` select, missing `lead_acceptances` webhook-path indexes, unthrottled `/api/contact` + auth, zero ISR on public pages, still-missing `.nvmrc`/`engines`.

## Scope / safety

No fixes applied. Every ⚠ item (schema / RLS / live Stripe) needs explicit sign-off. See the report's ranked remediation order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)