### PR TITLE
DLD-566: Store Stripe receipt_url on payments at webhook time + surface on Payment History

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -142,12 +142,31 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
           // the admin sale alert so Stripe redeliveries don't re-notify.
           let paymentRecorded = false;
           if (!existingPayment) {
+            // DLD-566: capture the Stripe receipt link for Payment History.
+            // Best-effort — a failed retrieve must never fail the capture flow.
+            let receiptUrl: string | null = null;
+            try {
+              const pi = await getStripe().paymentIntents.retrieve(paymentIntentId, {
+                expand: ['latest_charge'],
+              });
+              const charge = pi.latest_charge as Stripe.Charge | null;
+              receiptUrl = charge?.receipt_url ?? null;
+            } catch (receiptErr) {
+              logger.warn('Could not fetch receipt_url for lead unlock payment', {
+                function: 'handleStripeEvent',
+                paymentIntentId,
+              }, receiptErr);
+            }
+
             const paymentMetadata: Record<string, string> = {
               type: 'lead_unlock',
               quote_request_id,
               lead_city: leadCity,
               service_type: serviceType,
             };
+            if (receiptUrl) {
+              paymentMetadata.receipt_url = receiptUrl;
+            }
             // Older checkout sessions may predate lead_acceptance_id in metadata.
             if (lead_acceptance_id) {
               paymentMetadata.lead_acceptance_id = lead_acceptance_id;

--- a/app/dashboard/pro/payments/actions.ts
+++ b/app/dashboard/pro/payments/actions.ts
@@ -23,6 +23,8 @@ export interface PaymentRow {
   quote_request_id: string | null;
   service_type: string | null;
   lead_city: string | null;
+  /** Stripe receipt (charge receipt_url or hosted invoice URL) — DLD-566 */
+  receipt_url: string | null;
 }
 
 export async function getPaymentHistory(): Promise<{
@@ -72,6 +74,10 @@ export async function getPaymentHistory(): Promise<{
         quote_request_id: typeof meta.quote_request_id === 'string' ? meta.quote_request_id : null,
         service_type: typeof meta.service_type === 'string' ? meta.service_type : null,
         lead_city: typeof meta.lead_city === 'string' ? meta.lead_city : null,
+        receipt_url:
+          typeof meta.receipt_url === 'string' && meta.receipt_url.startsWith('https://')
+            ? meta.receipt_url
+            : null,
       };
     });
 

--- a/app/dashboard/pro/payments/page.tsx
+++ b/app/dashboard/pro/payments/page.tsx
@@ -168,6 +168,16 @@ export default function PaymentHistoryPage() {
                           </span>
                         </div>
                       )}
+                      {p.receipt_url && (
+                        <a
+                          href={p.receipt_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-block text-brand-dark underline hover:no-underline"
+                        >
+                          View receipt
+                        </a>
+                      )}
                     </div>
                   </div>
                 ))}
@@ -179,7 +189,7 @@ export default function PaymentHistoryPage() {
                   <table className="min-w-full divide-y divide-gray-200">
                     <thead className="bg-gray-50">
                       <tr>
-                        {['Date', 'Description', 'Lead', 'Amount', 'Status'].map((h) => (
+                        {['Date', 'Description', 'Lead', 'Amount', 'Status', 'Receipt'].map((h) => (
                           <th key={h} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                             {h}
                           </th>
@@ -199,6 +209,20 @@ export default function PaymentHistoryPage() {
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <StatusBadge status={p.status} />
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm">
+                            {p.receipt_url ? (
+                              <a
+                                href={p.receipt_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-brand-dark underline hover:no-underline"
+                              >
+                                View
+                              </a>
+                            ) : (
+                              <span className="text-gray-400">—</span>
+                            )}
                           </td>
                         </tr>
                       ))}

--- a/lib/stripe/subscription-service.ts
+++ b/lib/stripe/subscription-service.ts
@@ -334,7 +334,11 @@ export class SubscriptionService {
           currency: currency || 'usd',
           status: 'succeeded',
           description: 'Monthly subscription payment',
-          metadata: { invoice_id: invoice.id },
+          // DLD-566: hosted_invoice_url is the invoice-world receipt link —
+          // stored under the same receipt_url key the Payment History reads.
+          metadata: invoice.hosted_invoice_url
+            ? { invoice_id: invoice.id, receipt_url: invoice.hosted_invoice_url }
+            : { invoice_id: invoice.id },
           paid_at: new Date().toISOString(),
         });
         if (paymentError) {


### PR DESCRIPTION
## DLD-566 — receipt links for the Payment History page (PR #75 follow-up)

`payments.metadata` never carried `receipt_url`, so the Payment History page had nothing to link. Both webhook write-paths now capture it, and the page renders it. **No schema changes** — the URL lives in the existing `payments.metadata` jsonb.

### Capture
1. **Lead unlock** (`app/api/webhooks/stripe/route.ts`): on fresh payment insert, retrieve the PaymentIntent with `expand: ['latest_charge']` and store `charge.receipt_url`. Strictly best-effort: a failed retrieve logs a warning and the capture/payment/contact-release flow proceeds unchanged. Runs only inside the `!existingPayment` branch, so redeliveries add no extra Stripe calls.
2. **Subscriptions** (`lib/stripe/subscription-service.ts`): store `invoice.hosted_invoice_url` under the same `receipt_url` key — the invoice-world receipt link, no extra API call. (Ticket said `charge.receipt_url`; for invoices the hosted invoice page is Stripe's canonical receipt.)

### Surface
- `PaymentRow` gains `receipt_url` (accepted from metadata only when it's an `https://` string).
- Mobile cards: "View receipt" link. Desktop table: new **Receipt** column with View link or em dash.
- Historical rows (no stored URL) degrade gracefully to the dash.

### Verification
- `tsc --noEmit`: 0 new errors (56 = main baseline). `next build`: ✓ 89/89 pages.
- 4 files; payments-insert idempotency, capture flip, and email paths untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>