### PR TITLE
DLD-567: Fix job-photo uploads — service-role storage write after ownership check

### DIFF
--- a/app/api/bookings/[id]/photos/route.ts
+++ b/app/api/bookings/[id]/photos/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import { createLogger } from '@/lib/utils/logger';
 
 const logger = createLogger({ file: 'api/bookings/[id]/photos/route' });
@@ -63,6 +64,15 @@ export async function POST(
       return NextResponse.json({ error: 'Maximum 10 photos per upload' }, { status: 400 });
     }
 
+    // DLD-567: upload via the service-role client. The session client writes
+    // to portfolio-photos under job-photos/<bookingId>/..., but the bucket's
+    // only INSERT policy requires uid-prefixed folders, so every job-photo
+    // upload was silently failing. Ownership is already verified above
+    // (auth user -> pros row -> booking.cleaner_id match), so a service-role
+    // upload scoped to this booking's folder is safe. DB reads/writes below
+    // stay on the RLS-scoped session client.
+    const admin = createServiceRoleClient();
+
     const uploadedPhotos: { url: string; type: string }[] = [];
     const errors: string[] = [];
 
@@ -83,7 +93,7 @@ export async function POST(
       const arrayBuffer = await file.arrayBuffer();
       const buffer = new Uint8Array(arrayBuffer);
 
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await admin.storage
         .from('portfolio-photos')
         .upload(fileName, buffer, {
           contentType: file.type,
@@ -99,7 +109,7 @@ export async function POST(
 
       const {
         data: { publicUrl },
-      } = supabase.storage.from('portfolio-photos').getPublicUrl(fileName);
+      } = admin.storage.from('portfolio-photos').getPublicUrl(fileName);
 
       uploadedPhotos.push({ url: publicUrl, type: photoType });
     }


### PR DESCRIPTION
## DLD-567 — booking photo uploads were failing in production

**Root cause:** `app/api/bookings/[id]/photos/route.ts` uploads to the `portfolio-photos` bucket under `job-photos/<bookingId>/...` via the anon-key session client, but the bucket's only INSERT policy requires uid-prefixed folders — every upload hit a policy rejection (pre-existing; surfaced by the 2026-07-10 post-lockdown smoke test).

**Fix (app-layer only, per ticket option 1):** the storage `upload` + `getPublicUrl` calls now use `createServiceRoleClient()`. This is safe because the route already verifies ownership before any write: authenticated user → `pros` row → booking with matching `cleaner_id` (404 otherwise). Everything else (booking lookup, `booking_photos` insert, metadata fallback, GET) stays on the RLS-scoped session client. **No RLS or schema changes.**

### Verification
- `tsc --noEmit`: 0 new errors (56 = main baseline). `next build`: ✓ 89/89 pages.
- Diff: 1 file — import, one `admin` client, two storage call-site swaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>