### PR TITLE
DLD-557: Fix capture 0-row phantom + checkout session-overwrite race (NEW-03)

### DIFF
--- a/app/api/leads/[quoteId]/unlock/route.ts
+++ b/app/api/leads/[quoteId]/unlock/route.ts
@@ -91,12 +91,30 @@ export async function POST(
   const stripe = getStripe();
 
   if (existing?.status === 'pending' && existing.stripe_checkout_session_id) {
-    // Resume the in-flight checkout rather than minting a duplicate session.
+    // NEW-03 (DLD-557): decide by the prior session's actual state.
+    //  - open (unexpired)  -> resume it; never mint a second payable session.
+    //  - complete          -> the pro already PAID; the webhook capture is in
+    //                         flight. Minting a new session here would let the
+    //                         same lead be paid twice — reject instead.
+    //  - expired           -> fall through; the conditional link below swaps
+    //                         the stale id atomically.
     const prior = await stripe.checkout.sessions.retrieve(existing.stripe_checkout_session_id);
     if (prior.status === 'open' && prior.url) {
       return NextResponse.json({ url: prior.url, leadAcceptanceId: existing.id, resumed: true });
     }
-    // Otherwise fall through and create a fresh session for the existing row.
+    if (prior.status === 'complete') {
+      logger.warn('unlock.session_reuse_rejected: prior session already complete, capture in flight', {
+        function: 'POST',
+        quoteId,
+        leadAcceptanceId: existing.id,
+        priorSessionId: existing.stripe_checkout_session_id,
+      });
+      return NextResponse.json(
+        { error: 'Payment already completed for this lead; unlock is processing.', leadAcceptanceId: existing.id },
+        { status: 409 }
+      );
+    }
+    // expired -> fall through and create a fresh session for the existing row.
   }
 
   // 3 + 4. Insert the keystone row FIRST (status='pending') using the pro's own
@@ -171,20 +189,51 @@ export async function POST(
   //    service-role UPDATE scoped to this exact row id is correct and safe. We
   //    .select() to get the affected rows and treat 0 rows as a hard failure —
   //    never return a checkout URL for a row we couldn't link.
+  //    NEW-03 (DLD-557): the link is a compare-and-swap, not a blind overwrite.
+  //    Guards in the WHERE clause:
+  //      - status must still be 'pending' (a captured row's session id is
+  //        immutable — overwriting it would orphan the paid session), and
+  //      - the stored session id must be exactly what we inspected above
+  //        (the stale/expired one), or NULL for a fresh row.
+  //    A concurrent request that already linked a *different* session makes
+  //    this match 0 rows; we then expire our just-created session (so no
+  //    dangling payable checkout exists) and reject instead of overwriting.
   const admin = createServiceRoleClient();
-  const { data: linked, error: linkErr } = await admin
+  let linkQuery = admin
     .from('lead_acceptances')
     .update({ stripe_checkout_session_id: session.id })
     .eq('id', leadAcceptanceId)
-    .select('id');
+    .eq('status', 'pending');
+  if (existing?.stripe_checkout_session_id) {
+    linkQuery = linkQuery.eq('stripe_checkout_session_id', existing.stripe_checkout_session_id);
+  } else {
+    linkQuery = linkQuery.is('stripe_checkout_session_id', null);
+  }
+  const { data: linked, error: linkErr } = await linkQuery.select('id');
   if (linkErr || !linked || linked.length === 0) {
-    logger.error('Failed to link session to lead_acceptance', {
+    logger.error('unlock.session_link_rejected: 0 rows linked (status changed or session already replaced)', {
       function: 'POST',
       quoteId,
       leadAcceptanceId,
+      newSessionId: session.id,
+      priorSessionId: existing?.stripe_checkout_session_id ?? null,
       rowsAffected: linked?.length ?? 0,
     }, linkErr);
-    return NextResponse.json({ error: 'Could not finalize checkout.' }, { status: 500 });
+    // Best-effort: kill the unlinked session so the pro can't pay a checkout
+    // the webhook will never be able to match.
+    try {
+      await stripe.checkout.sessions.expire(session.id);
+    } catch (expireErr) {
+      logger.error('unlock.session_expire_failed for unlinked session', {
+        function: 'POST',
+        quoteId,
+        sessionId: session.id,
+      }, expireErr);
+    }
+    return NextResponse.json(
+      { error: 'Another checkout for this lead is already in progress. Refresh and try again.' },
+      { status: 409 }
+    );
   }
 
   return NextResponse.json({ url: session.url, leadAcceptanceId });

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -84,9 +84,15 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
             amountCents,
           });
 
-          // Update lead_acceptances: pending → captured
+          // Update lead_acceptances: pending → captured.
+          // NEW-03 (DLD-557): .select() the affected rows and treat 0 rows as a
+          // hard failure. Keying on stripe_checkout_session_id alone previously
+          // passed silently when no row matched (phantom capture: pro paid,
+          // nothing flipped) — e.g. if the session id was replaced after this
+          // checkout was created. Throwing sends it through the retry path and,
+          // if still unmatched, surfaces as a webhook failure Stripe re-delivers.
           const nowIso = new Date().toISOString();
-          const { error: unlockError } = await supabase
+          const { data: capturedRows, error: unlockError } = await supabase
             .from('lead_acceptances')
             .update({
               status: 'captured',
@@ -94,11 +100,22 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
               captured_at: nowIso,
               stripe_payment_intent_id: paymentIntentId,
             })
-            .eq('stripe_checkout_session_id', session.id);
+            .eq('stripe_checkout_session_id', session.id)
+            .select('id');
 
           if (unlockError) {
             logger.error('Failed to update lead_acceptances', { function: 'handleStripeEvent' }, unlockError);
             throw unlockError;
+          }
+          if (!capturedRows || capturedRows.length === 0) {
+            logger.error('capture.zero_rows: no lead_acceptance matched this checkout session — phantom capture averted', {
+              function: 'handleStripeEvent',
+              sessionId: session.id,
+              leadAcceptanceId: lead_acceptance_id ?? null,
+              quoteRequestId: quote_request_id,
+              cleanerId: cleaner_id,
+            });
+            throw new Error(`lead_acceptances capture matched 0 rows for session ${session.id}`);
           }
 
           // Read the quote once (service-role): supplies payments metadata


### PR DESCRIPTION
## DLD-557 — NEW-03 from AUDIT_2026-07

Two failure modes in the $30 lead-unlock money path, both fixed at the exact spots the audit flagged.

### 1. Phantom capture (webhook)
**Before:** the pending→captured flip in `app/api/webhooks/stripe/route.ts` keyed on `stripe_checkout_session_id` with only an error check — a 0-row update passed silently (pro paid, nothing flipped).
**After:** the flip `.select()`s affected rows; **0 rows throws** with full context (`capture.zero_rows` structured log: session id, acceptance id, quote id, cleaner id), which routes through the in-process retry wrapper and then Stripe re-delivery instead of vanishing. Redeliveries that match 1 row remain idempotent (same values re-written).

### 2. Session-overwrite race (unlock route)
**Before:** `app/api/leads/[quoteId]/unlock/route.ts` blindly overwrote `stripe_checkout_session_id` on the acceptance — a second concurrent checkout could orphan the first (paid) session, which then produces exactly the phantom capture above.
**After:** the link is a **compare-and-swap**: writes only when `status='pending'` AND the stored session id equals the stale one we inspected (or `IS NULL` for a fresh row). Lost race → `unlock.session_link_rejected` log, **best-effort `stripe.checkout.sessions.expire()`** of the just-created unlinked session (no dangling payable checkout), and 409. Also: a prior session in `complete` state now **rejects with 409** (`unlock.session_reuse_rejected` — payment already in flight) instead of minting a second payable session; `open` sessions resume exactly as before.

### Guardrails respected
- Branch `fix/new03-capture-race`, **one commit**, PR only — no merge/deploy.
- No schema/RLS changes.
- Payments-insert and contact-email webhook paths **untouched** (diff is confined to the `lead_acceptances` flip block and the unlock route's resume/link logic).

### Verification
- `tsc --noEmit`: 0 new errors (56 = main baseline).
- `next build`: ✓ 87/87 pages.
- Diff: 2 files, +75/−9.

### Suggested post-merge smoke (Stripe test mode)
Double-click the unlock button rapidly → exactly one payable session exists; pay it → capture flips exactly one row; replay the webhook event → no error, no dup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>