### PR TITLE
feat(notifications): close the 4 marketplace notification gaps (DLD-574)

### DIFF
--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -398,7 +398,9 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // SMS notification: look up recipient's phone number
+  // SMS notification: look up recipient's phone number. Also capture the
+  // recipient's user_id so we can write an in-app notification row.
+  let recipientUserId: string | null = null;
   if (isCustomer && cleanerId) {
     // Customer sent message to cleaner — notify the cleaner via SMS
     const { data: cleanerSms } = await supabase
@@ -406,6 +408,8 @@ export async function POST(request: NextRequest) {
       .select('business_phone, user_id')
       .eq('id', cleanerId)
       .single();
+
+    if (cleanerSms?.user_id) recipientUserId = cleanerSms.user_id;
 
     if (cleanerSms?.business_phone && cleanerSms?.user_id) {
       notifications.push(
@@ -423,6 +427,7 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (conv?.customer_id) {
+      recipientUserId = conv.customer_id;
       const { data: customerUser } = await supabase
         .from('users')
         .select('phone')
@@ -437,6 +442,24 @@ export async function POST(request: NextRequest) {
         );
       }
     }
+  }
+
+  // In-app notification row for the recipient (service-role: writing to another
+  // user's notifications row). Fire-and-forget.
+  if (recipientUserId) {
+    const preview = content.trim().substring(0, 100);
+    createServiceRoleClient()
+      .from('notifications')
+      .insert({
+        user_id: recipientUserId,
+        type: 'new_message',
+        title: 'New message',
+        message: `${senderName}: ${preview}`,
+        action_url: '/dashboard/messages',
+      })
+      .then(({ error }) => {
+        if (error) logger.error('Failed to create message notification', { function: 'POST' }, error);
+      });
   }
 
   // Fire all notifications, never let failures break the response

--- a/app/api/quotes/[id]/accept/route.ts
+++ b/app/api/quotes/[id]/accept/route.ts
@@ -4,6 +4,8 @@ import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import { createLogger } from '@/lib/utils/logger';
 import { proHasCapturedQuote } from '@/lib/lead-pii';
 import { scrubText } from '@/lib/pii-filter';
+import { sendQuoteAcceptedProEmail, sendQuoteAcceptedCustomerEmail } from '@/lib/email/notifications';
+import { notifyProQuoteAccepted, sendSMSIfEnabled } from '@/lib/sms/notifications';
 
 const logger = createLogger({ file: 'api/quotes/[id]/accept/route' });
 
@@ -212,16 +214,65 @@ export async function POST(
 
   // Booking exists (created now or already present from a prior accept). Reuse
   // the `admin` client from the accept write — no second service client needed.
+  const quotedPrice = Number(quote.quoted_price) || 0;
+  const businessName = (quote.cleaner.business_name as string) || 'Your pro';
+
+  // Pro in-app notification.
   try {
     await admin.from('notifications').insert({
       user_id: quote.cleaner.user_id,
       type: 'quote_accepted',
       title: 'Quote Accepted!',
-      message: `Your quote of $${quote.quoted_price} has been accepted. A booking has been created.`,
+      message: `Your quote of $${quotedPrice} has been accepted. A booking has been created.`,
       action_url: '/dashboard/pro/bookings',
     });
   } catch (notifErr) {
     logger.error('Failed to create cleaner notification', { function: 'POST' }, notifErr);
+  }
+
+  // Fetch contact details (service-role) for pro email/SMS and customer email.
+  const [{ data: proContact }, { data: customer }] = await Promise.all([
+    admin.from('pros').select('business_email, business_phone').eq('id', quote.cleaner_id).single(),
+    admin.from('users').select('full_name, email').eq('id', quote.customer_id).single(),
+  ]);
+
+  // Pro: email + consent-gated SMS. This is the moment before they pay the $30
+  // lead fee, so notify immediately. All non-blocking.
+  if (proContact?.business_email) {
+    sendQuoteAcceptedProEmail({
+      to: proContact.business_email,
+      businessName,
+      quoteAmount: quotedPrice,
+      quoteId,
+    }).catch((err) => logger.error('Failed pro quote-accepted email', { function: 'POST' }, err));
+  }
+  if (proContact?.business_phone) {
+    // Routes through the #89 consent gate (fail-closed): no consent → no text.
+    sendSMSIfEnabled(() =>
+      notifyProQuoteAccepted(quote.cleaner.user_id, proContact.business_phone, quotedPrice)
+    ).catch((err) => logger.error('Pro quote-accepted SMS error', { function: 'POST' }, err));
+  }
+
+  // Customer: in-app + email confirmation explaining what happens next.
+  try {
+    await admin.from('notifications').insert({
+      user_id: quote.customer_id,
+      type: 'quote_accepted',
+      title: 'Quote accepted',
+      message: `You accepted ${businessName}'s $${quotedPrice} quote. They'll receive your contact info and reach out to arrange the details.`,
+      action_url: '/dashboard/customer',
+    });
+  } catch (notifErr) {
+    logger.error('Failed to create customer notification', { function: 'POST' }, notifErr);
+  }
+  const customerEmail = customer?.email;
+  if (customerEmail) {
+    sendQuoteAcceptedCustomerEmail({
+      to: customerEmail,
+      customerName: (customer?.full_name as string) || 'there',
+      businessName,
+      quoteAmount: quotedPrice,
+    }).catch((err) => logger.error('Failed customer quote-accepted email', { function: 'POST' }, err));
   }
 
   logger.info('Quote accepted and booking confirmed', {

--- a/app/quote-request/actions.ts
+++ b/app/quote-request/actions.ts
@@ -4,6 +4,7 @@ import { headers } from 'next/headers';
 import { createClient } from '@/lib/supabase/server';
 import { createServiceRoleClient } from '@/lib/supabase/service-role';
 import { sendQuoteConfirmationEmail, sendNewLeadEmail } from '@/lib/email/notifications';
+import { notifyProNewLead, sendSMSIfEnabled } from '@/lib/sms/notifications';
 import { checkRateLimit, RATE_LIMITS } from '@/lib/middleware/rate-limit';
 import { createLogger } from '@/lib/utils/logger';
 
@@ -146,13 +147,13 @@ export async function submitQuoteRequest(
     // ============================================
     // Match by: approved cleaners whose service_areas include this zip code
     // Fallback: if no service_areas match, try cleaners whose user zip matches
-    let matchedPros: { cleaner_id: string; user_id: string; email: string; business_name: string }[] = [];
+    let matchedPros: { cleaner_id: string; user_id: string; email: string; business_name: string; business_phone: string | null }[] = [];
 
     try {
       // Primary match: service_areas table (service-role: cross-customer read)
       const { data: areaMatches } = await adminSupabase
         .from('service_areas')
-        .select('cleaner_id, cleaner:pros!inner(id, business_name, user_id, approval_status, user:users!inner(email))')
+        .select('cleaner_id, cleaner:pros!inner(id, business_name, user_id, approval_status, business_phone, user:users!inner(email))')
         .eq('zip_code', data.zip_code);
 
       if (areaMatches && areaMatches.length > 0) {
@@ -169,6 +170,7 @@ export async function submitQuoteRequest(
               user_id: cleaner.user_id as string,
               email: user.email as string,
               business_name: cleaner.business_name as string,
+              business_phone: (cleaner.business_phone as string) ?? null,
             };
           });
       }
@@ -178,7 +180,7 @@ export async function submitQuoteRequest(
       if (matchedPros.length === 0) {
         const { data: allApproved } = await adminSupabase
           .from('pros')
-          .select('id, business_name, user_id, user:users!inner(email)')
+          .select('id, business_name, user_id, business_phone, user:users!inner(email)')
           .eq('approval_status', 'approved');
 
         if (allApproved && allApproved.length > 0) {
@@ -189,6 +191,7 @@ export async function submitQuoteRequest(
               user_id: c.user_id,
               email: user.email as string,
               business_name: c.business_name,
+              business_phone: (c.business_phone as string) ?? null,
             };
           });
         }
@@ -234,6 +237,17 @@ export async function submitQuoteRequest(
       }).catch((err) =>
         logger.error('Failed to send pro email', { function: 'submitQuoteRequest', email: pro.email }, err)
       );
+
+      // SMS notification (consent-gated, fire-and-forget). Routes through the
+      // #89 consent gate inside notifyProNewLead — no consent record → no text,
+      // just email + in-app. Customer name is withheld pre-acceptance (PII).
+      if (pro.business_phone) {
+        sendSMSIfEnabled(() =>
+          notifyProNewLead(pro.user_id, pro.business_phone as string, 'A customer', data.service_type, data.zip_code)
+        ).catch((err) =>
+          logger.error('Pro new-lead SMS error', { function: 'submitQuoteRequest', userId: pro.user_id }, err)
+        );
+      }
     }
 
     // ============================================

--- a/lib/email/notifications.ts
+++ b/lib/email/notifications.ts
@@ -123,6 +123,85 @@ function generateQuoteConfirmationEmailHtml(data: QuoteConfirmationEmailData): s
   return wrapEmailTemplate(content);
 }
 
+export interface QuoteAcceptedProEmailData {
+  to: string;
+  businessName: string;
+  quoteAmount: number;
+  quoteId: string;
+}
+
+export interface QuoteAcceptedCustomerEmailData {
+  to: string;
+  customerName: string;
+  businessName: string;
+  quoteAmount: number;
+}
+
+/**
+ * Generate "your quote was accepted" email for the pro.
+ * Neutral-marketplace copy: BOC facilitates the introduction; the lead fee
+ * unlocks contact info. No guarantees about the job.
+ */
+function generateQuoteAcceptedProEmailHtml(data: QuoteAcceptedProEmailData): string {
+  const content = `
+    <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">Your quote was accepted!</h2>
+    <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
+      Hi ${data.businessName}, a customer accepted your quote of <strong>$${data.quoteAmount}</strong>.
+    </p>
+
+    <div style="background: #ecfdf5; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #10b981;">
+      <p style="margin: 0; color: #065f46; font-size: 14px;">
+        <strong>Next step:</strong> pay the $30 lead fee to unlock the customer's contact
+        details, then reach out to arrange the job directly. The lead fee is for the
+        introduction only.
+      </p>
+    </div>
+
+    ${generateButton('Unlock Contact & Respond', `${BASE_URL}/dashboard/pro/leads`)}
+
+    <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">
+      You set your own prices and arrange the work directly with the customer. Boss of
+      Clean is a marketplace that connects you — it is not a party to the job.
+    </p>
+  `;
+
+  return wrapEmailTemplate(content);
+}
+
+/**
+ * Generate "you accepted a quote" confirmation for the customer.
+ * Neutral-marketplace copy: explains what happens next without any guarantee or
+ * vetting claim.
+ */
+function generateQuoteAcceptedCustomerEmailHtml(data: QuoteAcceptedCustomerEmailData): string {
+  const content = `
+    <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">You accepted a quote</h2>
+    <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
+      Hi ${data.customerName}, you accepted <strong>${data.businessName}</strong>'s quote of
+      <strong>$${data.quoteAmount}</strong>.
+    </p>
+
+    <div style="background: #eff6ff; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #2563eb;">
+      <p style="margin: 0; color: #1e40af; font-size: 14px;">
+        <strong>What happens next?</strong><br>
+        ${data.businessName} will receive your contact information and reach out to
+        arrange the details directly with you. You and the pro agree on scheduling,
+        payment for the service, and any other terms between yourselves.
+      </p>
+    </div>
+
+    ${generateButton('View in Your Dashboard', `${BASE_URL}/dashboard/customer`)}
+
+    <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">
+      Boss of Clean connects you with independent professionals and does not vet, verify,
+      or guarantee any pro. Please confirm licensing and insurance directly with the pro
+      before work begins.
+    </p>
+  `;
+
+  return wrapEmailTemplate(content);
+}
+
 /**
  * Send email notification to cleaner about new lead
  */
@@ -175,6 +254,43 @@ export async function sendQuoteConfirmationEmail(data: QuoteConfirmationEmailDat
     to: data.to,
     subject: 'Your cleaning quote request has been submitted!',
     html: generateQuoteConfirmationEmailHtml(data),
+  });
+
+  return result.success;
+}
+
+/**
+ * Send "your quote was accepted" email to the pro.
+ */
+export async function sendQuoteAcceptedProEmail(data: QuoteAcceptedProEmailData): Promise<boolean> {
+  logger.info('Sending quote-accepted (pro) notification', {
+    function: 'sendQuoteAcceptedProEmail',
+    to: data.to,
+    quoteId: data.quoteId,
+  });
+
+  const result = await sendResendEmail({
+    to: data.to,
+    subject: 'Your quote was accepted — unlock the customer contact',
+    html: generateQuoteAcceptedProEmailHtml(data),
+  });
+
+  return result.success;
+}
+
+/**
+ * Send "you accepted a quote" confirmation email to the customer.
+ */
+export async function sendQuoteAcceptedCustomerEmail(data: QuoteAcceptedCustomerEmailData): Promise<boolean> {
+  logger.info('Sending quote-accepted (customer) confirmation', {
+    function: 'sendQuoteAcceptedCustomerEmail',
+    to: data.to,
+  });
+
+  const result = await sendResendEmail({
+    to: data.to,
+    subject: `You accepted ${data.businessName}'s quote`,
+    html: generateQuoteAcceptedCustomerEmailHtml(data),
   });
 
   return result.success;

--- a/lib/sms/notifications.ts
+++ b/lib/sms/notifications.ts
@@ -149,6 +149,39 @@ export async function notifyProNewMessage(
 }
 
 /**
+ * Notify a pro that a customer accepted their quote.
+ */
+export async function notifyProQuoteAccepted(
+  userId: string,
+  phoneNumber: string,
+  quoteAmount: number
+) {
+  const enabled = await isSmsEnabled(userId, 'sms_new_leads');
+  if (!enabled) {
+    logger.info('SMS disabled for new leads, skipping quote-accepted text', {
+      function: 'notifyProQuoteAccepted',
+      userId,
+    });
+    return { success: false, error: 'SMS not enabled' };
+  }
+
+  // TCPA / FTSA gate: never text a pro without a valid on-file consent record
+  // for this exact number. Fail-closed — no record → skip and log.
+  const consented = await proHasValidSmsConsent(userId, phoneNumber);
+  if (!consented) {
+    logger.info('No valid SMS consent on file for pro, skipping quote-accepted text', {
+      function: 'notifyProQuoteAccepted',
+      userId,
+    });
+    return { success: false, error: 'No SMS consent on file' };
+  }
+
+  const body = `Boss of Clean: Your $${quoteAmount} quote was accepted! Log in to unlock the customer's contact and respond. Reply STOP to unsubscribe`;
+
+  return sendSMS(phoneNumber, body);
+}
+
+/**
  * Notify a customer that a pro has sent them a quote.
  */
 export async function notifyCustomerQuoteReceived(


### PR DESCRIPTION
Closes the notification gaps found in the DLD-574 audit. The marketplace was silent at the three moments that matter most. **PR only — not merged.**

> No DB changes. Nothing touched in Stripe. All SMS routes through the #89 consent gate (fail-closed) and #90 E.164 storage.

### a. New lead → pro **SMS** (was: email + in-app only)
`notifyProNewLead` lived in the **orphaned `/api/quote` route (no caller)**. Wired it into the live path (`submitQuoteRequest`) for each matched pro. Routed through the #89 consent gate — **no consent record → no text**, just email + in-app. Customer name withheld pre-acceptance (PII). `app/quote-request/actions.ts`

### b. Quote accepted → **pro** (was: in-app only)
Added **Resend email** + **consent-gated SMS** (`notifyProQuoteAccepted`). This is the moment before they pay the $30 lead fee — they hear immediately on every channel they've consented to. `app/api/quotes/[id]/accept/route.ts`

### c. Quote accepted → **customer** (was: nothing on any channel)
Added **email confirmation + in-app row** explaining what happens next (the pro receives their contact info and reaches out; they arrange details directly). `app/api/quotes/[id]/accept/route.ts`

### d. New message **in-app** (was: unread badge only)
Added a `notifications`-table row for the recipient (service-role, both directions). `app/api/messages/route.ts`

### New email templates (2)
`lib/email/notifications.ts`: `sendQuoteAcceptedProEmail`, `sendQuoteAcceptedCustomerEmail`. Both use the existing `wrapEmailTemplate` styling and **neutral-marketplace copy**:
- Pro: *"the lead fee is for the introduction only… Boss of Clean is a marketplace that connects you — it is not a party to the job."*
- Customer: *"does not vet, verify, or guarantee any pro. Please confirm licensing and insurance directly with the pro before work begins."*

Rendered screenshots of both templates are attached in the session.

### Channel matrix after this PR
| Event | Actor | Email | In-app | SMS (consent-gated) |
|---|---|---|---|---|
| New lead | Pro | ✅ | ✅ | ✅ (new) |
| New message | Pro / Customer | ✅ | ✅ (new) | ✅ |
| Quote accepted | Pro | ✅ (new) | ✅ | ✅ (new) |
| Quote accepted | Customer | ✅ (new) | ✅ (new) | — (email + in-app per spec) |

Typecheck: no new errors (the pre-existing `any`/cast warnings on these files are unchanged and build-ignored via `next.config.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)