### PR TITLE
DLD-555: Close SEC-01/SEC-02 PII side-doors — customer contact only after captured lead

### DIFF
--- a/app/api/cleaner/bookings/route.ts
+++ b/app/api/cleaner/bookings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createLogger } from '@/lib/utils/logger';
+import { capturedCustomerIdsForPro, redactCustomerForPro } from '@/lib/lead-pii';
 
 const logger = createLogger({ file: 'api/cleaner/bookings/route' });
 
@@ -44,5 +45,35 @@ export async function GET() {
     return NextResponse.json({ error: 'Failed to fetch bookings' }, { status: 500 });
   }
 
-  return NextResponse.json({ bookings: bookings || [] });
+  // SEC-02 (DLD-555): PII wall. Until this pro has a captured (paid)
+  // lead_acceptance for the customer, redact contact fields to the
+  // quote_requests_pro_view exposure: first name, no email, no street
+  // address, scrub-safe fields only. Also covers legacy rows written with a
+  // full address before the write-time wall existed.
+  const rows = bookings || [];
+  const unlockedCustomerIds = await capturedCustomerIdsForPro(
+    supabase,
+    cleaner.id,
+    rows.map((b: { customer_id: string }) => b.customer_id)
+  );
+
+  const walledBookings = rows.map((b: Record<string, unknown>) => {
+    const isUnlocked = unlockedCustomerIds.has(b.customer_id as string);
+    const customerRaw = b.customer as unknown;
+    const customerObj = (Array.isArray(customerRaw) ? customerRaw[0] : customerRaw) as
+      | { id: string; full_name: string | null; email: string | null }
+      | null;
+
+    if (isUnlocked) {
+      return { ...b, customer: customerObj };
+    }
+    return {
+      ...b,
+      customer: redactCustomerForPro(customerObj, false),
+      address: '', // zip_code stays — same exposure as quote_requests_pro_view
+      special_instructions: null,
+    };
+  });
+
+  return NextResponse.json({ bookings: walledBookings });
 }

--- a/app/api/messages/[conversationId]/route.ts
+++ b/app/api/messages/[conversationId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createLogger } from '@/lib/utils/logger';
+import { proHasCapturedLeadForCustomer, redactCustomerForPro } from '@/lib/lead-pii';
 
 const logger = createLogger({ file: 'api/messages/[conversationId]/route' });
 
@@ -85,8 +86,23 @@ export async function GET(
     return NextResponse.json({ error: 'Failed to fetch messages' }, { status: 500 });
   }
 
+  // SEC-01 (DLD-555): PII wall. Pros only see the customer's full name/email
+  // after a captured (paid) lead_acceptance on one of this customer's quotes.
+  let conversation = conv;
+  if (!isCustomer) {
+    const customerRaw = conv.customer as unknown;
+    const customerObj = (Array.isArray(customerRaw) ? customerRaw[0] : customerRaw) as
+      | { id: string; full_name: string | null; email: string | null }
+      | null;
+    const isUnlocked = await proHasCapturedLeadForCustomer(supabase, conv.cleaner_id, conv.customer_id);
+    conversation = {
+      ...conv,
+      customer: redactCustomerForPro(customerObj, isUnlocked) as unknown as typeof conv.customer,
+    };
+  }
+
   return NextResponse.json({
-    conversation: conv,
+    conversation,
     messages: messages || [],
     isCustomer,
   });

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -6,6 +6,7 @@ import { rateLimitRoute, RATE_LIMITS } from '@/lib/middleware/rate-limit';
 import { createLogger } from '@/lib/utils/logger';
 import { notifyProNewMessage, notifyCustomerQuoteReceived, sendSMSIfEnabled } from '@/lib/sms/notifications';
 import { filterPII, filterPIIWithWindow } from '@/lib/pii-filter';
+import { capturedCustomerIdsForPro, redactCustomerForPro } from '@/lib/lead-pii';
 
 const logger = createLogger({ file: 'api/messages/route' });
 
@@ -78,6 +79,19 @@ export async function GET() {
     return NextResponse.json({ error: 'Failed to fetch conversations' }, { status: 500 });
   }
 
+  // SEC-01 (DLD-555): PII wall. A pro only sees the customer's full name and
+  // email after paying the lead fee (a captured lead_acceptance on one of that
+  // customer's quotes). Locked conversations get first name only, no email —
+  // same exposure as quote_requests_pro_view.
+  let unlockedCustomerIds = new Set<string>();
+  if (!isCustomer && cleanerId) {
+    unlockedCustomerIds = await capturedCustomerIdsForPro(
+      supabase,
+      cleanerId,
+      (conversations || []).map((c) => c.customer_id)
+    );
+  }
+
   // Get last message for each conversation
   const conversationsWithPreview = await Promise.all(
     (conversations || []).map(async (conv) => {
@@ -89,8 +103,17 @@ export async function GET() {
         .limit(1)
         .single();
 
+      // FK embed may be typed as array; normalize before redacting.
+      const customerRaw = conv.customer as unknown;
+      const customerObj = (Array.isArray(customerRaw) ? customerRaw[0] : customerRaw) as
+        | { id: string; full_name: string | null; email: string | null }
+        | null;
+
       return {
         ...conv,
+        customer: isCustomer
+          ? customerObj
+          : redactCustomerForPro(customerObj, unlockedCustomerIds.has(conv.customer_id)),
         lastMessage: lastMessage || null,
         unreadCount: isCustomer ? conv.customer_unread_count : conv.cleaner_unread_count,
       };

--- a/app/api/quotes/[id]/accept/route.ts
+++ b/app/api/quotes/[id]/accept/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import { createLogger } from '@/lib/utils/logger';
+import { proHasCapturedQuote } from '@/lib/lead-pii';
+import { scrubText } from '@/lib/pii-filter';
 
 const logger = createLogger({ file: 'api/quotes/[id]/accept/route' });
 
@@ -133,6 +135,28 @@ export async function POST(
   let booking = existingBooking;
   let bookingError = null;
   if (!existingBooking) {
+    // SEC-02 (DLD-555): PII wall at write time. The street address and raw
+    // notes only go on the booking once this pro has PAID for the lead (a
+    // captured lead_acceptance on this quote). Until then the booking carries
+    // the quote_requests_pro_view exposure: city + zip only, with the notes
+    // scrubbed of embedded contact info. Gating the write (not just the pro
+    // read path) also covers direct RLS-scoped client reads of bookings. The
+    // full address reaches the pro through the paid unlock handoff instead.
+    const hasCaptured = await proHasCapturedQuote(admin, quote.cleaner_id, quoteId);
+    const rawInstructions = quote.description || quote.special_requests || null;
+    const safeInstructions = hasCaptured
+      ? rawInstructions
+      : rawInstructions
+        ? scrubText(rawInstructions).scrubbed
+        : null;
+    if (!hasCaptured) {
+      logger.info('Booking created with PII-walled fields (lead not captured)', {
+        function: 'POST',
+        quoteId,
+        cleanerId: quote.cleaner_id,
+      });
+    }
+
     const insertRes = await admin
       .from('bookings')
       .insert({
@@ -146,8 +170,8 @@ export async function POST(
         start_time: safeStartTime,
         end_time: endTime,
         zip_code: quote.zip_code || '',
-        address: quote.address || quote.city || '',
-        special_instructions: quote.description || quote.special_requests || null,
+        address: hasCaptured ? (quote.address || quote.city || '') : (quote.city || ''),
+        special_instructions: safeInstructions,
         estimated_price: quote.quoted_price || 0,
         estimated_hours: estimatedHours,
         status: 'confirmed',

--- a/lib/lead-pii.ts
+++ b/lib/lead-pii.ts
@@ -1,0 +1,104 @@
+/**
+ * Lead PII wall — shared helpers (SEC-01 / SEC-02, DLD-555)
+ *
+ * The $30 lead fee gates customer contact info. Pros may only see a
+ * customer's full name / email / street address after they hold a
+ * lead_acceptances row with status='captured' for one of that customer's
+ * quote requests. Until then they get the same redacted shape as
+ * quote_requests_pro_view: first name + city/zip + job details.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** "Jane Smith" -> "Jane"; null-safe. */
+export function firstNameOnly(fullName: string | null | undefined): string | null {
+  if (!fullName) return null;
+  const first = fullName.trim().split(/\s+/)[0];
+  return first || null;
+}
+
+/**
+ * Batch check: which of these customers has this pro paid to unlock?
+ * A customer counts as unlocked when the pro has a captured lead_acceptance
+ * on ANY of that customer's quote requests.
+ */
+export async function capturedCustomerIdsForPro(
+  supabase: SupabaseClient,
+  cleanerId: string,
+  customerIds: string[]
+): Promise<Set<string>> {
+  const unique = Array.from(new Set(customerIds.filter(Boolean)));
+  if (!cleanerId || unique.length === 0) return new Set();
+
+  const { data, error } = await supabase
+    .from('lead_acceptances')
+    .select('quote_request:quote_requests!inner(customer_id)')
+    .eq('cleaner_id', cleanerId)
+    .eq('status', 'captured')
+    .in('quote_request.customer_id', unique);
+
+  if (error) {
+    // Fail closed: an error here must never widen PII exposure.
+    return new Set();
+  }
+
+  const ids = new Set<string>();
+  for (const row of data || []) {
+    // Many-to-one FK embeds come back as a single object at runtime, but the
+    // generated types may say array — normalize both shapes.
+    const qr = row.quote_request as unknown;
+    const obj = Array.isArray(qr) ? qr[0] : qr;
+    const customerId = (obj as { customer_id?: string } | null)?.customer_id;
+    if (customerId) ids.add(customerId);
+  }
+  return ids;
+}
+
+/**
+ * Single-customer convenience wrapper around capturedCustomerIdsForPro.
+ */
+export async function proHasCapturedLeadForCustomer(
+  supabase: SupabaseClient,
+  cleanerId: string,
+  customerId: string
+): Promise<boolean> {
+  const ids = await capturedCustomerIdsForPro(supabase, cleanerId, [customerId]);
+  return ids.has(customerId);
+}
+
+/**
+ * Has this pro captured (paid for) this specific quote request?
+ */
+export async function proHasCapturedQuote(
+  supabase: SupabaseClient,
+  cleanerId: string,
+  quoteRequestId: string
+): Promise<boolean> {
+  if (!cleanerId || !quoteRequestId) return false;
+  const { data, error } = await supabase
+    .from('lead_acceptances')
+    .select('id')
+    .eq('cleaner_id', cleanerId)
+    .eq('quote_request_id', quoteRequestId)
+    .eq('status', 'captured')
+    .limit(1)
+    .maybeSingle();
+  if (error) return false; // fail closed
+  return !!data;
+}
+
+/**
+ * Redact an embedded customer object for a pro who has NOT paid:
+ * first name only, no email. Pass-through when unlocked.
+ */
+export function redactCustomerForPro<
+  T extends { full_name?: string | null; email?: string | null }
+>(customer: T | null | undefined, isUnlocked: boolean): T | null {
+  if (!customer) return null;
+  if (isUnlocked) return customer;
+  return {
+    ...customer,
+    full_name: firstNameOnly(customer.full_name),
+    email: null,
+  };
+}


### PR DESCRIPTION
## DLD-555 — Revenue leakage fix (critical)

Pros could read customer contact info **without paying the $30 lead fee** through two side doors (AUDIT_2026-07 SEC-01/SEC-02). Both now enforce the `quote_requests_pro_view` wall: until the pro holds a `lead_acceptances.status='captured'` row for that customer, they get **first name + city/zip only** — no email, no street address. Customers' views are unchanged.

### Files touched + before/after per side-door

**New shared helper — `lib/lead-pii.ts`**
`firstNameOnly`, `capturedCustomerIdsForPro` (batch, **fails closed** on query error), `proHasCapturedLeadForCustomer`, `proHasCapturedQuote`, `redactCustomerForPro`.

**SEC-01 — messaging APIs**
- `app/api/messages/route.ts` (GET): **before** — `customer:users(id, full_name, email)` returned to pros for every conversation. **After** — pro viewers get a batch captured-check; locked conversations return first name only, `email: null`.
- `app/api/messages/[conversationId]/route.ts` (GET): **before** — same full join returned in `conversation`. **After** — per-conversation captured-check; locked → redacted embed.

**SEC-02 — accept→booking path**
- `app/api/quotes/[id]/accept/route.ts` (POST): **before** — booking insert copied full `address` + raw `special_instructions` regardless of payment. **After** — only when `proHasCapturedQuote`; otherwise city-only address and `scrubText()`-scrubbed notes. Write-time gating also covers direct RLS-scoped `bookings` reads from the client, and the full address still reaches the pro through the paid-unlock handoff email.
- `app/api/cleaner/bookings/route.ts` (GET): **before** — `customer:users(id, full_name, email)` + full row for every booking. **After** — batch captured-check; uncaptured customers → redacted embed, `address: ''`, `special_instructions: null` (covers legacy rows written before the wall). `zip_code` stays, matching the pro-view exposure.

### Verification
- `tsc --noEmit`: error count identical to main (56 pre-existing, **0 new**).
- `next build`: ✓ compiled, 87/87 pages.
- Guardrails respected: application-layer only — **no schema, no RLS, no Stripe code**; lead-unlock webhook capture path untouched; one commit; no merge/deploy (Board merges).

### Suggested post-merge check
As a pro without a captured lead: messages list/detail show customer first name + no email; `/api/cleaner/bookings` rows show no street address. After a test capture on one of that customer's quotes, full contact reappears in all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>