### PR TITLE
fix(phone): normalize all captured phones to E.164 (SMS was inert)

### DIFF
--- a/app/api/cleaners/onboarding/route.ts
+++ b/app/api/cleaners/onboarding/route.ts
@@ -5,6 +5,7 @@ import {
   normalizeCategorySlugs,
   reconcileProCategories,
 } from '@/lib/services/pro-categories'
+import { normalizeToE164 } from '@/lib/phone'
 
 const logger = createLogger({ file: 'api/cleaners/onboarding/route' })
 
@@ -99,6 +100,19 @@ export async function POST(request: NextRequest) {
 
     if (!step || step < 1 || step > 6) {
       return NextResponse.json({ error: 'Invalid step' }, { status: 400 })
+    }
+
+    // Store business_phone in E.164 (the SMS layer only sends to E.164). Normalize
+    // here so it applies to both the column write and the onboarding_data blob.
+    if (data?.business_phone != null && `${data.business_phone}`.trim() !== '') {
+      const phoneE164 = normalizeToE164(String(data.business_phone))
+      if (!phoneE164) {
+        return NextResponse.json(
+          { error: 'Please enter a valid US business phone number.' },
+          { status: 400 }
+        )
+      }
+      data.business_phone = phoneE164
     }
 
     // DLD-449: Resolve category slugs against the canonical taxonomy.

--- a/app/dashboard/customer/profile/page.tsx
+++ b/app/dashboard/customer/profile/page.tsx
@@ -8,6 +8,7 @@ import {
   User, MapPin, Save, Bell, Settings, CheckCircle, XCircle, Loader2
 } from 'lucide-react';
 import Link from 'next/link';
+import { normalizeToE164, formatPhoneForDisplay } from '@/lib/phone';
 
 interface CustomerProfile {
   id: string;
@@ -46,7 +47,8 @@ export default function CustomerProfilePage() {
       if (error && error.code !== 'PGRST116') throw error;
 
       if (data) {
-        setProfile(data);
+        // Show the stored E.164 number in friendly national format.
+        setProfile({ ...data, phone: formatPhoneForDisplay(data.phone) });
       } else {
         setProfile({
           id: user?.id || '',
@@ -68,13 +70,24 @@ export default function CustomerProfilePage() {
   const handleProfileSave = async () => {
     if (!profile) return;
 
+    // Phone is optional here; normalize to E.164 when present, reject if invalid.
+    let phoneToStore: string | null = null;
+    if (profile.phone?.trim()) {
+      phoneToStore = normalizeToE164(profile.phone);
+      if (!phoneToStore) {
+        setMessage('Please enter a valid US phone number.');
+        setTimeout(() => setMessage(''), 3000);
+        return;
+      }
+    }
+
     setSaving(true);
     try {
       const { error } = await supabase
         .from('users')
         .update({
           full_name: profile.full_name,
-          phone: profile.phone,
+          phone: phoneToStore,
           address: profile.address,
           city: profile.city,
           zip_code: profile.zip_code,

--- a/app/dashboard/pro/profile/page.tsx
+++ b/app/dashboard/pro/profile/page.tsx
@@ -16,6 +16,7 @@ import { createLogger } from '@/lib/utils/logger';
 import CategorySelector from '@/components/onboarding/CategorySelector';
 import { recordProSmsConsent, revokeProSmsConsent } from '@/lib/actions/tcpa';
 import { PRO_SMS_CONSENT_TEXT } from '@/lib/sms/consent-copy';
+import { normalizeToE164, formatPhoneForDisplay } from '@/lib/phone';
 
 const logger = createLogger({ file: 'app/dashboard/pro/profile/page.tsx' });
 
@@ -91,8 +92,11 @@ export default function CleanerProfilePage() {
         setProfile({
           ...data,
           secondary_categories: secondary,
+          // Show the stored E.164 number in friendly national format.
+          business_phone: formatPhoneForDisplay(data.business_phone),
         });
         // Show as opted-in only when consent is on file for the current number.
+        // Compare against the raw stored value (both are E.164).
         setSmsConsent(!!(data.sms_consent_at && data.sms_consent_phone === data.business_phone));
       } else {
         // Create default profile if none exists
@@ -274,7 +278,13 @@ export default function CleanerProfilePage() {
       setMessage('A valid 5-digit ZIP code is required');
       return;
     }
-    
+
+    const businessPhoneE164 = normalizeToE164(profile.business_phone);
+    if (!businessPhoneE164) {
+      setMessage('Please enter a valid US business phone number.');
+      return;
+    }
+
     setSaving(true);
     try {
       // DLD-449: route category changes through the dedicated endpoint so
@@ -298,7 +308,7 @@ export default function CleanerProfilePage() {
         .update({
           business_name: profile.business_name,
           business_description: profile.business_description,
-          business_phone: profile.business_phone,
+          business_phone: businessPhoneE164,
           business_email: profile.business_email,
           hourly_rate: profile.hourly_rate,
           minimum_hours: profile.minimum_hours,

--- a/app/dashboard/pro/setup/page.tsx
+++ b/app/dashboard/pro/setup/page.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { recordProSmsConsent } from '@/lib/actions/tcpa';
 import { PRO_SMS_CONSENT_TEXT } from '@/lib/sms/consent-copy';
+import { normalizeToE164 } from '@/lib/phone';
 
 const serviceTypes = [
   { value: 'residential', label: 'Residential Cleaning' },
@@ -125,10 +126,16 @@ export default function CleanerSetupPage() {
       setError('Please select at least one service area');
       return;
     }
-    
+
+    const businessPhoneE164 = normalizeToE164(formData.business_phone);
+    if (!businessPhoneE164) {
+      setError('Please enter a valid US business phone number.');
+      return;
+    }
+
     setLoading(true);
     setError('');
-    
+
     try {
       const { error } = await supabase
         .from('pros')
@@ -136,7 +143,7 @@ export default function CleanerSetupPage() {
           user_id: user?.id,
           business_name: formData.business_name,
           business_description: formData.business_description,
-          business_phone: formData.business_phone,
+          business_phone: businessPhoneE164,
           business_email: formData.business_email,
           website_url: formData.website_url || null,
           services: formData.services,

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -12,6 +12,7 @@ import {
   LogOut, Trash2, Mail, Phone, MapPin, CheckCircle, X
 } from 'lucide-react';
 import Link from 'next/link';
+import { normalizeToE164, formatPhoneForDisplay } from '@/lib/phone';
 import { useRouter } from 'next/navigation';
 
 interface UserSettings {
@@ -52,7 +53,8 @@ export default function SettingsPage() {
 
       if (error) throw error;
 
-      setSettings(data);
+      // Show the stored E.164 number in friendly national format.
+      setSettings({ ...data, phone: formatPhoneForDisplay(data.phone) });
     } catch (error) {
       logger.error('Error loading settings', { function: 'loadSettings', error });
       setMessage('Error loading settings');
@@ -63,14 +65,24 @@ export default function SettingsPage() {
 
   const handleSave = async () => {
     if (!settings) return;
-    
+
+    // Phone is optional; normalize to E.164 when present, reject if invalid.
+    let phoneToStore: string | null = null;
+    if (settings.phone?.trim()) {
+      phoneToStore = normalizeToE164(settings.phone);
+      if (!phoneToStore) {
+        setMessage('Please enter a valid US phone number.');
+        return;
+      }
+    }
+
     setSaving(true);
     try {
       const { error } = await supabase
         .from('users')
         .update({
           full_name: settings.full_name,
-          phone: settings.phone,
+          phone: phoneToStore,
           address: settings.address,
           city: settings.city,
           zip_code: settings.zip_code,

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -14,6 +14,7 @@ import { Loader2, Mail, CheckCircle, Eye, EyeOff } from 'lucide-react'
 import { resendVerificationEmail, canResendEmail, markEmailResent, getResendCooldownRemaining } from '@/lib/email/verification'
 import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton'
 import { recordUserTcpaConsent } from '@/lib/actions/tcpa'
+import { normalizeToE164 } from '@/lib/phone'
 
 interface AuthFormProps {
   mode: 'login' | 'signup'
@@ -121,6 +122,12 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
           setLoading(false)
           return
         }
+        const phoneE164 = normalizeToE164(phone)
+        if (!phoneE164) {
+          setError('Please enter a valid US phone number.')
+          setLoading(false)
+          return
+        }
         if (!tcpaConsented) {
           setError('You must agree to the contact consent to continue.')
           setLoading(false)
@@ -156,7 +163,7 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
             .from('users')
             .update({
               full_name: fullName || null,
-              phone: phone || null,
+              phone: phoneE164,
               updated_at: new Date().toISOString(),
             })
             .eq('id', authData.user.id)

--- a/lib/phone.ts
+++ b/lib/phone.ts
@@ -1,0 +1,29 @@
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
+
+/**
+ * Phone helpers. We store phone numbers in E.164 (+1XXXXXXXXXX) because the SMS
+ * layer (lib/sms/twilio.ts) only sends to E.164 US numbers. Normalize on every
+ * write; display in a friendly national format.
+ */
+
+/**
+ * Normalize a user-entered phone to E.164, assuming US when no country code is
+ * given. Returns null if the input is not a valid phone number (caller should
+ * reject invalid input).
+ */
+export function normalizeToE164(input: string | null | undefined): string | null {
+  if (!input) return null;
+  const parsed = parsePhoneNumberFromString(input.trim(), 'US');
+  if (!parsed || !parsed.isValid()) return null;
+  return parsed.number; // E.164, e.g. +14075550123
+}
+
+/**
+ * Format a stored phone for display, e.g. "(407) 555-0123". Falls back to the
+ * raw value if it can't be parsed (e.g. a legacy row not yet normalized).
+ */
+export function formatPhoneForDisplay(value: string | null | undefined): string {
+  if (!value) return '';
+  const parsed = parsePhoneNumberFromString(value.trim(), 'US');
+  return parsed ? parsed.formatNational() : value;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "eslint": "8.49.0",
         "eslint-config-next": "13.5.1",
         "input-otp": "^1.2.4",
+        "libphonenumber-js": "^1.13.8",
         "lucide-react": "^0.446.0",
         "next": "13.5.11",
         "next-themes": "^0.3.0",
@@ -5609,6 +5610,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.8.tgz",
+      "integrity": "sha512-80xal1m93rADejw2pMp2MSzFhHCPLEspjHxnH2UtqI+DgAmElsbmLMiqk9niwH9NWAfjsRtaJI+qBrOEmRx9nQ==",
+      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint": "8.49.0",
     "eslint-config-next": "13.5.1",
     "input-otp": "^1.2.4",
+    "libphonenumber-js": "^1.13.8",
     "lucide-react": "^0.446.0",
     "next": "13.5.11",
     "next-themes": "^0.3.0",

--- a/supabase/migrations/20260712120000_normalize_phones_to_e164.sql
+++ b/supabase/migrations/20260712120000_normalize_phones_to_e164.sql
@@ -1,0 +1,52 @@
+-- Normalize existing phone values to E.164 (+1XXXXXXXXXX).
+--
+-- DRAFT — NOT APPLIED. Reviewed and applied by Daniel/Claude by hand.
+--
+-- Context: the app now stores phones in E.164 via libphonenumber-js (lib/phone.ts).
+-- These legacy rows predate that and are stored free-form, so the SMS layer
+-- (lib/sms/twilio.ts, which requires ^\+1[2-9]\d{9}$) currently can't text them.
+--
+-- This is a BEST-EFFORT pure-SQL normalization (no libphonenumber here): it strips
+-- non-digits and maps 10-digit → +1XXXXXXXXXX and 11-digit-leading-1 → +1XXXXXXXXXX.
+-- Anything that doesn't resolve to a valid 10/11-digit US number is LEFT UNCHANGED
+-- for manual review. Spot-check the output against the preview in the PR before/after
+-- applying — with only a handful of rows this is eyeball-able.
+
+-- Helper: best-effort US → E.164. Dropped at the end so it doesn't linger.
+CREATE OR REPLACE FUNCTION _e164_us(raw text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $func$
+  SELECT CASE
+    WHEN raw IS NULL THEN NULL
+    WHEN length(regexp_replace(raw, '\D', '', 'g')) = 10
+      THEN '+1' || regexp_replace(raw, '\D', '', 'g')
+    WHEN length(regexp_replace(raw, '\D', '', 'g')) = 11
+         AND left(regexp_replace(raw, '\D', '', 'g'), 1) = '1'
+      THEN '+' || regexp_replace(raw, '\D', '', 'g')
+    ELSE raw  -- unrecognized format: leave untouched for manual review
+  END
+$func$;
+
+-- 1. users.phone
+UPDATE public.users
+SET phone = _e164_us(phone)
+WHERE phone IS NOT NULL
+  AND _e164_us(phone) IS DISTINCT FROM phone;
+
+-- 2. pros: normalize business_phone AND sms_consent_phone in the SAME statement.
+--    CRITICAL: if business_phone is reformatted but sms_consent_phone is not, the
+--    #89 send gate (which compares the two) would silently invalidate consent.
+--    Normalizing both identically keeps consent bound to the number.
+UPDATE public.pros
+SET business_phone    = _e164_us(business_phone),
+    sms_consent_phone = _e164_us(sms_consent_phone)
+WHERE (business_phone IS NOT NULL AND _e164_us(business_phone) IS DISTINCT FROM business_phone)
+   OR (sms_consent_phone IS NOT NULL AND _e164_us(sms_consent_phone) IS DISTINCT FROM sms_consent_phone);
+
+-- 3. sms_opt_outs.phone (the ledger key). Twilio delivers E.164 already, so new
+--    rows are fine; this covers any pre-existing/backfilled keys.
+UPDATE public.sms_opt_outs
+SET phone = _e164_us(phone)
+WHERE phone IS NOT NULL
+  AND _e164_us(phone) IS DISTINCT FROM phone;
+
+DROP FUNCTION _e164_us(text);


### PR DESCRIPTION
## Why

`sendSMS` only sends to E.164 US numbers (`^\+1[2-9]\d{9}$`), but every phone was stored free-form (e.g. `4074616039`, `(407) 555-0123`). **Zero** pros/customers were textable, so the SMS notifications from #89 were silently inert. This normalizes on every write.

> ⚠️ **No DB migration applied. Nothing touched in Stripe. Do not merge without cold review + Daniel's go-ahead.**

## a/b. Normalize on input, store E.164, display formatted

New `lib/phone.ts` (libphonenumber-js, default region US):
- `normalizeToE164(input)` → E.164 or `null` (caller rejects invalid)
- `formatPhoneForDisplay(value)` → `(407) 555-0123`

Applied at **every** live phone-capture point (not just the 3 named — the quote-request form has no phone field; it uses the account's `users.phone`):

| Column | Where | File |
|---|---|---|
| `users.phone` | Signup | `components/auth/AuthForm.tsx` |
| `users.phone` | Customer profile edit | `app/dashboard/customer/profile/page.tsx` |
| `users.phone` | Settings | `app/settings/page.tsx` |
| `pros.business_phone` | Pro setup | `app/dashboard/pro/setup/page.tsx` |
| `pros.business_phone` | Pro profile edit | `app/dashboard/pro/profile/page.tsx` |
| `pros.business_phone` | Pro onboarding (server, covers `BusinessInfoForm`) | `app/api/cleaners/onboarding/route.ts` |

Required fields reject invalid; optional fields (customer phone) store `null` when blank, reject when non-blank-invalid. Existing values display in national format and re-normalize to E.164 on save.

## c/d. Draft migration — `supabase/migrations/20260712120000_normalize_phones_to_e164.sql` (NOT APPLIED)

Best-effort pure-SQL normalization (no libphonenumber in Postgres): strips non-digits, maps 10-digit → `+1…` and 11-digit-leading-1 → `+1…`; anything else is **left untouched for manual review**.

- **`pros.business_phone` and `pros.sms_consent_phone` are normalized in the same UPDATE** — per the requirement, so #89's consent gate (which compares the two) doesn't silently invalidate consent. (Currently moot — 0 pros consented — but correct and future-proof.)
- Also normalizes `users.phone` and the `sms_opt_outs` ledger keys.
- Helper function is created and dropped within the migration.

### Read-only preview of what it would produce (not applied)

| col | before | after | sendable |
|---|---|---|---|
| pros.business_phone | `4074616039` | `+14074616039` | ✅ |
| pros.business_phone | `4078681274` | `+14078681274` | ✅ |
| pros.business_phone | `8137251831` | `+18137251831` | ✅ |
| pros.business_phone | `3472821354/9782274198` | *(unchanged)* | ❌ **manual review — two numbers in one field** |
| users.phone | `4074616039` | `+14074616039` | ✅ |

**6 of 7 values → sendable E.164; 1 malformed row flagged, not mangled.** `sms_consent_phone` is all-null (0 consented) and `sms_opt_outs` is empty, so those clauses are no-ops today.

## Notes
- New runtime dep: `libphonenumber-js@^1.13.8`.
- After this + the migration, pros who consent (#89) will actually receive texts.
- The one double-number row (`pros.business_phone`) needs a human to pick which number is correct before/after applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)