### PR TITLE
DLD-559: David AI assistant harness — /api/david (OpenRouter, streaming) behind flag

### DIFF
--- a/app/api/david/route.ts
+++ b/app/api/david/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { rateLimitRoute, getClientIp } from '@/lib/middleware/rate-limit'
+import { createLogger } from '@/lib/utils/logger'
+
+const logger = createLogger({ file: 'api/david/route' })
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 25
+
+// DLD-559: "David" — Boss of Clean's AI assistant, powered by OpenRouter.
+// The key is server-side ONLY (never NEXT_PUBLIC_); the route degrades to a
+// 503 when it's absent so the widget can hide/disable itself gracefully.
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions'
+const DAVID_MODEL = 'google/gemini-flash-1.5'
+const MAX_TOKENS = 500
+
+// 10 messages per IP per hour (standalone config — the traffic-slice branch's
+// shared profile can replace this once merged).
+const DAVID_RATE_LIMIT = { maxRequests: 10, windowSeconds: 3600 }
+
+// Keep request size bounded: last N turns, each capped.
+const MAX_TURNS = 12
+const MAX_CONTENT_CHARS = 1000
+
+const DAVID_SYSTEM_PROMPT =
+  "You are David, the friendly assistant for Boss of Clean, Florida's home and business services marketplace. " +
+  'Help visitors post quote requests, understand how lead fees work for pros, and navigate the site. ' +
+  'Never reveal customer contact information. ' +
+  "Never discuss other companies' platforms. " +
+  'Keep answers short and warm. Tagline: Purrfection is our Standard.'
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export async function POST(request: NextRequest) {
+  const limited = await rateLimitRoute('david-ip', getClientIp(request), DAVID_RATE_LIMIT)
+  if (limited) return limited
+
+  const apiKey = process.env.OPENROUTER_API_KEY
+  if (!apiKey) {
+    // Fail loudly server-side; fail gracefully client-side.
+    logger.error('OPENROUTER_API_KEY is not set — David is unavailable', { function: 'POST' })
+    return NextResponse.json({ error: 'assistant_unavailable' }, { status: 503 })
+  }
+
+  let body: { messages?: ChatMessage[] }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const raw = Array.isArray(body.messages) ? body.messages : []
+  const messages = raw
+    .filter(
+      (m): m is ChatMessage =>
+        !!m &&
+        (m.role === 'user' || m.role === 'assistant') &&
+        typeof m.content === 'string' &&
+        m.content.trim().length > 0
+    )
+    .slice(-MAX_TURNS)
+    .map((m) => ({ role: m.role, content: m.content.slice(0, MAX_CONTENT_CHARS) }))
+
+  if (messages.length === 0 || messages[messages.length - 1].role !== 'user') {
+    return NextResponse.json({ error: 'A user message is required' }, { status: 400 })
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(OPENROUTER_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': 'https://bossofclean.com',
+        'X-Title': 'Boss of Clean — David',
+      },
+      body: JSON.stringify({
+        model: DAVID_MODEL,
+        max_tokens: MAX_TOKENS,
+        stream: true,
+        messages: [{ role: 'system', content: DAVID_SYSTEM_PROMPT }, ...messages],
+      }),
+    })
+  } catch (err) {
+    logger.error('OpenRouter request failed', { function: 'POST' }, err)
+    return NextResponse.json({ error: 'assistant_unavailable' }, { status: 503 })
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    logger.error(`OpenRouter returned ${upstream.status}`, { function: 'POST' })
+    return NextResponse.json({ error: 'assistant_unavailable' }, { status: 503 })
+  }
+
+  // Parse the upstream SSE stream server-side and re-emit plain text deltas —
+  // the widget just appends chunks, no SSE parsing in the browser.
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let sseBuffer = ''
+
+  const textStream = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      sseBuffer += decoder.decode(chunk, { stream: true })
+      const lines = sseBuffer.split('\n')
+      sseBuffer = lines.pop() ?? ''
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed.startsWith('data:')) continue
+        const payload = trimmed.slice(5).trim()
+        if (payload === '[DONE]') continue
+        try {
+          const parsed = JSON.parse(payload) as {
+            choices?: { delta?: { content?: string } }[]
+          }
+          const delta = parsed.choices?.[0]?.delta?.content
+          if (delta) controller.enqueue(encoder.encode(delta))
+        } catch {
+          // Partial/keep-alive lines are expected in SSE — skip quietly.
+        }
+      }
+    },
+  })
+
+  return new Response(upstream.body.pipeThrough(textStream), {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-cache',
+    },
+  })
+}

--- a/components/boc-assistant/BocAssistant.tsx
+++ b/components/boc-assistant/BocAssistant.tsx
@@ -18,6 +18,11 @@ const WELCOME_MESSAGE: Message = {
 
 const BOSS_ORANGE = '#FF5F1F'
 
+// DLD-559: flag-gated cutover to the OpenRouter-powered "David" route.
+// Defaults OFF — the legacy /api/boc-chat path stays live until
+// NEXT_PUBLIC_DAVID_ENABLED=true is set (requires OPENROUTER_API_KEY too).
+const DAVID_ENABLED = process.env.NEXT_PUBLIC_DAVID_ENABLED === 'true'
+
 export default function BocAssistant() {
   const [open, setOpen] = useState(false)
   const [messages, setMessages] = useState<Message[]>([WELCOME_MESSAGE])
@@ -44,12 +49,52 @@ export default function BocAssistant() {
     setLoading(true)
 
     try {
+      const history = next.filter(m => m.id !== 'welcome').map(m => ({ role: m.role, content: m.content }))
+
+      if (DAVID_ENABLED) {
+        // David path: /api/david streams plain-text deltas — append as they arrive.
+        const res = await fetch('/api/david', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messages: history }),
+        })
+
+        if (!res.ok || !res.body) {
+          const fallback = res.status === 429
+            ? "You're sending messages a bit fast — give me a minute and try again."
+            : "I'm having trouble responding right now. Please try again soon."
+          setMessages(prev => [...prev, { id: `a-${Date.now()}`, role: 'assistant', content: fallback }])
+          return
+        }
+
+        const assistantId = `a-${Date.now()}`
+        setMessages(prev => [...prev, { id: assistantId, role: 'assistant', content: '' }])
+        const reader = res.body.getReader()
+        const decoder = new TextDecoder()
+        let acc = ''
+        for (;;) {
+          const { done, value } = await reader.read()
+          if (done) break
+          acc += decoder.decode(value, { stream: true })
+          const current = acc
+          setMessages(prev => prev.map(m => (m.id === assistantId ? { ...m, content: current } : m)))
+        }
+        if (!acc) {
+          setMessages(prev =>
+            prev.map(m =>
+              m.id === assistantId
+                ? { ...m, content: "I'm having trouble responding. Please try again." }
+                : m
+            )
+          )
+        }
+        return
+      }
+
       const res = await fetch('/api/boc-chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          messages: next.filter(m => m.id !== 'welcome').map(m => ({ role: m.role, content: m.content })),
-        }),
+        body: JSON.stringify({ messages: history }),
       })
 
       const data = await res.json()


### PR DESCRIPTION
## DLD-559 — David harness (flag-gated, safe to merge before the key exists)

### `app/api/david/route.ts` (new)
- OpenRouter chat completions: model `google/gemini-flash-1.5`, `max_tokens: 500`, **streaming**. Upstream SSE is parsed server-side and re-emitted as plain-text deltas, so the browser just appends chunks.
- `OPENROUTER_API_KEY` is **server-side only** (never `NEXT_PUBLIC_`). Missing key → loud server log + 503 `assistant_unavailable`; the widget shows a friendly in-chat fallback. **Merging this PR changes nothing in prod until Daniel creates the key AND flips the flag.**
- Rate limit **10 messages/IP/hour** using the existing `rateLimitRoute` helper with a standalone config (per ticket: traffic-slice profile not merged yet; can consolidate later).
- System prompt verbatim from the ticket (David persona, never reveal customer contact info, never discuss other platforms, short + warm, "Purrfection is our Standard").
- Input bounded: last 12 turns, 1,000 chars each, must end with a user message.

### `components/boc-assistant/BocAssistant.tsx`
- When `NEXT_PUBLIC_DAVID_ENABLED=true`: sends to `/api/david` and renders the stream incrementally; 429 → "sending a bit fast" fallback, 503/failed → "try again soon" fallback.
- Default (unset/`false`): the legacy `/api/boc-chat` path is untouched — **zero behavior change** until the flag flips.

### Activation checklist (Daniel)
1. Create the key at openrouter.ai **with a monthly spend cap**, add as `OPENROUTER_API_KEY` in Netlify (not NEXT_PUBLIC_).
2. Set `NEXT_PUBLIC_DAVID_ENABLED=true` in Netlify and redeploy.
3. Smoke: ask David how lead fees work; verify short streamed answer; 11th message in an hour from one IP → friendly rate-limit reply.

### Verification
- `tsc --noEmit`: 0 new errors (56 = main baseline). `next build`: ✓ 87/87 pages, `/api/david` registered.
- Guardrails: one commit, PR only, no merge/deploy; no Stripe/auth/PII code paths; no cross-brand references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>