### PR TITLE
feat(legal): publish Refund Policy + Review Policy pages

### DIFF
--- a/app/refund-policy/page.tsx
+++ b/app/refund-policy/page.tsx
@@ -145,8 +145,7 @@ export default function RefundPolicyPage() {
             <p className="text-gray-600 leading-relaxed">
               Refund claims are audited. Submitting false claims, or claiming a refund on a lead the
               Pro in fact serviced (on or off platform), is grounds for claim denial, clawback, and
-              account suspension. Initiating a card chargeback while a refund claim is open may pause
-              the claim.
+              account suspension.
             </p>
           </section>
 

--- a/app/refund-policy/page.tsx
+++ b/app/refund-policy/page.tsx
@@ -1,0 +1,184 @@
+import Link from 'next/link';
+import { generatePageMetadata } from '@/lib/seo/metadata';
+
+export const metadata = generatePageMetadata({
+  title: 'Lead Fee Refund Policy',
+  description:
+    'Boss of Clean lead fee refund policy. When the $30 lead fee is refundable, how to claim a bad lead, the 7-day claim window, and our resolution timeline.',
+  path: '/refund-policy',
+  keywords: ['refund policy', 'lead fee refund', 'bad lead', 'Boss of Clean refunds'],
+});
+
+export default function RefundPolicyPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Hero */}
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-brand-dark">
+          <div className="absolute inset-0 bg-gradient-to-br from-brand-dark via-brand-navy to-brand-dark" />
+        </div>
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16 text-center">
+          <h1 className="font-display text-4xl sm:text-5xl font-bold text-white leading-[1.1] mb-4">
+            Lead Fee Refund Policy
+          </h1>
+          <p className="text-gray-300 text-lg max-w-2xl mx-auto">
+            When the $30 lead fee is refundable, and how to make a claim.
+          </p>
+          <p className="text-gray-500 text-sm mt-4">Last updated: July 2026</p>
+        </div>
+      </section>
+
+      {/* Content */}
+      <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="prose prose-lg prose-gray max-w-none">
+          <section className="mb-12">
+            <p className="text-gray-600 leading-relaxed">
+              This policy applies to the <strong>$30 lead fee</strong> paid by service
+              professionals (&ldquo;Pros&rdquo;) on Boss of Clean, a Florida home and business
+              services marketplace.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              1. What the lead fee buys
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              A Pro pays the lead fee only after a customer has (a) accepted the Pro&apos;s quote and
+              (b) confirmed they want to hire that Pro. Payment releases the customer&apos;s contact
+              information (name, phone, email, service address) to that Pro for that job. The fee is
+              for the introduction &mdash; it is not a guarantee that the job will be completed or
+              that the customer will not change plans.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              2. Bad-lead criteria (refund-eligible)
+            </h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              A lead fee is refundable when the lead was defective at the time of purchase, meaning
+              any of:
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-600">
+              <li>
+                <strong>Disconnected or wrong contact info.</strong> The phone number is
+                disconnected, unreachable as dialed, or belongs to someone other than the requester;
+                or the email hard-bounces.
+              </li>
+              <li>
+                <strong>Fake or fraudulent request.</strong> The request was not submitted by a real
+                prospective customer (spam, pranks, bots, competitor probing).
+              </li>
+              <li>
+                <strong>Duplicate lead.</strong> The Pro already paid for the same customer and same
+                job on Boss of Clean (a repeat request for a <em>new</em> job is not a duplicate).
+              </li>
+              <li>
+                <strong>Customer cancelled before contact.</strong> The customer withdrew the request
+                before the Pro had any reasonable opportunity to make contact.
+              </li>
+              <li>
+                <strong>Outside stated service area.</strong> The job address is materially outside
+                the service area the lead displayed before purchase.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              3. Not refund-eligible
+            </h2>
+            <ul className="list-disc pl-6 space-y-2 text-gray-600">
+              <li>The customer chose another Pro, postponed, or negotiated a different scope.</li>
+              <li>The Pro was slow to respond (we recommend contact within 24 hours).</li>
+              <li>Price disagreement after contact.</li>
+              <li>The Pro simply changed their mind about wanting the job.</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              4. Claim window
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Refund claims must be submitted within <strong>7 calendar days</strong> of the fee
+              being charged. Claims outside the window are reviewed only at Boss of Clean&apos;s
+              discretion.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              5. How to claim and resolution timeline
+            </h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              Submit the refund request from the Pro dashboard, or email{' '}
+              <a href="mailto:admin@bossofclean.com" className="text-brand-gold hover:underline">
+                admin@bossofclean.com
+              </a>
+              , with the lead reference and the reason category. We may verify the claim (for
+              example, test the phone number, or review platform messages and request history). One
+              claim per lead.
+            </p>
+            <p className="text-gray-600 leading-relaxed">
+              We will issue a decision within <strong>5 business days</strong> of submission.
+              Approved refunds are returned to the original payment method within 10 business days
+              (card network timing may add processing days).
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              6. Form of refund
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Approved refunds are issued to the original payment method. Where the Pro prefers, we
+              may offer an account credit toward a future lead instead.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              7. Abuse
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Refund claims are audited. Submitting false claims, or claiming a refund on a lead the
+              Pro in fact serviced (on or off platform), is grounds for claim denial, clawback, and
+              account suspension. Initiating a card chargeback while a refund claim is open may pause
+              the claim.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              8. Contact
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Questions about this policy? Contact us at{' '}
+              <a href="mailto:admin@bossofclean.com" className="text-brand-gold hover:underline">
+                admin@bossofclean.com
+              </a>
+              . See also our{' '}
+              <Link href="/terms" className="text-brand-gold hover:underline">
+                Terms of Service
+              </Link>{' '}
+              and{' '}
+              <Link href="/review-policy" className="text-brand-gold hover:underline">
+                Review Policy
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+
+        {/* Back link */}
+        <div className="mt-12 pt-8 border-t border-gray-200">
+          <Link href="/" className="text-brand-gold hover:underline font-medium">
+            &larr; Back to Home
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/app/review-policy/page.tsx
+++ b/app/review-policy/page.tsx
@@ -94,7 +94,7 @@ export default function ReviewPolicyPage() {
             </h2>
             <p className="text-gray-600 leading-relaxed">
               Reviews must be about the service experience. We remove content that is unlawful,
-              defamatory, doxxing (posting someone&apos;s private contact info), hate speech,
+              defamatory per se, doxxing (posting someone&apos;s private contact info), hate speech,
               spam/ads, or unrelated to the job. We do <strong>not</strong> remove a review merely
               because it is negative.
             </p>

--- a/app/review-policy/page.tsx
+++ b/app/review-policy/page.tsx
@@ -1,0 +1,174 @@
+import Link from 'next/link';
+import { generatePageMetadata } from '@/lib/seo/metadata';
+
+export const metadata = generatePageMetadata({
+  title: 'Review Policy',
+  description:
+    'Boss of Clean review policy. Reviews come from verified customers only, no pay-for-reviews, content standards, and the Pro dispute process.',
+  path: '/review-policy',
+  keywords: ['review policy', 'verified reviews', 'Boss of Clean reviews'],
+});
+
+export default function ReviewPolicyPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Hero */}
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-brand-dark">
+          <div className="absolute inset-0 bg-gradient-to-br from-brand-dark via-brand-navy to-brand-dark" />
+        </div>
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16 text-center">
+          <h1 className="font-display text-4xl sm:text-5xl font-bold text-white leading-[1.1] mb-4">
+            Review Policy
+          </h1>
+          <p className="text-gray-300 text-lg max-w-2xl mx-auto">
+            Reviews on Boss of Clean reflect real, verified service experiences.
+          </p>
+          <p className="text-gray-500 text-sm mt-4">Last updated: July 2026</p>
+        </div>
+      </section>
+
+      {/* Content */}
+      <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="prose prose-lg prose-gray max-w-none">
+          <section className="mb-12">
+            <p className="text-gray-600 leading-relaxed">
+              Reviews on Boss of Clean must reflect real, verified service experiences.
+              &ldquo;Purrfection is our Standard&rdquo; only means something if the ratings are
+              honest.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              1. Who can review
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Only a customer who booked and received (or materially began) a service through Boss of
+              Clean may review the Pro for that job. One review per completed job. Pros may post a
+              public response to any review of their business.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              2. Verification requirement
+            </h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              Reviews are tied to a platform booking record. We do not accept:
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-600">
+              <li>reviews from accounts with no booking with that Pro;</li>
+              <li>reviews of a Pro by that Pro, their employees, or family/associates;</li>
+              <li>imported or copied reviews from other sites.</li>
+            </ul>
+            <p className="text-gray-600 leading-relaxed mt-4">
+              Reviews may display a &ldquo;Verified job&rdquo; indicator only when the underlying
+              booking exists on the platform.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              3. No pay-for-reviews
+            </h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              Neither Boss of Clean nor Pros may:
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-gray-600">
+              <li>pay, discount, tip, or otherwise compensate anyone for a positive review;</li>
+              <li>condition a refund or dispute resolution on editing or removing a review;</li>
+              <li>
+                run &ldquo;review gating&rdquo; (soliciting reviews only from customers screened as
+                happy).
+              </li>
+            </ul>
+            <p className="text-gray-600 leading-relaxed mt-4">
+              Asking a customer, neutrally, to leave an honest review is allowed and encouraged.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              4. Content standards
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Reviews must be about the service experience. We remove content that is unlawful,
+              defamatory, doxxing (posting someone&apos;s private contact info), hate speech,
+              spam/ads, or unrelated to the job. We do <strong>not</strong> remove a review merely
+              because it is negative.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              5. Dispute process (Pros)
+            </h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              A Pro may flag a review from their dashboard, or email{' '}
+              <a href="mailto:admin@bossofclean.com" className="text-brand-gold hover:underline">
+                admin@bossofclean.com
+              </a>
+              , within <strong>30 days</strong> of the review being posted, stating the specific
+              ground (no underlying job, wrong business, content-standard violation, suspected fake).
+            </p>
+            <p className="text-gray-600 leading-relaxed">
+              Boss of Clean reviews the booking record, messages, and payment history and issues a
+              decision within <strong>10 business days</strong>. Outcomes: keep, remove, or annotate.
+              The customer may be invited to revise factual errors. One escalation is available to a
+              second reviewer; that outcome is final at the platform level.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              6. No retaliation
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Pros may not threaten, penalize, or refuse warranty service to a customer because of an
+              honest review. Verified retaliation is grounds for suspension.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              7. Our role
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Boss of Clean is a marketplace. Reviews are the opinions of their authors. We moderate
+              against this policy but do not endorse review content.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-display text-2xl font-bold text-brand-dark mb-4">
+              8. Contact
+            </h2>
+            <p className="text-gray-600 leading-relaxed">
+              Questions about this policy? Contact us at{' '}
+              <a href="mailto:admin@bossofclean.com" className="text-brand-gold hover:underline">
+                admin@bossofclean.com
+              </a>
+              . See also our{' '}
+              <Link href="/terms" className="text-brand-gold hover:underline">
+                Terms of Service
+              </Link>{' '}
+              and{' '}
+              <Link href="/refund-policy" className="text-brand-gold hover:underline">
+                Lead Fee Refund Policy
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+
+        {/* Back link */}
+        <div className="mt-12 pt-8 border-t border-gray-200">
+          <Link href="/" className="text-brand-gold hover:underline font-medium">
+            &larr; Back to Home
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -28,6 +28,8 @@ const quickLinks = [
   { label: 'Help Center', href: '/help' },
   { label: 'Privacy Policy', href: '/privacy' },
   { label: 'Terms of Service', href: '/terms' },
+  { label: 'Refund Policy', href: '/refund-policy' },
+  { label: 'Review Policy', href: '/review-policy' },
 ];
 
 export default async function Footer() {


### PR DESCRIPTION
## Publish Refund Policy + Review Policy as live routes

Ships `docs/legal-drafts/refund-policy.md` and `review-policy.md` (PR #71) as live pages at **/refund-policy** and **/review-policy**, styled to match /terms and /privacy (hero + prose sections, brand palette, back-to-home link, `generatePageMetadata`). Footer legal section now links both.

### Fidelity — nothing invented
Policy terms are preserved verbatim from the drafts: refund 7-day claim window / 5-business-day decision / 10-business-day return / one-claim-per-lead / the 5 bad-lead criteria / the 4 not-eligible items; review 30-day flag window / 10-business-day decision / one-review-per-job / verification + no-pay-for-reviews + no-retaliation. No blanks existed in the drafts, so nothing was filled in.

### Not published (internal only)
The drafts' `DRAFT — FOR ATTORNEY REVIEW (DLD-276)` banners, the `Florida notes for counsel` section, and the `Counsel note:` asides are internal — stripped from the customer-facing pages. The anti-circumvention and consent-architecture drafts are NOT published (out of scope; only refund + review were requested).

### ⚠️ [DANIEL: CONFIRM] — items to sign off before/after launch (I did NOT invent or resolve these)
1. **Attorney review status.** The source drafts state attorney review (DLD-276) is a prerequisite to publishing. Confirm counsel has (or will) review before these stay live.
2. **/terms contradicts the lead-fee model.** The existing live /terms (section 4) describes a "5% platform fee," "Stripe direct-deposit payouts in 2–3 business days," and a "48-hour" lead-credit window — none of which match the real $30-lead-fee model this refund policy describes. /terms needs a reconciling edit (separate task — I did not touch it).
3. **Feature promises.** The refund page says claims can be filed "from the Pro dashboard" and the review page says a Pro can "flag a review from their dashboard." Confirm those dashboard controls exist or are planned; the email path (admin@bossofclean.com) works today regardless.
4. **Effective date** shown as "Last updated: July 2026" — adjust if you want a specific date.

A 6-lens adversarial fidelity audit ran against these pages; results folded into the final report. No merge until that comes back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdbyDufwshZ5uK3ydLy4Z

---
## Adversarial fidelity audit — 6 lenses, **0 blockers, mergeSafe**

Ran a 6-lens parallel audit (fidelity ×2, scaffolding/branding leak, consistency-vs-live-terms, cold-review, launch-doc). Scaffolding + branding: **clean**. No invented policy terms found. Two fidelity slips it caught were fixed in commit 2 (restored "defamatory per se"; removed a chargeback sentence that came from the drafts' internal counsel-notes rather than the approved body).

### 🔴 [DANIEL: CONFIRM] — sign-off items (reported, NOT fixed — none are code defects)

**Most important — /terms contradicts the lead-fee model (pre-existing, not introduced here):**
1. **/terms §4 says "5% platform fee on completed bookings"** — the real model (and this refund policy) is the flat **$30 lead fee**, no 5% cut. Two live pages now describe two revenue models to the same Pro.
2. **/terms §4–§6 describe a Stripe direct-deposit payout + platform-held service payment** that doesn't exist — Pros set their own prices and are paid directly by customers; BOC only collects the $30 lead fee. (§5 cancellation "50% of quoted price", §6 no-show "full refund", §7 "issue credits/refunds" all assume BOC holds the service payment.)
3. **/terms §8 "Lead Quality Guarantee" (48-hour report window, 48-hour account credit)** conflicts with this policy's 7-day claim / 5-business-day decision / refund-to-card. Two different deadlines + remedies for the same thing.
   → **Recommendation: reconcile /terms §4–§8 to the $30 lead-fee model before public launch.** Out of scope for this PR (I did not rewrite Terms); it's the loudest open item.

**Feature-promise vs. reality:**
4. Refund page says claims can be filed "from the Pro dashboard" — **no such control exists yet** (only a `refunded` status badge). Email path works today. Build the control or soften to email-only.
5. Review page says a Pro can "flag a review from their dashboard" — **Pro dashboard only has a review-response form**; flagging exists admin-side only. Same choice.

**Policy sign-off:**
6. **Attorney review (DLD-276):** the source drafts state counsel review is a prerequisite to publishing. Confirm that happened (or accept the risk of publishing pre-review).
7. Draft's counsel notes recommend adding **chargeback-pauses-claim** language — omitted from the live body (it wasn't approved policy text). Add it if counsel approves.
8. /terms frames lead access as a **non-refundable monthly subscription** ($79/$199 tiers per David); this refund policy is silent on subscription fees (covers only the per-lead $30). Confirm that's intended.

Nits (not blocking): footer label "Refund Policy" vs page H1 "Lead Fee Refund Policy" (footer label matches the task spec exactly, so left as-is).