### PR TITLE
perf: RLS traffic-prep — FK indexes, initplan fixes, top-5 policy consolidation (drafts, apply manually)

### DIFF
--- a/docs/perf/rls-traffic-prep-analysis.md
+++ b/docs/perf/rls-traffic-prep-analysis.md
@@ -1,0 +1,114 @@
+# RLS Traffic-Prep Analysis — 2026-07-10
+
+Source: Supabase performance advisor (live run) + full `pg_policies` pull.
+Advisor totals: **297 multiple_permissive_policies**, **10 auth_rls_initplan**,
+**3 unindexed_foreign_keys**, **3 duplicate_index** (also 84 `unused_index` and
+1 `auth_db_connections_absolute` — both explicitly out of scope here).
+
+**Nothing in this branch has been applied.** Three draft migrations:
+
+| File | Scope |
+|---|---|
+| `20260710170000_perf_fk_indexes_and_dup_indexes.sql` | A: 3 FK indexes + drop 3 duplicate indexes |
+| `20260710170100_perf_rls_initplan_fixes.sql` | B: wrap `auth.*()` in `(SELECT …)` in the 10 flagged policies |
+| `20260710170200_perf_policy_consolidation_top5.sql` | C: consolidate permissive policies on users, pros, quote_requests, conversations, messages, payments |
+
+## A — Indexes
+
+FK covers: `notification_logs(quote_request_id)`, `pro_licenses(verified_by)`,
+`service_categories(alias_for)`. Duplicates dropped (keeping the `idx_*` twin):
+`pii_filter_log_conversation_idx`, `pii_filter_log_created_idx`,
+`pii_filter_log_sender_idx`. Plain `CREATE INDEX` (not CONCURRENTLY — cannot run
+in a migration transaction; fine at pre-launch row counts, noted in the file).
+
+## B — initplan offenders (10)
+
+| Table | Policy | Wrapped call |
+|---|---|---|
+| rate_limits | Service role manage rate_limits | auth.jwt() |
+| notifications | Service role can insert notifications | auth.role() |
+| booking_photos | Cleaners can manage own booking photos | auth.uid() |
+| booking_photos | Customers can view their booking photos | auth.uid() |
+| bookings | Service role full access to bookings | auth.role() |
+| cleaner_blocked_dates | Service role full access to cleaner_blocked_dates | auth.role() |
+| pii_filter_log | Admins can read pii_filter_log | auth.uid() |
+| admin_actions | Admins can manage admin_actions | auth.uid() |
+| service_categories | service_categories: admin reads all | auth.uid() |
+| service_categories | service_categories: admin writes | auth.uid() |
+
+All rewrites are `ALTER POLICY` (roles/commands untouched); expressions are the
+live quals verbatim with only the `auth.*()` call sites wrapped. None of these
+policies are on `public.users`.
+
+## C — Consolidation soundness argument
+
+Postgres permissive policies are an OR-set: a row passes USING if **any**
+applicable permissive policy's USING passes, and a new row passes WITH CHECK if
+**any** applicable permissive policy's effective WITH CHECK passes — the two are
+evaluated independently across the set (a policy with null WITH CHECK
+contributes its USING). Therefore one merged policy per (role, command) with
+OR'd USINGs and OR'd effective WITH CHECKs is **exactly** equivalent. No pair
+required a judgment call; nothing was flagged unmergeable.
+
+Role note: admin ALL policies declared `TO authenticated` (pros, conversations)
+merge into `TO public` per-command policies via an `is_admin()` disjunct —
+equivalent because `is_admin()` is false for anon sessions.
+
+### Before → after, per table (semantics checklist)
+
+**users** (service_role ALL policy kept as-is)
+| Cmd | Before (who) | After (who) |
+|---|---|---|
+| SELECT | admin (users_admin_all) ∪ self (users_select_own) ∪ self-or-cleaner-views-customers (users_cleaners_view_location) | identical set: admin ∪ self ∪ (cleaner ∧ row.role='customer') — `users_select` |
+| INSERT | admin ∪ self | identical — `users_insert` |
+| UPDATE | admin ∪ self (check: admin ∪ self) | identical — `users_update` |
+| DELETE | admin only (via ALL) | identical — `users_delete_admin` |
+
+users hard rule respected: no policy on users references users; `is_admin()` /
+`is_cleaner()` are SECURITY DEFINER helpers already used on this table today.
+
+**pros**
+| Cmd | Before | After |
+|---|---|---|
+| SELECT | admin ∪ owner ∪ anyone-if-approved | identical — `pros_select` |
+| INSERT | admin ∪ owner | identical — `pros_insert` |
+| UPDATE | admin ∪ owner (checks same) | identical — `pros_update` |
+| DELETE | admin only | identical — `pros_delete_admin` |
+
+**quote_requests** (service_role ALL policy kept as-is)
+| Cmd | Before | After |
+|---|---|---|
+| SELECT | admin ∪ customer-own ∪ pro-assigned ∪ approved-pro-marketplace(pending, unclaimed) | identical — `quote_requests_select` |
+| INSERT | admin ∪ customer-own | identical — `quote_requests_insert` |
+| UPDATE | USING: admin ∪ customer-own-pending ∪ pro-assigned ∪ approved-pro-marketplace; CHECK: admin ∪ customer-own-pending ∪ cleaner_id-in-own-pros (marketplace claim) | identical — the marketplace claim check equals the pro-assigned qual, so the merged CHECK's three disjuncts cover the original four policies' effective checks exactly |
+| DELETE | admin only | identical |
+
+**conversations**
+| Cmd | Before | After |
+|---|---|---|
+| SELECT | admin ∪ customer-participant ∪ cleaner-participant | identical |
+| INSERT | admin ∪ customer-self (uid not null ∧ customer_id=uid) | identical |
+| UPDATE | admin (check admin) ∪ participants (check = qual) | identical |
+| DELETE | admin only | identical |
+
+**messages** (no DELETE policy existed before — none created; admins still have
+NO insert/update on messages, only SELECT of reported ones — not widened)
+| Cmd | Before | After |
+|---|---|---|
+| SELECT | admin-of-reported ∪ customer-participant ∪ cleaner-participant | identical |
+| INSERT | customer-sender-in-own-convo ∪ cleaner-sender-in-own-convo | identical |
+| UPDATE | USING: participants-report ∪ recipient-mark-read; CHECK: reported_by=uid ∪ recipient-mark-read-qual (null check → qual) | identical |
+
+**payments**
+| Cmd | Before | After |
+|---|---|---|
+| SELECT | admin ∪ own-cleaner | identical |
+| INSERT | admin (ALL, null check → qual) ∪ own-cleaner | identical |
+| UPDATE | admin ∪ own-cleaner (checks same) | identical |
+| DELETE | admin only | identical |
+
+## Follow-up ticket scope (not in this branch)
+- ~30 remaining tables with multiple_permissive_policies (297 warnings total;
+  this branch clears the 6 highest-traffic tables).
+- 84 unused_index findings — review after launch traffic, not before.
+- auth_db_connections_absolute — pooler sizing, ops decision.

--- a/docs/perf/rls-traffic-prep-analysis.md
+++ b/docs/perf/rls-traffic-prep-analysis.md
@@ -10,7 +10,7 @@ Advisor totals: **297 multiple_permissive_policies**, **10 auth_rls_initplan**,
 | File | Scope |
 |---|---|
 | `20260710170000_perf_fk_indexes_and_dup_indexes.sql` | A: 3 FK indexes + drop 3 duplicate indexes |
-| `20260710170100_perf_rls_initplan_fixes.sql` | B: wrap `auth.*()` in `(SELECT …)` in the 10 flagged policies |
+| `20260710170100_perf_initplan_fixes.sql` | B: wrap `auth.*()` in `(SELECT …)` in the 10 flagged policies |
 | `20260710170200_perf_policy_consolidation_top5.sql` | C: consolidate permissive policies on users, pros, quote_requests, conversations, messages, payments |
 
 ## A — Indexes

--- a/supabase/migrations/20260710170000_perf_fk_indexes_and_dup_indexes.sql
+++ b/supabase/migrations/20260710170000_perf_fk_indexes_and_dup_indexes.sql
@@ -1,0 +1,32 @@
+-- ============================================================================
+-- PERF A: cover the 3 unindexed FKs, drop the 3 duplicate indexes
+-- Advisor lints: unindexed_foreign_keys (3), duplicate_index (3)
+-- APPLY MANUALLY. Nothing here has been applied.
+--
+-- NOTE: CREATE INDEX CONCURRENTLY cannot run inside a transaction, so it
+-- cannot be used in a migration file. At current pre-launch row counts
+-- (all three tables are small) a plain CREATE INDEX takes milliseconds and
+-- a brief lock is acceptable. If applying post-launch with real traffic,
+-- run the CONCURRENTLY variants by hand instead.
+-- ============================================================================
+
+-- Unindexed foreign keys
+CREATE INDEX IF NOT EXISTS idx_notification_logs_quote_request_id
+  ON public.notification_logs (quote_request_id);
+CREATE INDEX IF NOT EXISTS idx_pro_licenses_verified_by
+  ON public.pro_licenses (verified_by);
+CREATE INDEX IF NOT EXISTS idx_service_categories_alias_for
+  ON public.service_categories (alias_for);
+
+-- Duplicate indexes on pii_filter_log — keep the idx_* variants, drop twins
+DROP INDEX IF EXISTS public.pii_filter_log_conversation_idx;
+DROP INDEX IF EXISTS public.pii_filter_log_created_idx;
+DROP INDEX IF EXISTS public.pii_filter_log_sender_idx;
+
+-- ---------------------------------------------------------------------------
+-- POST-APPLY VERIFICATION
+-- SELECT indexname FROM pg_indexes WHERE tablename IN
+--   ('notification_logs','pro_licenses','service_categories','pii_filter_log')
+-- ORDER BY tablename, indexname;
+-- Expect the three new idx_*; expect NO *_idx twins on pii_filter_log.
+-- ---------------------------------------------------------------------------

--- a/supabase/migrations/20260710170100_perf_initplan_fixes.sql
+++ b/supabase/migrations/20260710170100_perf_initplan_fixes.sql
@@ -1,0 +1,72 @@
+-- ============================================================================
+-- PERF B: auth_rls_initplan — wrap per-row auth.*() calls in scalar
+-- subselects so Postgres evaluates them ONCE per statement (InitPlan)
+-- instead of once per row. 10 advisor-flagged policies across 9 tables;
+-- expressions below are the live pg_policies quals (pulled fresh 2026-07-10)
+-- verbatim, with ONLY the auth.uid()/auth.role()/auth.jwt() call sites
+-- wrapped. ALTER POLICY preserves each policy's roles and command.
+--
+-- None of these policies are on public.users, so the "users policies must
+-- never self-reference users" rule is not in play (the EXISTS-against-users
+-- admin pattern inside OTHER tables' policies is unchanged).
+--
+-- ZERO overlap with 20260710170200 (consolidation): that file touches only
+-- users/pros/quote_requests/conversations/messages/payments; this file
+-- touches none of those tables.
+--
+-- APPLY MANUALLY. Nothing applied.
+-- ============================================================================
+
+ALTER POLICY "Service role manage rate_limits" ON public.rate_limits
+  USING ((( SELECT auth.jwt() ) ->> 'role'::text) = 'service_role'::text)
+  WITH CHECK ((( SELECT auth.jwt() ) ->> 'role'::text) = 'service_role'::text);
+
+ALTER POLICY "Service role can insert notifications" ON public.notifications
+  WITH CHECK ((( SELECT auth.role() ) = 'service_role'::text) OR is_admin());
+
+ALTER POLICY "Cleaners can manage own booking photos" ON public.booking_photos
+  USING (cleaner_id IN ( SELECT pros.id
+     FROM pros
+    WHERE (pros.user_id = ( SELECT auth.uid() ))));
+
+ALTER POLICY "Customers can view their booking photos" ON public.booking_photos
+  USING ((booking_id)::text IN ( SELECT (booking_history.id)::text AS id
+     FROM booking_history
+    WHERE (booking_history.customer_id = ( SELECT auth.uid() ))));
+
+ALTER POLICY "Service role full access to bookings" ON public.bookings
+  USING (( SELECT auth.role() ) = 'service_role'::text);
+
+ALTER POLICY "Service role full access to cleaner_blocked_dates" ON public.cleaner_blocked_dates
+  USING (( SELECT auth.role() ) = 'service_role'::text);
+
+ALTER POLICY "Admins can read pii_filter_log" ON public.pii_filter_log
+  USING (EXISTS ( SELECT 1
+     FROM users
+    WHERE ((users.id = ( SELECT auth.uid() )) AND (users.role = 'admin'::user_role))));
+
+ALTER POLICY "Admins can manage admin_actions" ON public.admin_actions
+  USING (EXISTS ( SELECT 1
+     FROM users
+    WHERE ((users.id = ( SELECT auth.uid() )) AND (users.role = 'admin'::user_role))));
+
+ALTER POLICY "service_categories: admin reads all" ON public.service_categories
+  USING (EXISTS ( SELECT 1
+     FROM users
+    WHERE ((users.id = ( SELECT auth.uid() )) AND (users.role = 'admin'::user_role))));
+
+ALTER POLICY "service_categories: admin writes" ON public.service_categories
+  USING (EXISTS ( SELECT 1
+     FROM users
+    WHERE ((users.id = ( SELECT auth.uid() )) AND (users.role = 'admin'::user_role))))
+  WITH CHECK (EXISTS ( SELECT 1
+     FROM users
+    WHERE ((users.id = ( SELECT auth.uid() )) AND (users.role = 'admin'::user_role))));
+
+-- ---------------------------------------------------------------------------
+-- POST-APPLY VERIFICATION
+-- Re-run the Supabase performance advisor: auth_rls_initplan must report 0.
+-- Spot-check one qual:
+--   SELECT qual FROM pg_policies WHERE policyname='Admins can manage admin_actions';
+--   must contain '( SELECT auth.uid()'.
+-- ---------------------------------------------------------------------------

--- a/supabase/migrations/20260710170200_perf_policy_consolidation_top5.sql
+++ b/supabase/migrations/20260710170200_perf_policy_consolidation_top5.sql
@@ -1,0 +1,268 @@
+-- ============================================================================
+-- PERF C: consolidate multiple permissive policies — TOP 5 TRAFFIC TABLES ONLY
+-- (users, pros, quote_requests, conversations+messages, payments).
+-- Remaining ~30 tables are a follow-up ticket. APPLY MANUALLY.
+--
+-- Soundness: Postgres evaluates PERMISSIVE policies as an OR-set, and USING /
+-- WITH CHECK are each satisfied if ANY applicable permissive policy passes —
+-- independently of which one. Therefore, for a given (role, command), replacing
+-- N permissive policies with ONE whose USING is the OR of the N USINGs and
+-- whose WITH CHECK is the OR of the N effective WITH CHECKs (a policy with a
+-- null WITH CHECK contributes its USING) is EXACTLY equivalent.
+--
+-- Role-narrowing note: admin ALL policies previously declared TO authenticated
+-- (pros, conversations) or TO public are merged into TO public per-command
+-- policies via an is_admin() disjunct. Equivalent because is_admin() is
+-- definitionally false for anon/unauthenticated sessions.
+--
+-- The 'cleaner' role string is preserved verbatim everywhere. service_role
+-- ALL policies (users, quote_requests) are left untouched — they are a
+-- different role and do not stack with public/authenticated in the planner
+-- the way the flagged pairs do.
+--
+-- Per-table DROP+CREATE runs inside this single migration transaction.
+-- ============================================================================
+
+-- ═══════════════════════════ users ═══════════════════════════
+-- HARD RULE: users policies never self-reference public.users. is_admin() and
+-- is_cleaner() are SECURITY DEFINER helpers (no RLS recursion) and are the
+-- pre-existing live pattern on this exact table — preserved, not widened.
+DROP POLICY "users_admin_all" ON public.users;
+DROP POLICY "users_select_own" ON public.users;
+DROP POLICY "users_cleaners_view_location" ON public.users;
+DROP POLICY "users_insert_own" ON public.users;
+DROP POLICY "users_update_own" ON public.users;
+
+CREATE POLICY "users_select" ON public.users FOR SELECT TO public
+  USING (
+    is_admin()
+    OR (( SELECT auth.uid() ) = id)
+    OR (is_cleaner() AND role = 'customer'::user_role)
+  );
+CREATE POLICY "users_insert" ON public.users FOR INSERT TO public
+  WITH CHECK ( is_admin() OR (( SELECT auth.uid() ) = id) );
+CREATE POLICY "users_update" ON public.users FOR UPDATE TO public
+  USING ( is_admin() OR (( SELECT auth.uid() ) = id) )
+  WITH CHECK ( is_admin() OR (( SELECT auth.uid() ) = id) );
+CREATE POLICY "users_delete_admin" ON public.users FOR DELETE TO public
+  USING ( is_admin() );
+
+-- ═══════════════════════════ pros ═══════════════════════════
+DROP POLICY "admin_full_access" ON public.pros;
+DROP POLICY "Users can view their cleaner profile" ON public.pros;
+DROP POLICY "public_can_view_approved_cleaners" ON public.pros;
+DROP POLICY "Users can create their own cleaner profile" ON public.pros;
+DROP POLICY "Users can update their cleaner profile" ON public.pros;
+
+CREATE POLICY "pros_select" ON public.pros FOR SELECT TO public
+  USING (
+    is_admin()
+    OR (( SELECT auth.uid() ) = user_id)
+    OR (approval_status = 'approved'::approval_status)
+  );
+CREATE POLICY "pros_insert" ON public.pros FOR INSERT TO public
+  WITH CHECK ( is_admin() OR (( SELECT auth.uid() ) = user_id) );
+CREATE POLICY "pros_update" ON public.pros FOR UPDATE TO public
+  USING ( is_admin() OR (( SELECT auth.uid() ) = user_id) )
+  WITH CHECK ( is_admin() OR (( SELECT auth.uid() ) = user_id) );
+CREATE POLICY "pros_delete_admin" ON public.pros FOR DELETE TO public
+  USING ( is_admin() );
+
+-- ═══════════════════════ quote_requests ═══════════════════════
+-- quote_requests_service_role_access (TO service_role) intentionally kept.
+DROP POLICY "quote_requests_admin_all" ON public.quote_requests;
+DROP POLICY "quote_requests_customers_select_own" ON public.quote_requests;
+DROP POLICY "quote_requests_cleaners_select_assigned" ON public.quote_requests;
+DROP POLICY "quote_requests_cleaners_select_marketplace" ON public.quote_requests;
+DROP POLICY "quote_requests_customers_insert_own" ON public.quote_requests;
+DROP POLICY "quote_requests_customers_update_own" ON public.quote_requests;
+DROP POLICY "quote_requests_cleaners_update_assigned" ON public.quote_requests;
+DROP POLICY "quote_requests_cleaners_update_marketplace" ON public.quote_requests;
+
+CREATE POLICY "quote_requests_select" ON public.quote_requests FOR SELECT TO public
+  USING (
+    (EXISTS ( SELECT 1 FROM users
+       WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+    OR (customer_id = ( SELECT auth.uid() ))
+    OR (cleaner_id IN ( SELECT pros.id FROM pros WHERE pros.user_id = ( SELECT auth.uid() ) ))
+    OR (
+      cleaner_id IS NULL AND status = 'pending'::quote_status
+      AND EXISTS ( SELECT 1 FROM pros
+        WHERE pros.user_id = ( SELECT auth.uid() )
+          AND pros.approval_status = 'approved'::approval_status )
+    )
+  );
+CREATE POLICY "quote_requests_insert" ON public.quote_requests FOR INSERT TO public
+  WITH CHECK (
+    (EXISTS ( SELECT 1 FROM users
+       WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+    OR (customer_id = ( SELECT auth.uid() ))
+  );
+CREATE POLICY "quote_requests_update" ON public.quote_requests FOR UPDATE TO public
+  USING (
+    (EXISTS ( SELECT 1 FROM users
+       WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+    OR (customer_id = ( SELECT auth.uid() ) AND status = 'pending'::quote_status)
+    OR (cleaner_id IN ( SELECT pros.id FROM pros WHERE pros.user_id = ( SELECT auth.uid() ) ))
+    OR (
+      cleaner_id IS NULL AND status = 'pending'::quote_status
+      AND EXISTS ( SELECT 1 FROM pros
+        WHERE pros.user_id = ( SELECT auth.uid() )
+          AND pros.approval_status = 'approved'::approval_status )
+    )
+  )
+  WITH CHECK (
+    (EXISTS ( SELECT 1 FROM users
+       WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+    OR (customer_id = ( SELECT auth.uid() ) AND status = 'pending'::quote_status)
+    OR (cleaner_id IN ( SELECT pros.id FROM pros WHERE pros.user_id = ( SELECT auth.uid() ) ))
+  );
+CREATE POLICY "quote_requests_delete_admin" ON public.quote_requests FOR DELETE TO public
+  USING (EXISTS ( SELECT 1 FROM users
+    WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ));
+
+-- ═══════════════════════ conversations ═══════════════════════
+DROP POLICY "admin_full_access" ON public.conversations;
+DROP POLICY "Customers can view their own conversations" ON public.conversations;
+DROP POLICY "Cleaners can view their conversations" ON public.conversations;
+DROP POLICY "Customers can create conversations" ON public.conversations;
+DROP POLICY "Participants can update conversations" ON public.conversations;
+
+CREATE POLICY "conversations_select" ON public.conversations FOR SELECT TO public
+  USING (
+    is_admin()
+    OR (customer_id = ( SELECT auth.uid() ))
+    OR (EXISTS ( SELECT 1 FROM pros c
+        WHERE c.id = conversations.cleaner_id AND c.user_id = ( SELECT auth.uid() ) ))
+  );
+CREATE POLICY "conversations_insert" ON public.conversations FOR INSERT TO public
+  WITH CHECK (
+    is_admin()
+    OR ((( SELECT auth.uid() ) IS NOT NULL) AND (customer_id = ( SELECT auth.uid() )))
+  );
+CREATE POLICY "conversations_update" ON public.conversations FOR UPDATE TO public
+  USING (
+    is_admin()
+    OR (customer_id = ( SELECT auth.uid() ))
+    OR (EXISTS ( SELECT 1 FROM pros c
+        WHERE c.id = conversations.cleaner_id AND c.user_id = ( SELECT auth.uid() ) ))
+  )
+  WITH CHECK (
+    is_admin()
+    OR (customer_id = ( SELECT auth.uid() ))
+    OR (EXISTS ( SELECT 1 FROM pros c
+        WHERE c.id = conversations.cleaner_id AND c.user_id = ( SELECT auth.uid() ) ))
+  );
+CREATE POLICY "conversations_delete_admin" ON public.conversations FOR DELETE TO public
+  USING ( is_admin() );
+
+-- ═══════════════════════════ messages ═══════════════════════════
+DROP POLICY "Admins can view reported messages" ON public.messages;
+DROP POLICY "Cleaners can view messages in their conversations" ON public.messages;
+DROP POLICY "Customers can view messages in their conversations" ON public.messages;
+DROP POLICY "Cleaners can send messages" ON public.messages;
+DROP POLICY "Customers can send messages" ON public.messages;
+DROP POLICY "Conversation participants can report messages" ON public.messages;
+DROP POLICY "Recipients can mark messages as read" ON public.messages;
+
+CREATE POLICY "messages_select" ON public.messages FOR SELECT TO public
+  USING (
+    ((EXISTS ( SELECT 1 FROM users
+        WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+      AND reported_at IS NOT NULL)
+    OR (EXISTS ( SELECT 1 FROM conversations c
+        WHERE c.id = messages.conversation_id AND c.customer_id = ( SELECT auth.uid() ) ))
+    OR (EXISTS ( SELECT 1 FROM conversations c JOIN pros cl ON cl.id = c.cleaner_id
+        WHERE c.id = messages.conversation_id AND cl.user_id = ( SELECT auth.uid() ) ))
+  );
+CREATE POLICY "messages_insert" ON public.messages FOR INSERT TO public
+  WITH CHECK (
+    (
+      sender_id = ( SELECT auth.uid() ) AND (sender_role)::text = 'customer'
+      AND EXISTS ( SELECT 1 FROM conversations c
+        WHERE c.id = messages.conversation_id AND c.customer_id = ( SELECT auth.uid() ) )
+    )
+    OR (
+      sender_id = ( SELECT auth.uid() ) AND (sender_role)::text = 'cleaner'
+      AND EXISTS ( SELECT 1 FROM conversations c JOIN pros cl ON cl.id = c.cleaner_id
+        WHERE c.id = messages.conversation_id AND cl.user_id = ( SELECT auth.uid() ) )
+    )
+  );
+CREATE POLICY "messages_update" ON public.messages FOR UPDATE TO public
+  USING (
+    -- report (participants)
+    (EXISTS ( SELECT 1 FROM conversations c
+      WHERE c.id = messages.conversation_id
+        AND (c.customer_id = ( SELECT auth.uid() )
+          OR c.cleaner_id = ( SELECT pros.id FROM pros WHERE pros.user_id = ( SELECT auth.uid() ) ))))
+    -- mark-as-read (recipients)
+    OR (
+      sender_id <> ( SELECT auth.uid() )
+      AND (
+        EXISTS ( SELECT 1 FROM conversations c
+          WHERE c.id = messages.conversation_id AND c.customer_id = ( SELECT auth.uid() ) )
+        OR EXISTS ( SELECT 1 FROM conversations c JOIN pros cl ON cl.id = c.cleaner_id
+          WHERE c.id = messages.conversation_id AND cl.user_id = ( SELECT auth.uid() ) )
+      )
+    )
+  )
+  WITH CHECK (
+    -- report policy's explicit check
+    (reported_by = ( SELECT auth.uid() ))
+    -- mark-as-read had null WITH CHECK → contributes its USING verbatim
+    OR (
+      sender_id <> ( SELECT auth.uid() )
+      AND (
+        EXISTS ( SELECT 1 FROM conversations c
+          WHERE c.id = messages.conversation_id AND c.customer_id = ( SELECT auth.uid() ) )
+        OR EXISTS ( SELECT 1 FROM conversations c JOIN pros cl ON cl.id = c.cleaner_id
+          WHERE c.id = messages.conversation_id AND cl.user_id = ( SELECT auth.uid() ) )
+      )
+    )
+  );
+
+-- ═══════════════════════════ payments ═══════════════════════════
+DROP POLICY "payments_admin_all" ON public.payments;
+DROP POLICY "payments_users_select_own" ON public.payments;
+DROP POLICY "payments_users_insert_own" ON public.payments;
+DROP POLICY "payments_users_update_own" ON public.payments;
+
+CREATE POLICY "payments_select" ON public.payments FOR SELECT TO public
+  USING (
+    (EXISTS ( SELECT 1 FROM users
+       WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+    OR (cleaner_id IN ( SELECT pros.id FROM pros WHERE pros.user_id = ( SELECT auth.uid() ) ))
+  );
+CREATE POLICY "payments_insert" ON public.payments FOR INSERT TO public
+  WITH CHECK (
+    (EXISTS ( SELECT 1 FROM users
+       WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+    OR (cleaner_id IN ( SELECT pros.id FROM pros WHERE pros.user_id = ( SELECT auth.uid() ) ))
+  );
+CREATE POLICY "payments_update" ON public.payments FOR UPDATE TO public
+  USING (
+    (EXISTS ( SELECT 1 FROM users
+       WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+    OR (cleaner_id IN ( SELECT pros.id FROM pros WHERE pros.user_id = ( SELECT auth.uid() ) ))
+  )
+  WITH CHECK (
+    (EXISTS ( SELECT 1 FROM users
+       WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ))
+    OR (cleaner_id IN ( SELECT pros.id FROM pros WHERE pros.user_id = ( SELECT auth.uid() ) ))
+  );
+CREATE POLICY "payments_delete_admin" ON public.payments FOR DELETE TO public
+  USING (EXISTS ( SELECT 1 FROM users
+    WHERE users.id = ( SELECT auth.uid() ) AND users.role = 'admin'::user_role ));
+
+-- ---------------------------------------------------------------------------
+-- POST-APPLY VERIFICATION
+-- 1. SELECT tablename, cmd, count(*) FROM pg_policies WHERE schemaname='public'
+--    AND tablename IN ('users','pros','quote_requests','conversations','messages','payments')
+--    GROUP BY 1,2 HAVING count(*) > 1;
+--    Expect zero rows for (public-role) commands, except the intentional
+--    service_role ALL policies on users / quote_requests.
+-- 2. Re-run performance advisor: multiple_permissive_policies should drop for
+--    these 6 tables.
+-- 3. App smoke as customer / pro / admin: browse pros, quote flow, messages,
+--    pro payments page.
+-- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Pre-launch RLS/perf hardening — 3 DRAFT migrations, NOTHING APPLIED

Daniel applies by hand after review. Full analysis + before/after semantics checklists in `docs/perf/rls-traffic-prep-analysis.md`.

### Migration A — indexes (`20260710170000`)
Covers the 3 advisor-flagged FKs: `notification_logs(quote_request_id)`, `pro_licenses(verified_by)`, `service_categories(alias_for)`. Drops the 3 duplicate `pii_filter_log` `*_idx` twins (keeps `idx_*`). Uses plain `CREATE INDEX` — CONCURRENTLY can't run inside a migration transaction; at pre-launch row counts the brief lock is fine (noted in-file with the post-launch alternative).

### Migration B — initplan fixes (`20260710170100`)
All 10 `auth_rls_initplan` offenders rewritten via `ALTER POLICY` (roles/commands untouched), wrapping `auth.uid()/auth.role()/auth.jwt()` in scalar subselects so they evaluate once per statement. Expressions are the live quals verbatim otherwise. None of the 10 are on `public.users`; the users-never-self-references rule is not in play.

### Migration C — policy consolidation, top 5 traffic tables only (`20260710170200`)
users, pros, quote_requests, conversations, messages, payments. **Soundness:** permissive policies are an OR-set, and USING / WITH CHECK are each satisfied by *any* applicable policy independently — so one merged policy per (role, command) with OR'd USINGs and OR'd effective WITH CHECKs (null check → contributes its USING) is exactly equivalent. **No pair needed a judgment call; nothing was unmergeable — no STOP.**

Key equivalence notes (full table-by-table checklist in the doc):
- `TO authenticated` admin ALL policies merge into `TO public` via an `is_admin()` disjunct (false for anon — equivalent).
- service_role ALL policies on users/quote_requests kept as-is (different role, no planner stacking with public).
- messages: admins had SELECT-of-reported only — **not widened**; no DELETE policy existed on messages, none created.
- quote_requests UPDATE: the marketplace-claim WITH CHECK equals the assigned-pro qual, so the merged check's 3 disjuncts cover the original 4 policies' effective checks exactly.
- `'cleaner'` role string preserved verbatim.

### Advisor scope
This clears: 3 unindexed FKs, 3 duplicate indexes, all 10 initplan warnings, and the multiple-permissive warnings on the 6 hottest tables. Follow-up ticket (not this branch): ~30 remaining tables of the 297 warnings, the 84 `unused_index` findings (post-launch review), and `auth_db_connections_absolute` (pooler sizing).

### Apply order (manual)
A → B → C, each as one paste in the SQL editor; verification queries in each file footer; re-run the performance advisor after C; smoke as customer/pro/admin (browse pros, quote flow, messages, pro payments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdbyDufwshZ5uK3ydLy4Z

---
**Update:** Migration B was missing from the initial push (file write landed on disk under a stray name and was never committed). Recreated from a fresh `pg_policies` pull as `20260710170100_perf_initplan_fixes.sql` (commit 84bc99d). Cross-check: B touches admin_actions, booking_photos, bookings, cleaner_blocked_dates, notifications, pii_filter_log, rate_limits, service_categories — **zero overlap** with C's six tables (verified mechanically). Analysis doc's initplan table matches the file 10/10; filename reference corrected.