### PR TITLE
feat(webhook): admin sale alert + HTML-escape lead-unlock emails

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -4,7 +4,7 @@ import { getStripe } from '@/lib/stripe/config';
 import { subscriptionService } from '@/lib/stripe/subscription-service';
 import { webhookEventService } from '@/lib/stripe/webhook-event-service';
 import { handleDisputeCreated, handleDisputeClosed } from '@/lib/stripe/disputes';
-import { sendLeadContactEmail } from '@/lib/email/lead-unlock';
+import { sendLeadContactEmail, sendAdminSaleNotification } from '@/lib/email/lead-unlock';
 import { createLogger } from '@/lib/utils/logger';
 import type Stripe from 'stripe';
 
@@ -121,6 +121,9 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
             .eq('stripe_payment_intent_id', paymentIntentId)
             .maybeSingle();
 
+          // True only when THIS delivery inserted a fresh payments row — gates
+          // the admin sale alert so Stripe redeliveries don't re-notify.
+          let paymentRecorded = false;
           if (!existingPayment) {
             const paymentMetadata: Record<string, string> = {
               type: 'lead_unlock',
@@ -158,6 +161,8 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
                 logger.error('Failed to record lead unlock payment', { function: 'handleStripeEvent' }, paymentError);
                 throw paymentError;
               }
+            } else {
+              paymentRecorded = true;
             }
           }
 
@@ -210,6 +215,25 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
               sessionId: session.id,
               quoteRequestId: quote_request_id,
             });
+          }
+
+          // Internal "new sale" alert to admin@bossofclean.com. Only on a
+          // freshly-recorded payment (not on Stripe redeliveries). Fire-and-
+          // forget: a mail failure must NEVER fail the webhook or the payments
+          // write (same contract as the handoff email above).
+          if (paymentRecorded) {
+            Promise.allSettled([
+              sendAdminSaleNotification({
+                proName: pro?.business_name || 'Unknown pro',
+                customerName: customer?.full_name || 'Customer',
+                serviceType,
+                city: leadCity,
+                amount: amountCents / 100, // dollars
+                paymentIntentId,
+              }),
+            ]).catch((err) =>
+              logger.error('Admin sale email batch error', { function: 'handleStripeEvent' }, err)
+            );
           }
 
           logger.info('Lead unlock fully processed', {

--- a/lib/email/lead-unlock.ts
+++ b/lib/email/lead-unlock.ts
@@ -6,10 +6,11 @@
  */
 
 import { createLogger } from '../utils/logger';
-import { sendResendEmail, wrapEmailTemplate, generateButton, generateInfoBox } from './resend';
+import { sendResendEmail, wrapEmailTemplate, generateButton, generateInfoBox, escapeHtml, ALERTS_FROM } from './resend';
 
 const logger = createLogger({ file: 'lib/email/lead-unlock' });
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://bossofclean.com';
+const ADMIN_EMAIL = 'admin@bossofclean.com';
 
 export interface LeadContactEmailData {
   recipientEmail: string;
@@ -31,16 +32,16 @@ export function generateLeadContactHtml(
   const content = `
     <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">Your lead is unlocked</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
-      Hi ${data.proName}, your payment cleared and the customer's contact details
+      Hi ${escapeHtml(data.proName)}, your payment cleared and the customer's contact details
       are now yours. Reach out soon — a fast response wins the job.
     </p>
 
     ${generateInfoBox([
-      { label: 'Customer', value: data.customerName },
-      { label: 'Phone', value: data.customerPhone || 'not provided' },
-      { label: 'Email', value: data.customerEmail },
-      { label: 'Service', value: (data.serviceType || '').replace(/_/g, ' ') },
-      { label: 'City', value: data.city },
+      { label: 'Customer', value: escapeHtml(data.customerName) },
+      { label: 'Phone', value: escapeHtml(data.customerPhone || 'not provided') },
+      { label: 'Email', value: escapeHtml(data.customerEmail) },
+      { label: 'Service', value: escapeHtml((data.serviceType || '').replace(/_/g, ' ')) },
+      { label: 'City', value: escapeHtml(data.city) },
     ])}
 
     ${generateButton('View lead', leadsUrl)}
@@ -70,6 +71,63 @@ export async function sendLeadContactEmail(
     to: data.recipientEmail,
     subject: 'Your lead is unlocked',
     html: generateLeadContactHtml(data, leadsUrl),
+  });
+
+  return result.success;
+}
+
+export interface AdminSaleEmailData {
+  proName: string;
+  customerName: string;
+  serviceType: string;
+  city: string;
+  /** dollars — the lead-unlock fee that just cleared */
+  amount: number;
+  paymentIntentId: string;
+}
+
+/**
+ * Generate HTML for the internal "new sale" admin alert.
+ * All interpolated values pass through escapeHtml (AUDIT_2026-07 flag).
+ */
+export function generateAdminSaleHtml(data: AdminSaleEmailData): string {
+  const content = `
+    <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">💰 New Sale — $30 Lead Capture</h2>
+    <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
+      A pro just paid to unlock a lead. Payment cleared in Stripe.
+    </p>
+
+    ${generateInfoBox([
+      { label: 'Pro', value: escapeHtml(data.proName) },
+      { label: 'Customer', value: escapeHtml(data.customerName) },
+      { label: 'Service', value: escapeHtml((data.serviceType || '').replace(/_/g, ' ')) },
+      { label: 'City', value: escapeHtml(data.city) },
+      { label: 'Amount', value: escapeHtml(`$${data.amount.toFixed(2)}`) },
+      { label: 'Payment Intent', value: escapeHtml(data.paymentIntentId) },
+    ])}
+  `;
+
+  return wrapEmailTemplate(content);
+}
+
+/**
+ * Send the internal "new sale" alert to the Boss of Clean admin inbox.
+ * Fire-and-forget from the webhook — a mail failure must never fail the
+ * webhook or the payments write.
+ */
+export async function sendAdminSaleNotification(
+  data: AdminSaleEmailData
+): Promise<boolean> {
+  logger.info('Sending admin sale notification', {
+    function: 'sendAdminSaleNotification',
+    paymentIntentId: data.paymentIntentId,
+  });
+
+  const result = await sendResendEmail({
+    to: ADMIN_EMAIL,
+    subject: '💰 New Sale — $30 Lead Capture',
+    html: generateAdminSaleHtml(data),
+    from: ALERTS_FROM,
   });
 
   return result.success;

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -154,6 +154,21 @@ export function generateButton(text: string, url: string, color: 'primary' | 'su
 }
 
 /**
+ * Escape user-supplied values before interpolating into email HTML.
+ * Prevents stored-field HTML/script injection into the admin inbox
+ * (AUDIT_2026-07: unescaped-interpolation flag). Callers pass user data
+ * (names, emails, service/city) through this before building templates.
+ */
+export function escapeHtml(value: string | null | undefined): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
  * Generate an info box
  */
 export function generateInfoBox(items: { label: string; value: string }[]): string {


### PR DESCRIPTION
Branch: `feat/admin-sale-notification`. One commit, three files. Does **not** touch the subscription path (task 3 is a read-only report, below — no code).

## 1. Admin sale email
On a freshly-recorded lead-unlock payment, the webhook fires a fire-and-forget alert to `admin@bossofclean.com`:
- Subject: `💰 New Sale — $30 Lead Capture`
- Body (info box): pro business name, customer name, service type, city, amount, payment intent ID
- `from: ALERTS_FROM` (`noreply@bossofclean.com`)
- Gated on a new `paymentRecorded` flag → only fires when *this* delivery inserted a fresh `payments` row, so Stripe redeliveries don't re-notify.
- Wrapped in `Promise.allSettled(...).catch()` — a mail failure never fails the webhook or the payments write.

## 2. HTML escaping
- New `escapeHtml()` in `lib/email/resend.ts`.
- All interpolated user fields escaped in the pro handoff email (`generateLeadContactHtml`) and the new admin template (`generateAdminSaleHtml`): customer name/email/phone, pro name, service, city (+ amount/payment-intent for consistency). Closes the AUDIT_2026-07 unescaped-interpolation flag for these two templates.

## Verification
`tsc --noEmit` → zero errors in the three touched files (pre-existing errors remain only in the already-flagged dead modules `lib/services/quote-service.ts` + `searchService.ts`).

## Resend from-address
`ALERTS_FROM = noreply@bossofclean.com` — on the bossofclean.com domain, same sender the existing `/api/contact` + signup + document-upload admin emails already use. No new domain introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)