### PR TITLE
DLD-556: Fix subscription webhook — Basil API fields + service-role client (BUG-01/SEC-15)

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -245,6 +245,11 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
       );
       break;
 
+    // Basil (2025+ Stripe API) emits invoice.paid; older versions emit
+    // invoice.payment_succeeded — and both can fire for the same invoice.
+    // handlePaymentSucceeded dedupes per invoice_id, so the double delivery
+    // records one payment.
+    case 'invoice.paid':
     case 'invoice.payment_succeeded':
       await processEventWithRetry(event, () =>
         subscriptionService.handlePaymentSucceeded(

--- a/lib/stripe/disputes.ts
+++ b/lib/stripe/disputes.ts
@@ -5,7 +5,9 @@
  * and sends notifications to admin and cleaner.
  */
 
-import { createClient } from '@/lib/supabase/server';
+// Service-role client: dispute handlers run from the Stripe webhook with no
+// user session, where the cookie/anon client is blocked by RLS on writes.
+import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import {
   sendDisputeAdminAlert,
   sendDisputeCleanerNotification,
@@ -17,7 +19,7 @@ import type Stripe from 'stripe';
 const logger = createLogger({ file: 'lib/stripe/disputes' });
 
 export async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
-  const supabase = await createClient();
+  const supabase = createServiceRoleClient();
 
   const chargeId = typeof dispute.charge === 'string'
     ? dispute.charge
@@ -127,7 +129,7 @@ export async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<voi
     ? new Date(dispute.evidence_details.due_by * 1000).toISOString()
     : null;
 
-  await supabase.from('disputes').insert({
+  const { error: disputeInsertError } = await supabase.from('disputes').insert({
     stripe_dispute_id: dispute.id,
     cleaner_id: cleanerId,
     charge_id: chargeId,
@@ -138,16 +140,22 @@ export async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<voi
     status: dispute.status,
     evidence_due_by: evidenceDueBy,
   });
+  if (disputeInsertError) {
+    throw new Error(`disputes insert failed for ${dispute.id}: ${disputeInsertError.message}`);
+  }
 
   // Flag the cleaner
   const newDisputeCount = (cleaner?.dispute_count || 0) + 1;
-  await supabase
+  const { error: prosFlagError } = await supabase
     .from('pros')
     .update({
       dispute_count: newDisputeCount,
       dispute_status: 'under_review',
     })
     .eq('id', cleanerId);
+  if (prosFlagError) {
+    throw new Error(`pros dispute-flag update failed for ${dispute.id}: ${prosFlagError.message}`);
+  }
 
   // Notify admin
   await sendDisputeAdminAlert({
@@ -176,12 +184,12 @@ export async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<voi
 }
 
 export async function handleDisputeClosed(dispute: Stripe.Dispute): Promise<void> {
-  const supabase = await createClient();
+  const supabase = createServiceRoleClient();
 
   const outcome = dispute.status === 'won' ? 'won' : 'lost';
 
   // Update dispute record
-  await supabase
+  const { error: disputeUpdateError } = await supabase
     .from('disputes')
     .update({
       status: dispute.status,
@@ -189,6 +197,9 @@ export async function handleDisputeClosed(dispute: Stripe.Dispute): Promise<void
       updated_at: new Date().toISOString(),
     })
     .eq('stripe_dispute_id', dispute.id);
+  if (disputeUpdateError) {
+    throw new Error(`disputes update failed for ${dispute.id}: ${disputeUpdateError.message}`);
+  }
 
   // Get dispute details for cleaner lookup
   const { data: disputeRecord } = await supabase
@@ -212,10 +223,13 @@ export async function handleDisputeClosed(dispute: Stripe.Dispute): Promise<void
 
   const newDisputeStatus = (count && count > 0) ? 'under_review' : 'none';
 
-  await supabase
+  const { error: prosStatusError } = await supabase
     .from('pros')
     .update({ dispute_status: newDisputeStatus })
     .eq('id', disputeRecord.cleaner_id);
+  if (prosStatusError) {
+    throw new Error(`pros dispute-status update failed for ${dispute.id}: ${prosStatusError.message}`);
+  }
 
   // Get cleaner email for notification
   const { data: cleaner } = await supabase

--- a/lib/stripe/dunning.ts
+++ b/lib/stripe/dunning.ts
@@ -11,7 +11,9 @@
  *  - Downgrade: Day 7 (grace period expires)
  */
 
-import { createClient } from '@/lib/supabase/server';
+// Service-role client: dunning runs from webhook handlers with no user
+// session, where the cookie/anon client is blocked by RLS on pros/subscriptions.
+import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import { sendPaymentFailedEmail, sendFinalWarningEmail, sendDowngradeEmail } from '@/lib/email/payment-failed';
 import { createLogger } from '../utils/logger';
 
@@ -35,7 +37,7 @@ export async function processDunningEvent(
   cleanerId: string,
   invoiceId: string
 ): Promise<DunningState> {
-  const supabase = await createClient();
+  const supabase = createServiceRoleClient();
 
   // Get current cleaner state
   const { data: cleaner } = await supabase
@@ -75,19 +77,25 @@ export async function processDunningEvent(
     // First failure: Start grace period, send first warning
     const gracePeriodEnd = new Date(now.getTime() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000);
 
-    await supabase
+    const { error: graceError } = await supabase
       .from('pros')
       .update({
         grace_period_end: gracePeriodEnd.toISOString(),
       })
       .eq('id', cleanerId);
+    if (graceError) {
+      throw new Error(`pros grace-period update failed for ${cleanerId}: ${graceError.message}`);
+    }
 
     // Update subscription status to past_due
-    await supabase
+    const { error: pastDueError } = await supabase
       .from('subscriptions')
       .update({ status: 'past_due' })
       .eq('cleaner_id', cleanerId)
       .neq('status', 'canceled');
+    if (pastDueError) {
+      throw new Error(`subscriptions past_due update failed for ${cleanerId}: ${pastDueError.message}`);
+    }
 
     state.gracePeriodEnd = gracePeriodEnd.toISOString();
     state.isInGracePeriod = true;
@@ -147,10 +155,10 @@ export async function processDunningEvent(
  * Downgrade a cleaner to the free tier after grace period expiration.
  */
 async function downgradeToFree(cleanerId: string): Promise<void> {
-  const supabase = await createClient();
+  const supabase = createServiceRoleClient();
 
   // Update cleaner to free tier
-  await supabase
+  const { error: downgradeError } = await supabase
     .from('pros')
     .update({
       subscription_tier: 'free',
@@ -158,13 +166,19 @@ async function downgradeToFree(cleanerId: string): Promise<void> {
       payment_failed_count: 0,
     })
     .eq('id', cleanerId);
+  if (downgradeError) {
+    throw new Error(`pros downgrade failed for ${cleanerId}: ${downgradeError.message}`);
+  }
 
   // Mark subscription as canceled
-  await supabase
+  const { error: cancelError } = await supabase
     .from('subscriptions')
     .update({ status: 'canceled' })
     .eq('cleaner_id', cleanerId)
     .neq('status', 'canceled');
+  if (cancelError) {
+    throw new Error(`subscriptions cancel failed for ${cleanerId}: ${cancelError.message}`);
+  }
 
   logger.info(`Cleaner ${cleanerId} downgraded to free tier after failed payments`);
 }
@@ -179,7 +193,7 @@ export async function getGracePeriodStatus(cleanerId: string): Promise<{
   gracePeriodEnd: string | null;
   daysRemaining: number | null;
 }> {
-  const supabase = await createClient();
+  const supabase = createServiceRoleClient();
 
   const { data: cleaner } = await supabase
     .from('pros')
@@ -215,22 +229,28 @@ export async function getGracePeriodStatus(cleanerId: string): Promise<{
  * Called by the payment succeeded handler.
  */
 export async function resetDunningState(cleanerId: string): Promise<void> {
-  const supabase = await createClient();
+  const supabase = createServiceRoleClient();
 
-  await supabase
+  const { error: resetError } = await supabase
     .from('pros')
     .update({
       payment_failed_count: 0,
       grace_period_end: null,
     })
     .eq('id', cleanerId);
+  if (resetError) {
+    throw new Error(`pros dunning reset failed for ${cleanerId}: ${resetError.message}`);
+  }
 
   // Restore subscription status to active
-  await supabase
+  const { error: reactivateError } = await supabase
     .from('subscriptions')
     .update({ status: 'active' })
     .eq('cleaner_id', cleanerId)
     .eq('status', 'past_due');
+  if (reactivateError) {
+    throw new Error(`subscriptions reactivate failed for ${cleanerId}: ${reactivateError.message}`);
+  }
 
   logger.info(`Dunning state reset for cleaner ${cleanerId}`);
 }

--- a/lib/stripe/subscription-service.ts
+++ b/lib/stripe/subscription-service.ts
@@ -1,5 +1,5 @@
 import { stripe, PLAN_DETAILS, type SubscriptionTier } from './config';
-import { createClient } from '@/lib/supabase/server';
+import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import { processDunningEvent, resetDunningState } from '@/lib/stripe/dunning';
 import { createLogger } from '../utils/logger';
 import type Stripe from 'stripe';
@@ -8,7 +8,26 @@ const logger = createLogger({ file: 'lib/stripe/subscription-service' });
 
 export class SubscriptionService {
   private async getSupabase() {
-    return await createClient();
+    // Webhook handlers run with no user session — the cookie/anon client is
+    // blocked by RLS on subscriptions/payments/pros writes, so rows silently
+    // never land. Service role matches the lead-unlock pattern in
+    // app/api/webhooks/stripe/route.ts.
+    return createServiceRoleClient();
+  }
+
+  // Basil (2025+ Stripe API): invoice.subscription was removed; the link now
+  // lives at invoice.parent.subscription_details.subscription. Keep the legacy
+  // top-level field as a fallback for older payloads.
+  private resolveInvoiceSubscriptionId(invoice: Stripe.Invoice): string | null {
+    const inv = invoice as Stripe.Invoice & {
+      subscription?: string | { id: string } | null;
+      parent?: {
+        subscription_details?: { subscription?: string | { id: string } | null } | null;
+      } | null;
+    };
+    const sub = inv.parent?.subscription_details?.subscription ?? inv.subscription;
+    if (!sub) return null;
+    return typeof sub === 'string' ? sub : sub.id;
   }
 
   async createCheckoutSession(
@@ -93,37 +112,54 @@ export class SubscriptionService {
     });
 
     // Update cleaner with Stripe customer ID
-    await supabase
+    const { error: updateError } = await supabase
       .from('pros')
       .update({ stripe_customer_id: customer.id })
       .eq('id', cleanerId);
+    if (updateError) {
+      logger.error(`Failed to save stripe_customer_id for cleaner ${cleanerId}:`, {}, updateError);
+    }
 
     return customer;
   }
 
   async handleSubscriptionCreated(subscription: Stripe.Subscription) {
-    // Use bracket notation for properties that may not be in strict types
-    const sub = subscription as Stripe.Subscription & {
-      current_period_start: number;
-      current_period_end: number;
-    };
-    const { customer, id, status, current_period_start, current_period_end, metadata } = sub;
+    const { customer, id, status, metadata } = subscription;
     const cleanerId = metadata.cleaner_id;
     const tier = metadata.tier as SubscriptionTier;
 
     if (!cleanerId || !tier) {
-      logger.error('Missing cleaner_id or tier in subscription metadata');
+      logger.warn(
+        `Missing cleaner_id or tier in metadata for subscription ${id} — cannot record it`,
+        { subscriptionId: id, metadata }
+      );
       return;
     }
 
-    const tierConfig = PLAN_DETAILS[tier];
-    const periodStart = new Date(current_period_start * 1000).toISOString();
-    const periodEnd = new Date(current_period_end * 1000).toISOString();
-
     try {
+      const tierConfig = PLAN_DETAILS[tier];
+
+      // Basil (2025+ Stripe API): current_period_start/end moved from the
+      // subscription to each subscription item. Fall back to the legacy
+      // top-level fields for older payloads.
+      const item = subscription.items?.data?.[0] as
+        | (Stripe.SubscriptionItem & { current_period_start?: number; current_period_end?: number })
+        | undefined;
+      const legacy = subscription as Stripe.Subscription & {
+        current_period_start?: number;
+        current_period_end?: number;
+      };
+      const periodStartUnix = item?.current_period_start ?? legacy.current_period_start;
+      const periodEndUnix = item?.current_period_end ?? legacy.current_period_end;
+      if (!periodStartUnix || !periodEndUnix) {
+        throw new Error(`Missing current_period_start/end on subscription ${id}`);
+      }
+      const periodStart = new Date(periodStartUnix * 1000).toISOString();
+      const periodEnd = new Date(periodEndUnix * 1000).toISOString();
+
       const supabase = await this.getSupabase();
       // Insert subscription record
-      await supabase.from('subscriptions').insert({
+      const { error: insertError } = await supabase.from('subscriptions').insert({
         cleaner_id: cleanerId,
         stripe_subscription_id: id,
         stripe_customer_id: typeof customer === 'string' ? customer : customer?.id,
@@ -134,9 +170,12 @@ export class SubscriptionService {
         monthly_price: tierConfig.price,
         features: tierConfig.features,
       });
+      if (insertError) {
+        throw new Error(`subscriptions insert failed for ${id}: ${insertError.message}`);
+      }
 
       // Update cleaner subscription info and billing dates
-      await supabase
+      const { error: prosError } = await supabase
         .from('pros')
         .update({
           subscription_tier: tier,
@@ -146,6 +185,9 @@ export class SubscriptionService {
           payment_failed_count: 0, // Reset on new subscription
         })
         .eq('id', cleanerId);
+      if (prosError) {
+        throw new Error(`pros update failed for subscription ${id}: ${prosError.message}`);
+      }
 
       logger.info(`Subscription created for cleaner ${cleanerId}: ${tier}`);
     } catch (error) {
@@ -155,16 +197,23 @@ export class SubscriptionService {
   }
 
   async handleSubscriptionUpdated(subscription: Stripe.Subscription) {
-    const sub = subscription as Stripe.Subscription & {
-      current_period_end: number;
-    };
-    const { id, status, current_period_end, cancel_at } = sub;
-    const periodEnd = new Date(current_period_end * 1000).toISOString();
+    const { id, status, cancel_at } = subscription;
 
     try {
+      // Basil: period fields live on the subscription item (legacy fallback below).
+      const item = subscription.items?.data?.[0] as
+        | (Stripe.SubscriptionItem & { current_period_end?: number })
+        | undefined;
+      const legacy = subscription as Stripe.Subscription & { current_period_end?: number };
+      const periodEndUnix = item?.current_period_end ?? legacy.current_period_end;
+      if (!periodEndUnix) {
+        throw new Error(`Missing current_period_end on subscription ${id}`);
+      }
+      const periodEnd = new Date(periodEndUnix * 1000).toISOString();
+
       const supabase = await this.getSupabase();
       // Update subscription record
-      await supabase
+      const { error: subError } = await supabase
         .from('subscriptions')
         .update({
           status,
@@ -172,15 +221,21 @@ export class SubscriptionService {
           cancel_at: cancel_at ? new Date(cancel_at * 1000).toISOString() : null,
         })
         .eq('stripe_subscription_id', id);
+      if (subError) {
+        throw new Error(`subscriptions update failed for ${id}: ${subError.message}`);
+      }
 
       // Update cleaner subscription expiry and next billing date
-      await supabase
+      const { error: prosError } = await supabase
         .from('pros')
         .update({
           subscription_expires_at: periodEnd,
           next_billing_date: periodEnd,
         })
         .eq('stripe_subscription_id', id);
+      if (prosError) {
+        throw new Error(`pros update failed for subscription ${id}: ${prosError.message}`);
+      }
 
       logger.info(`Subscription updated: ${id}`);
     } catch (error) {
@@ -195,7 +250,7 @@ export class SubscriptionService {
     try {
       const supabase = await this.getSupabase();
       // Update cleaner to free tier and clear billing dates
-      await supabase
+      const { error: prosError } = await supabase
         .from('pros')
         .update({
           subscription_tier: 'free',
@@ -204,12 +259,18 @@ export class SubscriptionService {
           next_billing_date: null,
         })
         .eq('stripe_subscription_id', id);
+      if (prosError) {
+        throw new Error(`pros update failed for subscription ${id}: ${prosError.message}`);
+      }
 
       // Update subscription status
-      await supabase
+      const { error: subError } = await supabase
         .from('subscriptions')
         .update({ status: 'canceled' })
         .eq('stripe_subscription_id', id);
+      if (subError) {
+        throw new Error(`subscriptions update failed for ${id}: ${subError.message}`);
+      }
 
       logger.info(`Subscription canceled: ${id}`);
     } catch (error) {
@@ -219,36 +280,54 @@ export class SubscriptionService {
   }
 
   async handlePaymentSucceeded(invoice: Stripe.Invoice) {
-    // Extended type for invoice properties that may not be in strict types
     const inv = invoice as Stripe.Invoice & {
-      subscription?: string | { id: string } | null;
       payment_intent?: string | { id: string } | null;
     };
-    const { subscription, amount_paid, currency } = inv;
+    const { amount_paid, currency } = inv;
 
-    if (!subscription) {
+    const subscriptionId = this.resolveInvoiceSubscriptionId(invoice);
+    if (!subscriptionId) {
       logger.debug('No subscription associated with invoice, skipping');
       return;
     }
 
-    const subscriptionId = typeof subscription === 'string' ? subscription : subscription.id;
-
     try {
       const supabase = await this.getSupabase();
       // Record successful payment
-      const { data: subscriptionData } = await supabase
+      const { data: subscriptionData, error: lookupError } = await supabase
         .from('subscriptions')
         .select('cleaner_id')
         .eq('stripe_subscription_id', subscriptionId)
         .single();
+      if (lookupError) {
+        throw new Error(`subscriptions lookup failed for ${subscriptionId}: ${lookupError.message}`);
+      }
 
       if (subscriptionData) {
+        // Dedupe: invoice.paid and invoice.payment_succeeded both fire for the
+        // same invoice on current API versions — only record it once.
+        const { data: existingPayment, error: dedupeError } = await supabase
+          .from('payments')
+          .select('id')
+          .eq('cleaner_id', subscriptionData.cleaner_id)
+          .eq('status', 'succeeded')
+          .contains('metadata', { invoice_id: invoice.id })
+          .limit(1)
+          .maybeSingle();
+        if (dedupeError) {
+          throw new Error(`payments dedupe lookup failed for ${subscriptionId}: ${dedupeError.message}`);
+        }
+        if (existingPayment) {
+          logger.info(`Payment for invoice ${invoice.id} already recorded, skipping duplicate event`);
+          return;
+        }
+
         const paymentIntentId = typeof inv.payment_intent === 'string'
           ? inv.payment_intent
           : inv.payment_intent?.id || null;
 
         // Record payment
-        await supabase.from('payments').insert({
+        const { error: paymentError } = await supabase.from('payments').insert({
           cleaner_id: subscriptionData.cleaner_id,
           stripe_payment_intent_id: paymentIntentId,
           amount: (amount_paid || 0) / 100, // Convert cents to dollars
@@ -258,9 +337,12 @@ export class SubscriptionService {
           metadata: { invoice_id: invoice.id },
           paid_at: new Date().toISOString(),
         });
+        if (paymentError) {
+          throw new Error(`payments insert failed for ${subscriptionId}: ${paymentError.message}`);
+        }
 
         // Update last payment date, reset failed count, and reset monthly lead acceptance counter
-        await supabase
+        const { error: prosError } = await supabase
           .from('pros')
           .update({
             last_payment_date: new Date().toISOString(),
@@ -268,6 +350,9 @@ export class SubscriptionService {
             monthly_accepted_lead_count: 0,
           })
           .eq('id', subscriptionData.cleaner_id);
+        if (prosError) {
+          throw new Error(`pros update failed for ${subscriptionId}: ${prosError.message}`);
+        }
 
         // Reset dunning state (grace period, subscription status)
         await resetDunningState(subscriptionData.cleaner_id);
@@ -281,41 +366,43 @@ export class SubscriptionService {
   }
 
   async handlePaymentFailed(invoice: Stripe.Invoice) {
-    // Extended type for invoice properties that may not be in strict types
     const inv = invoice as Stripe.Invoice & {
-      subscription?: string | { id: string } | null;
       payment_intent?: string | { id: string } | null;
     };
-    const { subscription } = inv;
 
-    if (!subscription) {
+    const subscriptionId = this.resolveInvoiceSubscriptionId(invoice);
+    if (!subscriptionId) {
       logger.debug('No subscription associated with failed invoice, skipping');
       return;
     }
 
-    const subscriptionId = typeof subscription === 'string' ? subscription : subscription.id;
-
     try {
       const supabase = await this.getSupabase();
       // Get cleaner ID from subscription
-      const { data: subscriptionData } = await supabase
+      const { data: subscriptionData, error: lookupError } = await supabase
         .from('subscriptions')
         .select('cleaner_id')
         .eq('stripe_subscription_id', subscriptionId)
         .single();
+      if (lookupError) {
+        throw new Error(`subscriptions lookup failed for ${subscriptionId}: ${lookupError.message}`);
+      }
 
       if (subscriptionData) {
         // Increment failed payment count using RPC
-        await supabase.rpc('increment_payment_failed_count', {
+        const { error: rpcError } = await supabase.rpc('increment_payment_failed_count', {
           p_cleaner_id: subscriptionData.cleaner_id,
         });
+        if (rpcError) {
+          throw new Error(`increment_payment_failed_count failed for ${subscriptionId}: ${rpcError.message}`);
+        }
 
         const paymentIntentId = typeof inv.payment_intent === 'string'
           ? inv.payment_intent
           : inv.payment_intent?.id || null;
 
         // Record failed payment
-        await supabase.from('payments').insert({
+        const { error: paymentError } = await supabase.from('payments').insert({
           cleaner_id: subscriptionData.cleaner_id,
           stripe_payment_intent_id: paymentIntentId,
           amount: (invoice.amount_due || 0) / 100,
@@ -325,6 +412,9 @@ export class SubscriptionService {
           metadata: { invoice_id: invoice.id },
           failed_at: new Date().toISOString(),
         });
+        if (paymentError) {
+          throw new Error(`payments insert failed for ${subscriptionId}: ${paymentError.message}`);
+        }
       }
 
       logger.info(`Payment failed for subscription: ${subscriptionId}`);


### PR DESCRIPTION
## DLD-556 — Latent money-path bug (fix before first real subscriber)

The first real pro subscription would charge in Stripe but record **nothing**: every subscription/dunning/dispute DB write used the cookie/anon client, which is RLS-blocked in webhook context and rejected **silently** (no error checks), and the handlers read pre-Basil Stripe field shapes that no longer exist. Verified July 3: zero subscriptions in the DB, so nothing to backfill — this closes the gap ahead of the first subscriber.

### Changes (4 files, +190/−61, one commit)
1. **Service-role client + no silent rejections** — `lib/stripe/subscription-service.ts`, `dunning.ts`, `disputes.ts` swap `@/lib/supabase/server` for `createServiceRoleClient()` (same pattern as the lead-unlock branch in `route.ts`). Every insert/update/rpc now destructures `{ error }` and throws with the subscription/dispute ID, so failures hit the webhook retry path instead of vanishing.
2. **Basil compatibility** — `current_period_start/end` read from `subscription.items.data[0]` with legacy top-level fallback; invoice→subscription resolved via `invoice.parent.subscription_details.subscription` with legacy `invoice.subscription` fallback (shared `resolveInvoiceSubscriptionId()`). All date math moved inside try blocks.
3. **`invoice.paid` handled** alongside `invoice.payment_succeeded` (both → `handlePaymentSucceeded`). ⚠️ Both events can fire for the *same invoice* on current API versions and the event-ID idempotency guard can't dedupe across two distinct events — so `handlePaymentSucceeded` now checks for an existing succeeded payment with the same `invoice_id` before inserting.
4. **Warn-log with subscription ID** when `metadata.cleaner_id`/`tier` is missing (was a generic error with no ID).

### Verification
- `tsc --noEmit`: error count identical to main (56 pre-existing, **0 new**).
- `next build`: ✓ compiled, 87/87 pages.
- Guardrails respected: no schema/RLS changes, lead-unlock capture path untouched, no Stripe dashboard config touched, one commit, **no merge/deploy** (Board merges).

### Suggested post-merge smoke test (Stripe test mode)
Checkout a test subscription → confirm `subscriptions` + `payments` rows land, `pros.subscription_tier` updates, and a re-delivered `invoice.paid` does not duplicate the payments row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>