### PR TITLE
security: RPC EXECUTE lockdown for SECURITY DEFINER functions (apply manually)

### DIFF
--- a/app/dashboard/admin/actions.ts
+++ b/app/dashboard/admin/actions.ts
@@ -286,7 +286,9 @@ export async function verifyDocument(
   const supabase = await createClient()
 
   const { data, error } = await supabase.rpc('verify_document', {
-    p_document_id: documentId
+    p_document_id: documentId,
+    p_status: status,
+    p_notes: notes ?? null
   })
 
   if (error) {

--- a/lib/stripe/webhook-event-service.ts
+++ b/lib/stripe/webhook-event-service.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import { createLogger } from '../utils/logger';
 import type Stripe from 'stripe';
 
@@ -11,7 +11,9 @@ export interface WebhookEventRecord {
 
 export class WebhookEventService {
   private async getSupabase() {
-    return await createClient();
+    // Webhooks have no user session; the RPC helpers require service_role
+    // after the RPC EXECUTE lockdown migration (PR #73).
+    return createServiceRoleClient();
   }
 
   /**

--- a/supabase/migrations/20260709120000_revoke_rpc_execute_lockdown.sql
+++ b/supabase/migrations/20260709120000_revoke_rpc_execute_lockdown.sql
@@ -1,0 +1,124 @@
+-- ============================================================================
+-- RPC EXECUTE LOCKDOWN — revoke anon/authenticated EXECUTE on SECURITY DEFINER
+-- functions exposed via PostgREST (/rest/v1/rpc/*).
+-- Advisor lint: anon_security_definer_function_executable
+-- Project: jisjxdsrflheosvodoxk (Boss of Clean production)
+--
+-- APPLY MANUALLY. Do not auto-push.
+--
+-- NOTE: service_role has BYPASSRLS and its own blanket EXECUTE grant, so all
+-- server code using createServiceRoleClient() is unaffected by these REVOKEs.
+-- However, code using lib/supabase/server.ts runs with the ANON key + user
+-- cookies (role = authenticated, or anon when no session) — those call sites
+-- are what the GRANT section below preserves.
+--
+-- ⚠️ PRE-APPLY REQUIREMENT (BLOCKING):
+-- lib/stripe/webhook-event-service.ts uses the anon-key server client, so the
+-- Stripe webhook route currently calls record_webhook_event /
+-- mark_webhook_processed / mark_webhook_failed / is_webhook_processed as the
+-- `anon` role. This migration revokes those. Before applying, deploy the
+-- one-line fix switching webhook-event-service.ts to createServiceRoleClient()
+-- — otherwise Stripe webhook processing breaks.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. TRIGGER FUNCTIONS — never legitimately RPC-callable
+-- ---------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.enforce_cleaner_location_complete() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.guard_users_role_change() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.handle_user_delete() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_admin_new_signup() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pro_licenses_guard_verification_columns() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.sync_pros_primary_category() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_conversation_last_message() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_conversation_on_message() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_lead_distributions_updated_at() FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2. ADMIN-ONLY FUNCTIONS — called from app/dashboard/admin/actions.ts server
+--    actions, which run as the admin's `authenticated` session (anon-key SSR
+--    client). Revoke anon/PUBLIC; re-grant authenticated below.
+--    ⚠️ approve_cleaner and verify_document(uuid) have NO internal admin
+--    check (app layer verifyAdmin() is the only gate) — follow-up: add an
+--    is_admin() guard inside these functions or move calls to service_role.
+-- ---------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.approve_cleaner(p_cleaner_id uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.reject_cleaner(p_cleaner_id uuid, p_reason text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.request_cleaner_info(p_cleaner_id uuid, p_message text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.verify_document(p_document_id uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.verify_document(p_document_id uuid, p_status text, p_notes text) FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3. WEBHOOK / BILLING / SERVICE-ROLE-ONLY — server-side only; no grants back.
+--    (See BLOCKING note in header re: webhook-event-service.ts code fix.)
+-- ---------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.record_webhook_event(p_event_id character varying, p_event_type character varying, p_payload jsonb, p_customer_id text, p_subscription_id text, p_invoice_id text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.mark_webhook_processed(p_event_id character varying) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.mark_webhook_failed(p_event_id character varying, p_error_message text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.is_webhook_processed(p_event_id character varying) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.increment_payment_failed_count(p_cleaner_id uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_cleaner_billing_dates(p_cleaner_id uuid, p_last_payment_date timestamp with time zone, p_next_billing_date timestamp with time zone, p_reset_failed_count boolean) FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. UNUSED VIA RPC IN CODEBASE — no .rpc() call sites, not referenced by any
+--    RLS policy. Revoke fully.
+-- ---------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.match_lead_pros(p_quote_request_id uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.check_booking_tier_limit(p_customer_id uuid, p_tier subscription_tier) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.check_booking_tier_limit(p_customer_id uuid, p_tier text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.check_lead_unlock_cap(p_quote_request_id uuid, p_cleaner_id uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_comparisons() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_rate_limits() FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 5. QUOTE FLOW + RATE LIMIT + RLS HELPERS — revoke, then grant back the
+--    minimum proven necessary.
+-- ---------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.check_and_increment_customer_limits(p_user_id uuid, p_ip inet, p_increment boolean) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.check_quote_request_tier_limit(p_cleaner_id uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.create_quote_request(p_customer_id uuid, p_cleaner_id uuid, p_service_type text, p_service_date date, p_service_time time without time zone, p_address text, p_city text, p_zip_code text, p_description text, p_special_requests text, p_property_type text, p_property_size text, p_frequency text, p_duration_hours integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.check_rate_limit(p_identifier text, p_endpoint text, p_max_requests integer, p_window_seconds integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.is_admin() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.is_cleaner() FROM PUBLIC, anon, authenticated;
+
+-- ===========================================================================
+-- GRANTS RESTORED (minimum proven by code audit, 2026-07-09)
+-- ===========================================================================
+
+-- RLS helper functions: is_admin() appears in 23 RLS policies, is_cleaner()
+-- in 1 (users_cleaners_view_location). Policies evaluate these as the
+-- querying role, and anon can query policy-bearing public tables (pros,
+-- users, etc.) — both roles need EXECUTE or all reads on those tables fail.
+GRANT EXECUTE ON FUNCTION public.is_admin() TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.is_cleaner() TO anon, authenticated;
+
+-- Quote flow: app/api/quote/route.ts uses the anon-key SSR client and allows
+-- anonymous submitters (p_user_id may be null) → both roles required.
+GRANT EXECUTE ON FUNCTION public.check_and_increment_customer_limits(p_user_id uuid, p_ip inet, p_increment boolean) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_quote_request_tier_limit(p_cleaner_id uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_quote_request(p_customer_id uuid, p_cleaner_id uuid, p_service_type text, p_service_date date, p_service_time time without time zone, p_address text, p_city text, p_zip_code text, p_description text, p_special_requests text, p_property_type text, p_property_size text, p_frequency text, p_duration_hours integer) TO anon, authenticated;
+
+-- Rate limiter: lib/middleware/rate-limit.ts calls /rest/v1/rpc/check_rate_limit
+-- with the raw anon key (Bearer = anon key, no user JWT) → anon required.
+GRANT EXECUTE ON FUNCTION public.check_rate_limit(p_identifier text, p_endpoint text, p_max_requests integer, p_window_seconds integer) TO anon;
+
+-- Admin actions: app/dashboard/admin/actions.ts server actions run as the
+-- admin's authenticated session (anon-key SSR client) after verifyAdmin().
+GRANT EXECUTE ON FUNCTION public.approve_cleaner(p_cleaner_id uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reject_cleaner(p_cleaner_id uuid, p_reason text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.request_cleaner_info(p_cleaner_id uuid, p_message text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.verify_document(p_document_id uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.verify_document(p_document_id uuid, p_status text, p_notes text) TO authenticated;
+
+-- Prevent future functions from inheriting EXECUTE via default PUBLIC grant.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+
+-- ===========================================================================
+-- POST-APPLY VERIFICATION (run manually; expected rows listed in PR)
+-- ===========================================================================
+-- SELECT p.proname, r.rolname FROM pg_proc p
+-- JOIN pg_namespace n ON n.oid=p.pronamespace
+-- CROSS JOIN (VALUES('anon'),('authenticated')) AS r(rolname)
+-- WHERE n.nspname='public'
+-- AND has_function_privilege(r.rolname, p.oid, 'EXECUTE');

--- a/supabase/migrations/20260709130000_admin_guard_privileged_rpcs.sql
+++ b/supabase/migrations/20260709130000_admin_guard_privileged_rpcs.sql
@@ -1,0 +1,151 @@
+-- ============================================================================
+-- ADMIN GUARD FOR PRIVILEGED RPCs
+-- Follow-up to 20260709120000_revoke_rpc_execute_lockdown.sql (PR #73,
+-- section 2 note): these SECURITY DEFINER functions are granted to
+-- `authenticated` but had NO internal admin check — any signed-in user could
+-- call them via /rest/v1/rpc/ directly, bypassing the app-layer verifyAdmin().
+--
+-- This adds `IF NOT public.is_admin() THEN RAISE 42501` as the FIRST
+-- statement. Bodies otherwise byte-identical to live pg_get_functiondef
+-- (pulled 2026-07-09). search_path normalized to `public, pg_temp`
+-- (SECURITY DEFINER hygiene; was `public` only).
+--
+-- APPLY MANUALLY. Do not auto-push.
+--
+-- ⚠️ EXCLUDED — STOPPED PER AUDIT CONSTRAINT (ghost columns, do not guess):
+--   * verify_document(p_document_id uuid) — writes cleaner_documents.status,
+--     which does NOT exist (live column is verification_status). This is the
+--     overload app/dashboard/admin/actions.ts:288 calls, so admin document
+--     verification is ALREADY BROKEN in production. Needs a decided fix
+--     (rewrite against verification_status, or drop in favor of the 3-arg
+--     overload) before a guard can be added.
+--   * verify_document(p_document_id uuid, p_status text, p_notes text) —
+--     writes cleaner_documents.verification_notes, which does NOT exist.
+--     (This overload does have an internal admin check already.)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.approve_cleaner(p_cleaner_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_email text;
+  v_business_name text;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'permission denied: admin only'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.cleaners
+  SET approval_status = 'approved',
+      approved_at = now(),
+      updated_at = now()
+  WHERE id = p_cleaner_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Professional not found');
+  END IF;
+
+  SELECT u.email, c.business_name
+  INTO v_email, v_business_name
+  FROM public.cleaners c
+  JOIN public.users u ON u.id = c.user_id
+  WHERE c.id = p_cleaner_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'email', v_email,
+    'business_name', v_business_name
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.reject_cleaner(p_cleaner_id uuid, p_reason text DEFAULT ''::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_email text;
+  v_business_name text;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'permission denied: admin only'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.cleaners
+  SET approval_status = 'rejected',
+      rejected_reason = p_reason,
+      updated_at = now()
+  WHERE id = p_cleaner_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Professional not found');
+  END IF;
+
+  SELECT u.email, c.business_name
+  INTO v_email, v_business_name
+  FROM public.cleaners c
+  JOIN public.users u ON u.id = c.user_id
+  WHERE c.id = p_cleaner_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'email', v_email,
+    'business_name', v_business_name
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.request_cleaner_info(p_cleaner_id uuid, p_message text DEFAULT ''::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_email text;
+  v_business_name text;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'permission denied: admin only'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.cleaners
+  SET approval_status = 'info_requested',
+      rejected_reason = p_message,
+      updated_at = now()
+  WHERE id = p_cleaner_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Professional not found');
+  END IF;
+
+  SELECT u.email, c.business_name
+  INTO v_email, v_business_name
+  FROM public.cleaners c
+  JOIN public.users u ON u.id = c.user_id
+  WHERE c.id = p_cleaner_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'email', v_email,
+    'business_name', v_business_name
+  );
+END;
+$function$;
+
+-- ===========================================================================
+-- POST-APPLY VERIFICATION (run manually)
+-- ===========================================================================
+-- As a non-admin authenticated user:
+--   select public.approve_cleaner('00000000-0000-0000-0000-000000000000');
+-- must fail with SQLSTATE 42501 'permission denied: admin only'.
+-- As an admin, the admin dashboard approve/reject/request-info flows must
+-- behave unchanged (actions.ts verifyAdmin() session passes is_admin()).

--- a/supabase/migrations/20260709140000_fix_verify_document.sql
+++ b/supabase/migrations/20260709140000_fix_verify_document.sql
@@ -1,0 +1,80 @@
+-- ============================================================================
+-- FIX + CONSOLIDATE verify_document (PR #73, follow-up to the ghost-column
+-- STOP in 20260709130000_admin_guard_privileged_rpcs.sql)
+--
+-- Both live overloads referenced columns that do not exist on
+-- public.cleaner_documents:
+--   * verify_document(uuid)            wrote `status` (live: verification_status)
+--     — this was the overload actions.ts called, so admin document
+--     verification has been broken in production.
+--   * verify_document(uuid,text,text)  wrote `verification_notes` (absent).
+--
+-- This migration drops both and creates ONE guarded 3-arg replacement built
+-- against the live schema. Live CHECK constraint
+-- cleaner_documents_verification_status_check allows:
+--   'pending' | 'verified' | 'rejected' | 'expired'
+-- The function accepts only 'verified' | 'rejected' (admin actions).
+--
+-- SEQUENCING NOTE: migrations 20260709120000 (REVOKE/GRANT on the old
+-- verify_document overloads) are left untouched — they are valid at their
+-- point in the chain, where the old overloads still exist. This migration
+-- supersedes them at the end of the chain.
+--
+-- APPLY MANUALLY. Do not auto-push.
+-- ============================================================================
+
+DROP FUNCTION public.verify_document(uuid);
+DROP FUNCTION public.verify_document(uuid, text, text);
+
+CREATE FUNCTION public.verify_document(
+  p_document_id uuid,
+  p_status text,
+  p_notes text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'permission denied: admin only'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_status NOT IN ('verified', 'rejected') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid status');
+  END IF;
+
+  UPDATE public.cleaner_documents
+  SET verification_status = p_status,
+      verified_at         = now(),
+      verified_by         = auth.uid(),
+      rejection_reason    = CASE WHEN p_status = 'rejected' THEN p_notes
+                                 ELSE rejection_reason END,
+      updated_at          = now()
+  WHERE id = p_document_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Document not found');
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'status', p_status);
+END;
+$function$;
+
+-- Lockdown consistent with PR #73: internally guarded, callable only by
+-- signed-in users (admin server actions run as the admin's authenticated
+-- session). service_role bypasses grants.
+REVOKE EXECUTE ON FUNCTION public.verify_document(p_document_id uuid, p_status text, p_notes text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.verify_document(p_document_id uuid, p_status text, p_notes text) TO authenticated;
+
+-- ===========================================================================
+-- POST-APPLY VERIFICATION (run manually)
+-- ===========================================================================
+-- 1. Only one overload remains:
+--    SELECT pg_get_function_identity_arguments(oid) FROM pg_proc
+--    WHERE proname='verify_document';
+-- 2. As non-admin authenticated: SELECT public.verify_document(gen_random_uuid(),'verified');
+--    must fail with SQLSTATE 42501.
+-- 3. Admin dashboard: verify + reject-with-notes flows on a test document.


### PR DESCRIPTION
## RPC EXECUTE lockdown — migration only, DO NOT MERGE-AND-APPLY blindly

Revokes EXECUTE from `PUBLIC`, `anon`, `authenticated` on all 31 advisor-flagged SECURITY DEFINER functions (33 signatures incl. both `verify_document` and `check_booking_tier_limit` overloads), then grants back only what the code audit proved necessary. **Daniel applies the migration by hand after review. No `db push` was run.**

`service_role` bypasses grants entirely, so all code using `createServiceRoleClient()` is unaffected. But `lib/supabase/server.ts` uses the **anon key + cookies** — those "server" call sites run as `authenticated` (or `anon` with no session), which drives every grant below.

### ⚠️ BLOCKING pre-apply requirement
`lib/stripe/webhook-event-service.ts` uses the anon-key server client, so the Stripe webhook route (`app/api/webhooks/stripe/route.ts`) calls `record_webhook_event` / `mark_webhook_processed` / `mark_webhook_failed` / `is_webhook_processed` **as `anon`**. This migration revokes those grants. Deploy a one-line fix (switch that service to `createServiceRoleClient()`) **before** applying, or Stripe webhook processing breaks.

### 🔴 Findings beyond the lint
- **`approve_cleaner` and `verify_document(uuid)` have NO internal admin check** — today anyone holding the public anon key can approve a cleaner or verify a document via `/rest/v1/rpc/`. This migration closes the `anon` hole; any *authenticated* user can still call them directly (app-layer `verifyAdmin()` only gates the UI path). Follow-up: add an `is_admin()` guard inside these functions or move the calls to service role.
- Added `ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;` so future functions don't reappear in the advisor lint.

### Classification table (Step 1 audit)

| Function | Caller | Role at runtime | Class | Post-migration |
|---|---|---|---|---|
| approve_cleaner, reject_cleaner, request_cleaner_info, verify_document (both) | `app/dashboard/admin/actions.ts` (server action, anon-key SSR client) | authenticated | admin-only | GRANT authenticated |
| check_and_increment_customer_limits, check_quote_request_tier_limit, create_quote_request | `app/api/quote/route.ts` (anon-key SSR client; anonymous submitters allowed) | anon + authenticated | client-facing quote flow | GRANT anon, authenticated |
| check_rate_limit | `lib/middleware/rate-limit.ts` (raw anon key fetch to `/rest/v1/rpc/`) | anon | rate limiter | GRANT anon |
| is_admin, is_cleaner | no `.rpc()` calls; referenced in **23 / 1 RLS policies** (incl. publicly readable `pros`, `users`) | anon + authenticated (policy evaluation) | RLS helper | GRANT anon, authenticated |
| record_webhook_event, mark_webhook_processed, mark_webhook_failed, is_webhook_processed | `lib/stripe/webhook-event-service.ts` ← Stripe webhook route | **anon (bug — see blocking note)** | webhook/service-role-only | revoked; requires code fix |
| increment_payment_failed_count | `lib/stripe/subscription-service.ts` (service role) | service_role | service-role-only | revoked (unaffected) |
| update_cleaner_billing_dates, match_lead_pros, check_booking_tier_limit (both), check_lead_unlock_cap, cleanup_expired_comparisons, cleanup_expired_rate_limits | no call sites, no RLS references | — | unused via RPC | revoked |
| handle_new_user, handle_user_delete, notify_admin_new_signup, enforce_cleaner_location_complete, guard_users_role_change, pro_licenses_guard_verification_columns, sync_pros_primary_category, update_conversation_last_message, update_conversation_on_message, update_lead_distributions_updated_at | trigger functions (RETURNS trigger) | — | trigger | revoked |

Note: `canonical_service_slug` is also called via `.rpc()` (`lib/services/quote-service.ts`, `lib/services/pro-categories.ts`) but was not advisor-flagged; left untouched.

### Post-apply verification
```sql
SELECT p.proname, r.rolname FROM pg_proc p
JOIN pg_namespace n ON n.oid=p.pronamespace
CROSS JOIN (VALUES('anon'),('authenticated')) AS r(rolname)
WHERE n.nspname='public'
AND has_function_privilege(r.rolname, p.oid, 'EXECUTE');
```
Expected among the flagged set: is_admin/is_cleaner (both roles), quote-flow trio (both roles), check_rate_limit (anon), the 5 admin signatures (authenticated only). Nothing else. Then re-run `get_advisors` — `anon_security_definer_function_executable` should clear.




---

## Commit 2: `20260709130000_admin_guard_privileged_rpcs.sql` — is_admin() guards

Adds `IF NOT public.is_admin() THEN RAISE EXCEPTION ... ERRCODE '42501'` as the **first statement** of the privileged cleaner RPCs. Bodies are byte-identical to live `pg_get_functiondef` (pulled 2026-07-09) except the guard and `search_path` normalized from `'public'` to `'public', 'pg_temp'`. SECURITY DEFINER and default volatility preserved; no argument/return/logic changes. `CREATE OR REPLACE` retains existing grants, so the commit-1 grant set stands.

**Zero app changes needed:** `app/dashboard/admin/actions.ts` already runs each RPC as the admin's authenticated session after `verifyAdmin()`, so `is_admin()` returns true on the legitimate path. Non-admin authenticated users hitting `/rest/v1/rpc/` directly now get SQLSTATE 42501.

### 🛑 STOPPED: both `verify_document` overloads EXCLUDED (ghost columns)

Per audit constraint (report, don't guess):

- **`verify_document(p_document_id uuid)`** writes `cleaner_documents.status`, which **does not exist** — the live column is `verification_status`. This is the overload `app/dashboard/admin/actions.ts:288` calls, meaning **admin document verification is already broken in production** (every call errors 42703 undefined_column).
- **`verify_document(p_document_id uuid, p_status text, p_notes text)`** writes `cleaner_documents.verification_notes`, which **also does not exist**. (This overload does contain its own internal admin check.)

Live `cleaner_documents` columns: id, cleaner_id, document_type, file_name, file_url, file_size, mime_type, verification_status, verified_at, verified_by, rejection_reason, expires_at, metadata, created_at, updated_at.

**Decision needed from Daniel:** rewrite the 1-arg overload against `verification_status` (and fix/drop the 3-arg one), or drop the broken 1-arg overload and point actions.ts at a corrected 3-arg version. Guard will be added in the same fix.

### ⚠️ Discrepancy vs. task brief
The brief stated the `webhook-event-service.ts` service-role fix is already on this branch — **it is not**. The branch contains only the two migration files. The blocking pre-apply requirement from commit 1 (switch `lib/stripe/webhook-event-service.ts` to `createServiceRoleClient()` before applying the revoke migration) still stands.

### Before/after bodies (diff review)

<details><summary><code>approve_cleaner(p_cleaner_id uuid)</code> — BEFORE (live)</summary>

```sql
CREATE OR REPLACE FUNCTION public.approve_cleaner(p_cleaner_id uuid)
 RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path TO 'public'
AS $function$
DECLARE
  v_email text;
  v_business_name text;
BEGIN
  UPDATE public.cleaners
  SET approval_status = 'approved',
      approved_at = now(),
      updated_at = now()
  WHERE id = p_cleaner_id;

  IF NOT FOUND THEN
    RETURN jsonb_build_object('success', false, 'error', 'Professional not found');
  END IF;

  SELECT u.email, c.business_name
  INTO v_email, v_business_name
  FROM public.cleaners c
  JOIN public.users u ON u.id = c.user_id
  WHERE c.id = p_cleaner_id;

  RETURN jsonb_build_object(
    'success', true,
    'email', v_email,
    'business_name', v_business_name
  );
END;
$function$
```
</details>

<details><summary><code>reject_cleaner(p_cleaner_id uuid, p_reason text DEFAULT '')</code> — BEFORE (live)</summary>

```sql
CREATE OR REPLACE FUNCTION public.reject_cleaner(p_cleaner_id uuid, p_reason text DEFAULT ''::text)
 RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path TO 'public'
AS $function$
DECLARE
  v_email text;
  v_business_name text;
BEGIN
  UPDATE public.cleaners
  SET approval_status = 'rejected',
      rejected_reason = p_reason,
      updated_at = now()
  WHERE id = p_cleaner_id;

  IF NOT FOUND THEN
    RETURN jsonb_build_object('success', false, 'error', 'Professional not found');
  END IF;

  SELECT u.email, c.business_name
  INTO v_email, v_business_name
  FROM public.cleaners c
  JOIN public.users u ON u.id = c.user_id
  WHERE c.id = p_cleaner_id;

  RETURN jsonb_build_object(
    'success', true,
    'email', v_email,
    'business_name', v_business_name
  );
END;
$function$
```
</details>

<details><summary><code>request_cleaner_info(p_cleaner_id uuid, p_message text DEFAULT '')</code> — BEFORE (live)</summary>

```sql
CREATE OR REPLACE FUNCTION public.request_cleaner_info(p_cleaner_id uuid, p_message text DEFAULT ''::text)
 RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path TO 'public'
AS $function$
DECLARE
  v_email text;
  v_business_name text;
BEGIN
  UPDATE public.cleaners
  SET approval_status = 'info_requested',
      rejected_reason = p_message,
      updated_at = now()
  WHERE id = p_cleaner_id;

  IF NOT FOUND THEN
    RETURN jsonb_build_object('success', false, 'error', 'Professional not found');
  END IF;

  SELECT u.email, c.business_name
  INTO v_email, v_business_name
  FROM public.cleaners c
  JOIN public.users u ON u.id = c.user_id
  WHERE c.id = p_cleaner_id;

  RETURN jsonb_build_object(
    'success', true,
    'email', v_email,
    'business_name', v_business_name
  );
END;
$function$
```
</details>

<details><summary><code>verify_document(p_document_id uuid)</code> — BEFORE (live, EXCLUDED — ghost column <code>status</code>)</summary>

```sql
CREATE OR REPLACE FUNCTION public.verify_document(p_document_id uuid)
 RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path TO 'public'
AS $function$
BEGIN
  UPDATE public.cleaner_documents
  SET status = 'verified',        -- ❌ ghost column (live: verification_status)
      updated_at = now()
  WHERE id = p_document_id;

  IF NOT FOUND THEN
    RETURN jsonb_build_object('success', false, 'error', 'Document not found');
  END IF;

  RETURN jsonb_build_object('success', true);
END;
$function$
```
</details>

<details><summary><code>verify_document(p_document_id uuid, p_status text, p_notes text DEFAULT NULL)</code> — BEFORE (live, EXCLUDED — ghost column <code>verification_notes</code>)</summary>

```sql
CREATE OR REPLACE FUNCTION public.verify_document(p_document_id uuid, p_status text, p_notes text DEFAULT NULL::text)
 RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path TO 'public'
AS $function$
DECLARE
  v_admin_id uuid;
  v_cleaner_id uuid;
  v_doc_type text;
  v_trust_score int;
  v_verification_level text;
BEGIN
  IF p_status NOT IN ('verified', 'rejected', 'expired') THEN
    RETURN jsonb_build_object('success', false, 'error', 'Invalid status');
  END IF;

  -- Must be admin
  SELECT id INTO v_admin_id FROM public.users
    WHERE id = (SELECT auth.uid()) AND role = 'admin';
  IF v_admin_id IS NULL THEN
    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
  END IF;

  -- Get document info
  SELECT cleaner_id, document_type INTO v_cleaner_id, v_doc_type
    FROM public.cleaner_documents WHERE id = p_document_id;
  IF NOT FOUND THEN
    RETURN jsonb_build_object('success', false, 'error', 'Document not found');
  END IF;

  -- Update document record
  UPDATE public.cleaner_documents SET
    verification_status = p_status,
    verification_notes  = p_notes,   -- ❌ ghost column (not in live table)
    rejection_reason    = CASE WHEN p_status = 'rejected' THEN p_notes ELSE NULL END,
    verified_at         = CASE WHEN p_status IN ('verified', 'rejected') THEN now() ELSE verified_at END,
    verified_by         = v_admin_id,
    updated_at          = now()
  WHERE id = p_document_id;

  -- Update cleaner verification flags based on doc type
  IF p_status = 'verified' THEN
    CASE v_doc_type
      WHEN 'insurance'         THEN UPDATE public.cleaners SET insurance_verified = true, updated_at = now() WHERE id = v_cleaner_id;
      WHEN 'id_photo'          THEN UPDATE public.cleaners SET photo_verified = true,     updated_at = now() WHERE id = v_cleaner_id;
      WHEN 'background_check'  THEN UPDATE public.cleaners SET background_check_verified = true, updated_at = now() WHERE id = v_cleaner_id;
      WHEN 'license'           THEN UPDATE public.cleaners SET license_verified = true,   updated_at = now() WHERE id = v_cleaner_id;
      ELSE NULL;
    END CASE;
  ELSIF p_status = 'rejected' THEN
    CASE v_doc_type
      WHEN 'insurance'         THEN UPDATE public.cleaners SET insurance_verified = false, updated_at = now() WHERE id = v_cleaner_id;
      WHEN 'id_photo'          THEN UPDATE public.cleaners SET photo_verified = false,     updated_at = now() WHERE id = v_cleaner_id;
      WHEN 'background_check'  THEN UPDATE public.cleaners SET background_check_verified = false, updated_at = now() WHERE id = v_cleaner_id;
      WHEN 'license'           THEN UPDATE public.cleaners SET license_verified = false,   updated_at = now() WHERE id = v_cleaner_id;
      ELSE NULL;
    END CASE;
  END IF;

  -- Recalculate trust_score and verification_level
  SELECT
    (CASE WHEN photo_verified THEN 20 ELSE 0 END) +
    (CASE WHEN insurance_verified THEN 30 ELSE 0 END) +
    (CASE WHEN background_check_verified THEN 20 ELSE 0 END) +
    (CASE WHEN license_verified THEN 10 ELSE 0 END)
  INTO v_trust_score
  FROM public.cleaners WHERE id = v_cleaner_id;

  v_verification_level := CASE
    WHEN v_trust_score >= 80 THEN 'fully_verified'
    WHEN v_trust_score >= 50 THEN 'partially_verified'
    WHEN v_trust_score >= 20 THEN 'basic_verified'
    ELSE 'unverified'
  END;

  UPDATE public.cleaners SET
    trust_score        = v_trust_score,
    verification_level = v_verification_level,
    updated_at         = now()
  WHERE id = v_cleaner_id;

  RETURN jsonb_build_object(
    'success', true,
    'cleaner_id', v_cleaner_id,
    'document_type', v_doc_type,
    'status', p_status,
    'trust_score', v_trust_score,
    'verification_level', v_verification_level
  );
END;
$function$
```
</details>

**AFTER** bodies are in `supabase/migrations/20260709130000_admin_guard_privileged_rpcs.sql` — the only deltas per function are the guard block inserted after `BEGIN` and `SET search_path TO 'public', 'pg_temp'`.




---

## Commit 3: webhook service-role fix + verify_document rebuild — branch now apply-ready

### Task A — webhook client fix (clears the blocking pre-apply requirement)
`lib/stripe/webhook-event-service.ts`:
```diff
-import { createClient } from '@/lib/supabase/server';
+import { createServiceRoleClient } from '@/lib/supabase/service-role';
 ...
   private async getSupabase() {
-    return await createClient();
+    // Webhooks have no user session; the RPC helpers require service_role
+    // after the RPC EXECUTE lockdown migration (PR #73).
+    return createServiceRoleClient();
   }
```
Verified: no other file in the Stripe webhook path calls the four webhook RPCs (`app/api/webhooks/stripe/route.ts` already uses `createServiceRoleClient()` for its own queries; `webhook-event-service.ts` was the sole RPC caller). The discrepancy note from the previous update is resolved.

### Task B — `20260709140000_fix_verify_document.sql`
Live CHECK constraint `cleaner_documents_verification_status_check` allows **'pending' | 'verified' | 'rejected' | 'expired'** — the requested `'verified'/'rejected'` literals match, so no STOP was needed.

- `DROP FUNCTION public.verify_document(uuid)` and `(uuid, text, text)` — both wrote ghost columns (`status` / `verification_notes`).
- Recreated one 3-arg `verify_document(p_document_id uuid, p_status text, p_notes text DEFAULT NULL) RETURNS jsonb`, SECURITY DEFINER, `search_path = public, pg_temp`, with the `is_admin()` 42501 guard as the first statement, writing only live columns (`verification_status`, `verified_at`, `verified_by = auth.uid()`, `rejection_reason` on reject, `updated_at`).
- One deliberate deviation from the brief: "no row matched" returns `jsonb {success:false, error:'Document not found'}` instead of RAISE — this matches the `data?.success / data?.error` contract `actions.ts` already checks and the old overloads' behavior. (Invalid status handled the same way.)
- `REVOKE ... FROM PUBLIC, anon, authenticated; GRANT ... TO authenticated;` consistent with the PR pattern.
- Migrations 1 and 2 left untouched: their old-overload REVOKE/GRANT lines are valid at their point in the chain; this migration supersedes them at the end. Noted in the file header.

Dropped from commit-2's known limitation: the trust-score/verification-flag recalculation logic from the old 3-arg overload was **not** carried over — it referenced only live columns but was never reachable (the app called the broken 1-arg overload). If you want `cleaners.insurance_verified`/`trust_score`/`verification_level` updated on document verification, say so and I'll add it back against the live schema.

### Task C — caller
`app/dashboard/admin/actions.ts` `verifyDocument` now passes `p_status` and `p_notes` through. The UI (`cleaner-detail-modal.tsx:139`) already offered both **verify and reject-with-notes** and was passing them — the old action silently dropped both and blind-verified. No UI gap; zero component changes needed.

Pre-existing, untouched: `actions.ts:47` TS2352 error exists on main (unrelated `getProContact` cast).

### Apply order (manual, by Daniel)
1. Deploy this branch's code (webhook service-role fix + actions.ts) — safe before migrations.
2. Apply `20260709120000_revoke_rpc_execute_lockdown.sql`
3. Apply `20260709130000_admin_guard_privileged_rpcs.sql`
4. Apply `20260709140000_fix_verify_document.sql`
5. Run the verification queries in each file footer; re-run `get_advisors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdbyDufwshZ5uK3ydLy4Z
