### PR TITLE
feat(david): OpenRouter assistant on homepage widget, flag-gated

### DIFF
--- a/app/api/david/route.ts
+++ b/app/api/david/route.ts
@@ -11,7 +11,7 @@ export const maxDuration = 25
 // The key is server-side ONLY (never NEXT_PUBLIC_); the route degrades to a
 // 503 when it's absent so the widget can hide/disable itself gracefully.
 const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions'
-const DAVID_MODEL = 'google/gemini-flash-1.5'
+const DAVID_MODEL = 'google/gemini-2.5-flash-lite'
 const MAX_TOKENS = 500
 
 // 10 messages per IP per hour (standalone config — the traffic-slice branch's
@@ -24,10 +24,10 @@ const MAX_CONTENT_CHARS = 1000
 
 const DAVID_SYSTEM_PROMPT =
   "You are David, the friendly assistant for Boss of Clean, Florida's home and business services marketplace. " +
-  'Help visitors post quote requests, understand how lead fees work for pros, and navigate the site. ' +
+  'Help visitors post quote requests, understand how the $30 pay-per-lead model works for pros, and navigate the site. ' +
   'Never reveal customer contact information. ' +
-  "Never discuss other companies' platforms. " +
-  'Keep answers short and warm. Tagline: Purrfection is our Standard.'
+  'Never discuss or recommend competitor platforms. ' +
+  "Keep answers short, warm, professional. Boss of Clean's tagline is 'Purrfection is our Standard.'"
 
 interface ChatMessage {
   role: 'user' | 'assistant'

--- a/components/boc-assistant/BocAssistant.tsx
+++ b/components/boc-assistant/BocAssistant.tsx
@@ -18,10 +18,9 @@ const WELCOME_MESSAGE: Message = {
 
 const BOSS_ORANGE = '#FF5F1F'
 
-// DLD-559: flag-gated cutover to the OpenRouter-powered "David" route.
-// Defaults OFF — the legacy /api/boc-chat path stays live until
-// NEXT_PUBLIC_DAVID_ENABLED=true is set (requires OPENROUTER_API_KEY too).
-const DAVID_ENABLED = process.env.NEXT_PUBLIC_DAVID_ENABLED === 'true'
+// DLD-559: this widget is mounted only when NEXT_PUBLIC_DAVID_ENABLED === 'true'
+// (gated in BocAssistantLoader), so it talks exclusively to the OpenRouter-
+// powered /api/david route.
 
 export default function BocAssistant() {
   const [open, setOpen] = useState(false)
@@ -51,59 +50,42 @@ export default function BocAssistant() {
     try {
       const history = next.filter(m => m.id !== 'welcome').map(m => ({ role: m.role, content: m.content }))
 
-      if (DAVID_ENABLED) {
-        // David path: /api/david streams plain-text deltas — append as they arrive.
-        const res = await fetch('/api/david', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ messages: history }),
-        })
-
-        if (!res.ok || !res.body) {
-          const fallback = res.status === 429
-            ? "You're sending messages a bit fast — give me a minute and try again."
-            : "I'm having trouble responding right now. Please try again soon."
-          setMessages(prev => [...prev, { id: `a-${Date.now()}`, role: 'assistant', content: fallback }])
-          return
-        }
-
-        const assistantId = `a-${Date.now()}`
-        setMessages(prev => [...prev, { id: assistantId, role: 'assistant', content: '' }])
-        const reader = res.body.getReader()
-        const decoder = new TextDecoder()
-        let acc = ''
-        for (;;) {
-          const { done, value } = await reader.read()
-          if (done) break
-          acc += decoder.decode(value, { stream: true })
-          const current = acc
-          setMessages(prev => prev.map(m => (m.id === assistantId ? { ...m, content: current } : m)))
-        }
-        if (!acc) {
-          setMessages(prev =>
-            prev.map(m =>
-              m.id === assistantId
-                ? { ...m, content: "I'm having trouble responding. Please try again." }
-                : m
-            )
-          )
-        }
-        return
-      }
-
-      const res = await fetch('/api/boc-chat', {
+      // /api/david streams plain-text deltas — append as they arrive.
+      const res = await fetch('/api/david', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ messages: history }),
       })
 
-      const data = await res.json()
-      const assistantMsg: Message = {
-        id: `a-${Date.now()}`,
-        role: 'assistant',
-        content: data.reply || "I'm having trouble responding. Please try again.",
+      if (!res.ok || !res.body) {
+        const fallback = res.status === 429
+          ? "You're sending messages a bit fast — give me a minute and try again."
+          : "I'm having trouble responding right now. Please try again soon."
+        setMessages(prev => [...prev, { id: `a-${Date.now()}`, role: 'assistant', content: fallback }])
+        return
       }
-      setMessages(prev => [...prev, assistantMsg])
+
+      const assistantId = `a-${Date.now()}`
+      setMessages(prev => [...prev, { id: assistantId, role: 'assistant', content: '' }])
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let acc = ''
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) break
+        acc += decoder.decode(value, { stream: true })
+        const current = acc
+        setMessages(prev => prev.map(m => (m.id === assistantId ? { ...m, content: current } : m)))
+      }
+      if (!acc) {
+        setMessages(prev =>
+          prev.map(m =>
+            m.id === assistantId
+              ? { ...m, content: "I'm having trouble responding. Please try again." }
+              : m
+          )
+        )
+      }
     } catch {
       setMessages(prev => [
         ...prev,

--- a/components/boc-assistant/BocAssistantLoader.tsx
+++ b/components/boc-assistant/BocAssistantLoader.tsx
@@ -7,6 +7,10 @@ const BocAssistant = dynamic(() => import('./BocAssistant'), { ssr: false })
 
 export default function BocAssistantLoader() {
   const pathname = usePathname()
+  // Gate the whole David widget behind the flag — hidden entirely unless
+  // NEXT_PUBLIC_DAVID_ENABLED is exactly "true" (needs OPENROUTER_API_KEY set
+  // server-side too). Inlined at build time; nothing renders when off.
+  if (process.env.NEXT_PUBLIC_DAVID_ENABLED !== 'true') return null
   // Suppress on all dashboard routes — authenticated users have role-specific support
   if (pathname?.startsWith('/dashboard')) return null
   return <BocAssistant />


### PR DESCRIPTION
Branch `feat/david-assistant`, one commit. Reconciles the existing DLD-559 David harness (already on main via #70) to the current spec. No Stripe/auth/PII/webhook code touched; no schema changes; no SOTSVC/TCE references.

## Changes
- **Model** → `google/gemini-2.5-flash-lite` (was `google/gemini-flash-1.5`), `app/api/david/route.ts`.
- **System prompt** → exact spec text: `$30 pay-per-lead` framing, "Never discuss or recommend competitor platforms", "short, warm, professional", full "Boss of Clean's tagline is 'Purrfection is our Standard.'"
- **Whole-widget gate** → `BocAssistantLoader` returns `null` unless `NEXT_PUBLIC_DAVID_ENABLED === 'true'`. The widget no longer falls back to legacy `/api/boc-chat`; it is David-only, and the now-unreachable fallback branch was removed from `BocAssistant.tsx`.

## Already spec-compliant on main (unchanged)
- `OPENROUTER_API_KEY` read server-side only; never `NEXT_PUBLIC_`; **503** friendly error when missing.
- `max_tokens: 500`, streamed response (server parses upstream SSE, re-emits plain-text deltas; widget appends).
- OpenRouter headers `HTTP-Referer: https://bossofclean.com`, `X-Title: Boss of Clean — David`.
- Rate limit **10 msg / IP / hour** via the existing `lib/middleware/rate-limit.ts` (`rateLimitRoute` + `getClientIp`).

## Verify
- `tsc --noEmit`: zero errors in the three touched files.
- Brand-leak grep (SOTSVC / TCE / other-brand tagline): clean.

## Enablement (no code)
Widget stays hidden until `NEXT_PUBLIC_DAVID_ENABLED=true` is set in Netlify. `OPENROUTER_API_KEY` already present (Functions+Builds+Runtime). No deploy performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)