### PR TITLE
fix(sms): TCPA/FTSA pro SMS consent — capture, fail-closed send gate, STOP

### DIFF
--- a/app/api/webhooks/twilio/route.ts
+++ b/app/api/webhooks/twilio/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import twilio from 'twilio';
+import { recordOptOut, removeOptOut } from '@/lib/sms/consent';
+import { createLogger } from '@/lib/utils/logger';
+
+const logger = createLogger({ file: 'api/webhooks/twilio/route' });
+
+// Standard SMS keywords. If Twilio Advanced Opt-Out is enabled it handles these
+// at the carrier level and blocks sends itself; this webhook is the backstop
+// that also persists the choice to our own ledger (sms_opt_outs).
+const STOP_KEYWORDS = new Set(['stop', 'stopall', 'unsubscribe', 'cancel', 'end', 'quit']);
+const START_KEYWORDS = new Set(['start', 'unstop', 'yes']);
+
+function twiml(message?: string): NextResponse {
+  const body = message
+    ? `<?xml version="1.0" encoding="UTF-8"?><Response><Message>${message}</Message></Response>`
+    : `<?xml version="1.0" encoding="UTF-8"?><Response></Response>`;
+  return new NextResponse(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/xml' },
+  });
+}
+
+/**
+ * Inbound SMS webhook. Handles STOP/START so opt-outs are honored server-side.
+ * Requests are verified against the Twilio signature — fail-closed on any
+ * missing config or bad signature.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const signature = req.headers.get('x-twilio-signature');
+  // Twilio signs against the exact public URL it POSTed to. Behind a proxy the
+  // inferred URL can differ, so allow an explicit override.
+  const url = process.env.TWILIO_WEBHOOK_URL || req.nextUrl.href;
+
+  const form = await req.formData();
+  const params: Record<string, string> = {};
+  form.forEach((value, key) => {
+    params[key] = typeof value === 'string' ? value : '';
+  });
+
+  if (!authToken || !signature || !twilio.validateRequest(authToken, signature, url, params)) {
+    logger.warn('Rejected Twilio webhook: missing/invalid signature', { function: 'POST' });
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  const from = (params.From || '').trim();
+  const bodyText = (params.Body || '').trim().toLowerCase();
+  if (!from) return twiml();
+
+  if (STOP_KEYWORDS.has(bodyText)) {
+    await recordOptOut(from, 'sms_stop');
+    logger.info('Recorded SMS opt-out', { function: 'POST' });
+    return twiml('You are unsubscribed from Boss of Clean texts and will not receive more. Reply START to resubscribe.');
+  }
+
+  if (START_KEYWORDS.has(bodyText)) {
+    await removeOptOut(from);
+    logger.info('Removed SMS opt-out', { function: 'POST' });
+    return twiml('You are resubscribed to Boss of Clean texts. Reply STOP to opt out.');
+  }
+
+  return twiml();
+}

--- a/app/dashboard/pro/profile/page.tsx
+++ b/app/dashboard/pro/profile/page.tsx
@@ -14,6 +14,8 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { createLogger } from '@/lib/utils/logger';
 import CategorySelector from '@/components/onboarding/CategorySelector';
+import { recordProSmsConsent, revokeProSmsConsent } from '@/lib/actions/tcpa';
+import { PRO_SMS_CONSENT_TEXT } from '@/lib/sms/consent-copy';
 
 const logger = createLogger({ file: 'app/dashboard/pro/profile/page.tsx' });
 
@@ -42,6 +44,9 @@ interface CleanerProfile {
   // DLD-449
   primary_category?: string | null;
   secondary_categories?: string[];
+  // SMS consent audit (mirrors users.tcpa_consent_*)
+  sms_consent_at?: string | null;
+  sms_consent_phone?: string | null;
 }
 
 export default function CleanerProfilePage() {
@@ -52,6 +57,9 @@ export default function CleanerProfilePage() {
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [message, setMessage] = useState('');
+  // Separate, opt-in SMS consent. Reflects whether valid consent is on file for
+  // the current business_phone; the pro toggles it and it applies on save.
+  const [smsConsent, setSmsConsent] = useState(false);
   const supabase = createClient();
 
   useEffect(() => {
@@ -84,6 +92,8 @@ export default function CleanerProfilePage() {
           ...data,
           secondary_categories: secondary,
         });
+        // Show as opted-in only when consent is on file for the current number.
+        setSmsConsent(!!(data.sms_consent_at && data.sms_consent_phone === data.business_phone));
       } else {
         // Create default profile if none exists
         const newProfile = {
@@ -310,6 +320,17 @@ export default function CleanerProfilePage() {
         return;
       }
 
+      // Apply SMS consent choice. Consent binds to the phone just saved; an
+      // unchecked box revokes any prior consent so sends stop. Both run through
+      // service-role server actions (IP captured server-side).
+      if (user?.id) {
+        if (smsConsent) {
+          await recordProSmsConsent(user.id, navigator.userAgent).catch(() => {});
+        } else if (profile.sms_consent_at) {
+          await revokeProSmsConsent(user.id).catch(() => {});
+        }
+      }
+
       setMessage('Profile updated successfully!');
       setTimeout(() => setMessage(''), 3000);
     } catch (error) {
@@ -449,8 +470,20 @@ export default function CleanerProfilePage() {
                     className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     placeholder="(555) 123-4567"
                   />
+                  {/* SMS consent — separate, opt-in, not a condition of service */}
+                  <label className="mt-3 flex items-start gap-3">
+                    <input
+                      type="checkbox"
+                      checked={smsConsent}
+                      onChange={(e) => setSmsConsent(e.target.checked)}
+                      className="mt-1 h-4 w-4 shrink-0 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                    />
+                    <span className="text-xs text-gray-600 leading-snug">
+                      {PRO_SMS_CONSENT_TEXT}
+                    </span>
+                  </label>
                 </div>
-                
+
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">
                     Website URL (Optional)

--- a/app/dashboard/pro/profile/page.tsx
+++ b/app/dashboard/pro/profile/page.tsx
@@ -321,12 +321,14 @@ export default function CleanerProfilePage() {
       }
 
       // Apply SMS consent choice. Consent binds to the phone just saved; an
-      // unchecked box revokes any prior consent so sends stop. Both run through
+      // unchecked box unconditionally revokes any consent so sends stop. Revoke
+      // is unconditional (not gated on stale loaded state) and idempotent, so a
+      // same-session opt-in then opt-out is honored. Both run through
       // service-role server actions (IP captured server-side).
       if (user?.id) {
         if (smsConsent) {
           await recordProSmsConsent(user.id, navigator.userAgent).catch(() => {});
-        } else if (profile.sms_consent_at) {
+        } else {
           await revokeProSmsConsent(user.id).catch(() => {});
         }
       }

--- a/app/dashboard/pro/setup/page.tsx
+++ b/app/dashboard/pro/setup/page.tsx
@@ -5,10 +5,12 @@ import { useAuth } from '@/lib/context/AuthContext';
 import { ProtectedRoute } from '@/lib/auth/protected-route';
 import { createClient } from '@/lib/supabase/client';
 import { useRouter } from 'next/navigation';
-import { 
-  Building2, Phone, Mail, Globe, DollarSign, Clock, 
+import {
+  Building2, Phone, Mail, Globe, DollarSign, Clock,
   MapPin, CheckCircle, AlertCircle, Info
 } from 'lucide-react';
+import { recordProSmsConsent } from '@/lib/actions/tcpa';
+import { PRO_SMS_CONSENT_TEXT } from '@/lib/sms/consent-copy';
 
 const serviceTypes = [
   { value: 'residential', label: 'Residential Cleaning' },
@@ -56,6 +58,8 @@ export default function CleanerSetupPage() {
   });
 
   const [customZipCode, setCustomZipCode] = useState('');
+  // Separate, opt-in SMS consent. NOT a condition of creating a profile.
+  const [smsConsent, setSmsConsent] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value, type } = e.target;
@@ -148,6 +152,12 @@ export default function CleanerSetupPage() {
         });
 
       if (error) throw error;
+
+      // Record SMS consent only if the pro affirmatively opted in. IP is
+      // captured server-side; consent is bound to the business_phone just saved.
+      if (smsConsent && user?.id) {
+        recordProSmsConsent(user.id, navigator.userAgent).catch(() => {});
+      }
 
       setSuccess('Profile created successfully! Redirecting to dashboard...');
       setTimeout(() => {
@@ -469,6 +479,22 @@ export default function CleanerSetupPage() {
                     />
                   </div>
                 )}
+              </div>
+
+              {/* SMS consent — separate, opt-in, not a condition of signing up */}
+              <div className="border border-gray-200 rounded-md p-4">
+                <label className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    name="smsConsent"
+                    checked={smsConsent}
+                    onChange={(e) => setSmsConsent(e.target.checked)}
+                    className="mt-1 h-4 w-4 shrink-0 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                  />
+                  <span className="text-xs text-gray-600 leading-snug">
+                    {PRO_SMS_CONSENT_TEXT}
+                  </span>
+                </label>
               </div>
 
               {/* Info Box */}

--- a/lib/actions/tcpa.ts
+++ b/lib/actions/tcpa.ts
@@ -2,11 +2,16 @@
 
 import { headers } from 'next/headers';
 import { createServiceRoleClient } from '@/lib/supabase/service-role';
+import { PRO_SMS_CONSENT_TEXT } from '@/lib/sms/consent-copy';
 
-export async function recordUserTcpaConsent(userId: string, userAgent: string): Promise<void> {
+async function clientIp(): Promise<string> {
   const headersList = await headers();
   const forwarded = headersList.get('x-forwarded-for');
-  const ip = forwarded ? forwarded.split(',')[0].trim() : (headersList.get('x-real-ip') || 'unknown');
+  return forwarded ? forwarded.split(',')[0].trim() : (headersList.get('x-real-ip') || 'unknown');
+}
+
+export async function recordUserTcpaConsent(userId: string, userAgent: string): Promise<void> {
+  const ip = await clientIp();
 
   const supabase = createServiceRoleClient();
   await supabase
@@ -17,4 +22,53 @@ export async function recordUserTcpaConsent(userId: string, userAgent: string): 
       tcpa_consent_ua: userAgent.slice(0, 512),
     })
     .eq('id', userId);
+}
+
+/**
+ * Record a pro's affirmative SMS consent for automated Twilio alerts.
+ * Mirrors recordUserTcpaConsent. IP is captured server-side; the consent text
+ * is the canonical PRO_SMS_CONSENT_TEXT (not client-supplied, so it can't be
+ * spoofed); consent is bound to the pro's current business_phone so a later
+ * number change invalidates it. Call this AFTER the pros row is saved.
+ */
+export async function recordProSmsConsent(userId: string, userAgent: string): Promise<void> {
+  const ip = await clientIp();
+  const supabase = createServiceRoleClient();
+
+  const { data: pro } = await supabase
+    .from('pros')
+    .select('business_phone')
+    .eq('user_id', userId)
+    .single();
+
+  await supabase
+    .from('pros')
+    .update({
+      sms_consent_at: new Date().toISOString(),
+      sms_consent_ip: ip,
+      sms_consent_ua: userAgent.slice(0, 512),
+      sms_consent_text: PRO_SMS_CONSENT_TEXT,
+      sms_consent_phone: pro?.business_phone ?? null,
+    })
+    .eq('user_id', userId);
+}
+
+/**
+ * Clear a pro's SMS consent (they unchecked the box). After this the send gate
+ * fails closed and no further automated texts go to that pro until they opt in
+ * again. This is a preference revocation; distinct from an inbound STOP, which
+ * is recorded in sms_opt_outs.
+ */
+export async function revokeProSmsConsent(userId: string): Promise<void> {
+  const supabase = createServiceRoleClient();
+  await supabase
+    .from('pros')
+    .update({
+      sms_consent_at: null,
+      sms_consent_ip: null,
+      sms_consent_ua: null,
+      sms_consent_text: null,
+      sms_consent_phone: null,
+    })
+    .eq('user_id', userId);
 }

--- a/lib/sms/consent-copy.ts
+++ b/lib/sms/consent-copy.ts
@@ -1,0 +1,20 @@
+/**
+ * The exact SMS consent disclosure shown to pros.
+ *
+ * Imported by both the consent checkbox UI (setup + profile) and the server
+ * action that records consent, so the persisted `pros.sms_consent_text` is
+ * always byte-for-byte what the pro actually saw.
+ *
+ * Required TCPA / Florida FTSA elements, all present below:
+ *  - automated text messages          ("automated text messages")
+ *  - message frequency                ("Message frequency varies")
+ *  - consent is not a condition        ("not a condition of using Boss of Clean")
+ *  - msg/data rates apply              ("Message and data rates may apply")
+ *  - how to opt out                    ("Reply STOP to opt out")
+ */
+export const PRO_SMS_CONSENT_TEXT =
+  'I agree to receive automated text messages from Boss of Clean at the business ' +
+  'phone number I provide, including new-lead and new-message alerts. Message ' +
+  'frequency varies. Consent is not a condition of using Boss of Clean or ' +
+  'receiving leads. Message and data rates may apply. Reply STOP to opt out at ' +
+  'any time; reply HELP for help.';

--- a/lib/sms/consent.ts
+++ b/lib/sms/consent.ts
@@ -1,0 +1,93 @@
+/**
+ * SMS consent + opt-out gates (TCPA / Florida FTSA).
+ *
+ * Server-side, fail-closed. Two independent questions:
+ *   - proHasValidSmsConsent: did the pro affirmatively opt IN for THIS number?
+ *   - isPhoneOptedOut:        did this number opt OUT (reply STOP)?
+ * Both must be satisfied before any automated text is sent to a pro.
+ */
+
+import { createServiceRoleClient } from '../supabase/service-role';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger({ file: 'lib/sms/consent' });
+
+/**
+ * Fail-closed: does this pro have a valid, on-file SMS consent record for the
+ * exact number we are about to text? Returns false on any missing record,
+ * phone mismatch, or error. No consent → no text.
+ */
+export async function proHasValidSmsConsent(userId: string, phone: string): Promise<boolean> {
+  try {
+    const supabase = createServiceRoleClient();
+    const { data, error } = await supabase
+      .from('pros')
+      .select('sms_consent_at, sms_consent_phone')
+      .eq('user_id', userId)
+      .single();
+
+    if (error || !data) return false;
+    if (!data.sms_consent_at) return false;
+
+    // Consent is bound to the exact number consented to. A changed business_phone
+    // invalidates consent until the pro re-consents.
+    if ((data.sms_consent_phone ?? '').trim() !== (phone ?? '').trim()) return false;
+
+    return true;
+  } catch (err) {
+    logger.error('proHasValidSmsConsent failed (fail-closed)', {
+      function: 'proHasValidSmsConsent',
+      userId,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    });
+    return false;
+  }
+}
+
+/**
+ * Fail-closed: is this phone on the STOP / opt-out ledger? On any error we treat
+ * the number as opted out (skip the send) — honoring a revocation is the safe
+ * default.
+ */
+export async function isPhoneOptedOut(phone: string): Promise<boolean> {
+  try {
+    const supabase = createServiceRoleClient();
+    const { data, error } = await supabase
+      .from('sms_opt_outs')
+      .select('phone')
+      .eq('phone', phone)
+      .maybeSingle();
+
+    if (error) {
+      logger.error('isPhoneOptedOut check failed (fail-closed = opted out)', {
+        function: 'isPhoneOptedOut',
+        error: error.message,
+      });
+      return true;
+    }
+    return !!data;
+  } catch (err) {
+    logger.error('isPhoneOptedOut threw (fail-closed = opted out)', {
+      function: 'isPhoneOptedOut',
+      error: err instanceof Error ? err.message : 'Unknown error',
+    });
+    return true;
+  }
+}
+
+/** Record an opt-out (inbound STOP). Idempotent. */
+export async function recordOptOut(phone: string, source = 'sms_stop'): Promise<void> {
+  const supabase = createServiceRoleClient();
+  await supabase
+    .from('sms_opt_outs')
+    .upsert(
+      { phone, source, opted_out_at: new Date().toISOString() },
+      { onConflict: 'phone' }
+    );
+}
+
+/** Remove an opt-out (inbound START / resubscribe). Idempotent. */
+export async function removeOptOut(phone: string): Promise<void> {
+  const supabase = createServiceRoleClient();
+  await supabase.from('sms_opt_outs').delete().eq('phone', phone);
+}

--- a/lib/sms/notifications.ts
+++ b/lib/sms/notifications.ts
@@ -8,6 +8,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { createLogger } from '../utils/logger';
 import { sendSMS } from './twilio';
+import { proHasValidSmsConsent } from './consent';
 
 const logger = createLogger({ file: 'lib/sms/notifications' });
 
@@ -97,6 +98,17 @@ export async function notifyProNewLead(
     return { success: false, error: 'SMS not enabled' };
   }
 
+  // TCPA / FTSA gate: never text a pro without a valid on-file consent record
+  // for this exact number. Fail-closed — no record → skip and log.
+  const consented = await proHasValidSmsConsent(userId, phoneNumber);
+  if (!consented) {
+    logger.info('No valid SMS consent on file for pro, skipping new-lead text', {
+      function: 'notifyProNewLead',
+      userId,
+    });
+    return { success: false, error: 'No SMS consent on file' };
+  }
+
   const service = serviceType.replace(/_/g, ' ');
   const body = `Boss of Clean: New ${service} lead in ${zipCode} from ${customerName}. Log in to respond. Reply STOP to unsubscribe`;
 
@@ -118,6 +130,17 @@ export async function notifyProNewMessage(
       userId,
     });
     return { success: false, error: 'SMS not enabled' };
+  }
+
+  // TCPA / FTSA gate: never text a pro without a valid on-file consent record
+  // for this exact number. Fail-closed — no record → skip and log.
+  const consented = await proHasValidSmsConsent(userId, phoneNumber);
+  if (!consented) {
+    logger.info('No valid SMS consent on file for pro, skipping new-message text', {
+      function: 'notifyProNewMessage',
+      userId,
+    });
+    return { success: false, error: 'No SMS consent on file' };
   }
 
   const body = `Boss of Clean: New message from ${customerName}. Log in to reply. Reply STOP to unsubscribe`;

--- a/lib/sms/twilio.ts
+++ b/lib/sms/twilio.ts
@@ -7,6 +7,7 @@
 
 import twilio from 'twilio';
 import { createLogger } from '../utils/logger';
+import { isPhoneOptedOut } from './consent';
 
 const logger = createLogger({ file: 'lib/sms/twilio' });
 
@@ -54,6 +55,12 @@ export async function sendSMS(to: string, body: string): Promise<SendSMSResult> 
   if (!isValidUSPhone(to)) {
     logger.warn('Invalid phone number format', { function: 'sendSMS', to });
     return { success: false, error: `Invalid US phone number: ${to}` };
+  }
+
+  // Honor STOP for every recipient (pros and customers). Fail-closed.
+  if (await isPhoneOptedOut(to)) {
+    logger.info('Recipient opted out of SMS, skipping', { function: 'sendSMS', to });
+    return { success: false, error: 'Recipient opted out' };
   }
 
   try {

--- a/supabase/migrations/20260711120000_pro_sms_consent_and_opt_outs.sql
+++ b/supabase/migrations/20260711120000_pro_sms_consent_and_opt_outs.sql
@@ -1,0 +1,44 @@
+-- Pro SMS consent (TCPA / Florida FTSA) audit trail + global opt-out ledger.
+--
+-- DRAFT — NOT APPLIED. Reviewed and applied by Daniel/Claude by hand.
+--
+-- Mirrors the existing customer consent columns (users.tcpa_consent_* from
+-- 20260418_dld245_tcpa_consent_columns.sql) for the pro side. Automated Twilio
+-- lead/message alerts are sent to pros.business_phone — a number entered during
+-- onboarding/profile edit that today has no consent record. This adds the
+-- audit columns so a pro's affirmative opt-in is captured, and a phone-keyed
+-- opt-out ledger so inbound STOP is honored.
+
+-- 1. Pro SMS consent audit trail.
+--    Mirrors users.tcpa_consent_at/ip/ua, plus the exact disclosure text shown
+--    and the phone number consented to. Consent is bound to that number: if
+--    business_phone later changes, the send gate sees the mismatch and stops
+--    texting until the pro re-consents.
+ALTER TABLE public.pros
+  ADD COLUMN IF NOT EXISTS sms_consent_at    TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS sms_consent_ip    TEXT,
+  ADD COLUMN IF NOT EXISTS sms_consent_ua    TEXT,
+  ADD COLUMN IF NOT EXISTS sms_consent_text  TEXT,
+  ADD COLUMN IF NOT EXISTS sms_consent_phone TEXT;
+
+COMMENT ON COLUMN public.pros.sms_consent_at IS
+  'When the pro affirmatively opted in to automated SMS to business_phone (TCPA/FTSA). NULL = no consent = no texts.';
+COMMENT ON COLUMN public.pros.sms_consent_phone IS
+  'The business_phone value the pro consented to. If business_phone changes this no longer matches and sends stop until re-consent.';
+
+-- 2. Global, phone-keyed opt-out ledger. Presence of a row suppresses all
+--    outbound SMS to that number (honored for pros and customers alike).
+CREATE TABLE IF NOT EXISTS public.sms_opt_outs (
+  phone        TEXT PRIMARY KEY,
+  opted_out_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  source       TEXT NOT NULL DEFAULT 'sms_stop',
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.sms_opt_outs IS
+  'Recipients who replied STOP (or were opted out). Phone stored in E.164. Presence = suppress all outbound SMS to this number.';
+
+-- 3. RLS: deny-by-default. No policies are granted, so anon/authenticated
+--    clients cannot read or write. Server code accesses this via the service
+--    role, which bypasses RLS.
+ALTER TABLE public.sms_opt_outs ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Launch blocker: pros were texted with no consent record

Automated Twilio lead/message alerts go to **`pros.business_phone`**, but that number is collected during **pro onboarding** and **profile edit** with **no consent checkbox and no consent record**. Under TCPA / Florida FTSA that's $500–$1,500 per text. Customers already have a compliant pattern; this mirrors it for pros.

> ⚠️ **No DB migration applied. Nothing touched in Stripe. Do not merge without cold review + Daniel's go-ahead.**

---

### 1. Every phone-collection point (audit)

| Actor | Where | File:line | Consent before this PR |
|---|---|---|---|
| Customer | Signup checkbox | `components/auth/AuthForm.tsx:515` + record `:165` | ✅ (existing, unchanged) |
| Customer | Quote-submit checkbox | `app/quote-request/page.tsx:559` | ✅ (existing, unchanged) |
| **Pro** | **Onboarding — inserts `business_phone`** | `app/dashboard/pro/setup/page.tsx:135` (input `:224`) | ❌ → **fixed** |
| **Pro** | **Profile edit — updates `business_phone`** | `app/dashboard/pro/profile/page.tsx:291` (input `:447`) | ❌ → **fixed** |
| Pro | Admin views phone | `app/dashboard/admin/*` | view-only, N/A |

Note: signup captures consent tied to `users.phone`, but the SMS actually targets `pros.business_phone` — a **separate, later-entered number** the signup consent never covered.

### 2. Consent copy shown to pros (`lib/sms/consent-copy.ts`, single source of truth for UI + stored text)

> I agree to receive automated text messages from Boss of Clean at the business phone number I provide, including new-lead and new-message alerts. Message frequency varies. Consent is not a condition of using Boss of Clean or receiving leads. Message and data rates may apply. Reply STOP to opt out at any time; reply HELP for help.

Checkbox is **separate, unchecked by default, optional** (not bundled with Terms, **not** a condition of signing up — the submit button is not gated on it).

### 3. Draft migration — `supabase/migrations/20260711120000_pro_sms_consent_and_opt_outs.sql` (NOT APPLIED)

```sql
ALTER TABLE public.pros
  ADD COLUMN IF NOT EXISTS sms_consent_at    TIMESTAMPTZ,
  ADD COLUMN IF NOT EXISTS sms_consent_ip    TEXT,
  ADD COLUMN IF NOT EXISTS sms_consent_ua    TEXT,
  ADD COLUMN IF NOT EXISTS sms_consent_text  TEXT,
  ADD COLUMN IF NOT EXISTS sms_consent_phone TEXT;

CREATE TABLE IF NOT EXISTS public.sms_opt_outs (
  phone        TEXT PRIMARY KEY,
  opted_out_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  source       TEXT NOT NULL DEFAULT 'sms_stop',
  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
);
ALTER TABLE public.sms_opt_outs ENABLE ROW LEVEL SECURITY; -- deny-by-default, service-role only
```

Mirrors `users.tcpa_consent_*`, plus the exact text shown and the number consented to (a later phone change invalidates consent).

### 4. Send path is gated (server-side, fail-closed)

```
api/quote/route.ts / api/messages/route.ts
  → notifyProNewLead / notifyProNewMessage
      ├─ isSmsEnabled(prefs)                 (existing preference toggle)
      ├─ proHasValidSmsConsent(user, phone)  ← NEW consent gate, fail-closed
      └─ sendSMS(to, body)
            └─ isPhoneOptedOut(to)           ← NEW opt-out gate, fail-closed (all recipients)
```

`sendSMS` is only ever called from these functions (verified), so **no pro SMS path bypasses the gate**. `proHasValidSmsConsent` returns false on missing record, phone mismatch, or any error → **no consent record → no text**.

### 5. Existing pros — no backfill

7 pros / 5 with a business_phone / **0 consent records**. They simply stop receiving texts until they opt in. No consent fabricated.

### 6. STOP / opt-out

New signature-verified inbound webhook `app/api/webhooks/twilio/route.ts` records STOP→`sms_opt_outs`, START→removes. `sendSMS` honors it for pros **and** customers. (If Twilio "Advanced Opt-Out" is enabled it also blocks at carrier level — this is the backstop + our own ledger.)

### 7. Neutral-marketplace (PR #88) — no contradiction

Copy makes no vetting/verifying/certifying/guaranteeing claims. Branding leak check clean.

---

### Manual items for Daniel
- Apply the draft migration by hand.
- Set the Twilio inbound-SMS webhook URL to `/api/webhooks/twilio` (and optionally `TWILIO_WEBHOOK_URL` env if behind a proxy).
- Attorney review of the pro consent copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)