### PR TITLE
fix(auth): persist signup phone via service role (DLD-576)

### DIFF
--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -158,18 +158,19 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
 
         if (authData.user) {
           // The handle_new_user DB trigger creates the users row automatically.
-          // Update it with additional fields the trigger doesn't have.
-          await supabase
-            .from('users')
-            .update({
-              full_name: fullName || null,
-              phone: phoneE164,
-              updated_at: new Date().toISOString(),
-            })
-            .eq('id', authData.user.id)
-
-          // Record TCPA consent (IP captured server-side)
-          recordUserTcpaConsent(authData.user.id, navigator.userAgent).catch(() => {})
+          // Persist phone + full_name + TCPA consent via a service-role server
+          // action: the email isn't confirmed yet so the client has no session,
+          // and a direct client-side users UPDATE is blocked by RLS (DLD-576).
+          const profileResult = await recordUserTcpaConsent(
+            authData.user.id,
+            navigator.userAgent,
+            { phone: phoneE164, fullName: fullName || null }
+          )
+          if (!profileResult.ok) {
+            // No more silent drops — surface it (account still exists).
+            console.error('Failed to persist signup contact info', profileResult.error)
+            setError('Your account was created, but we could not save your phone number. Please add it in your profile settings.')
+          }
 
           // If cleaner, update the trigger-created cleaners profile with form data
           if (role === 'cleaner') {

--- a/lib/actions/tcpa.ts
+++ b/lib/actions/tcpa.ts
@@ -10,18 +10,33 @@ async function clientIp(): Promise<string> {
   return forwarded ? forwarded.split(',')[0].trim() : (headersList.get('x-real-ip') || 'unknown');
 }
 
-export async function recordUserTcpaConsent(userId: string, userAgent: string): Promise<void> {
+/**
+ * Persist TCPA consent AND signup contact (phone, full_name) via the service
+ * role. At signup the email is not yet confirmed, so the client has no session
+ * and a direct client-side `users` UPDATE is blocked by the users_update RLS
+ * policy (auth.uid() = id) — that silently dropped the phone (DLD-576). Writing
+ * here bypasses RLS and returns a result so the caller can surface failures.
+ */
+export async function recordUserTcpaConsent(
+  userId: string,
+  userAgent: string,
+  contact?: { phone?: string | null; fullName?: string | null }
+): Promise<{ ok: boolean; error?: string }> {
   const ip = await clientIp();
 
+  const update: Record<string, unknown> = {
+    tcpa_consent_at: new Date().toISOString(),
+    tcpa_consent_ip: ip,
+    tcpa_consent_ua: userAgent.slice(0, 512),
+  };
+  if (contact?.phone) update.phone = contact.phone;
+  if (contact?.fullName) update.full_name = contact.fullName;
+
   const supabase = createServiceRoleClient();
-  await supabase
-    .from('users')
-    .update({
-      tcpa_consent_at: new Date().toISOString(),
-      tcpa_consent_ip: ip,
-      tcpa_consent_ua: userAgent.slice(0, 512),
-    })
-    .eq('id', userId);
+  const { error } = await supabase.from('users').update(update).eq('id', userId);
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
 }
 
 /**


### PR DESCRIPTION
**DLD-576 — launch blocker.** Customer phone (required field) was silently dropped at signup. **PR only, not merged.** No DB, no Stripe.

### Root cause
`AuthForm` persisted phone via a **client-side** `supabase.from('users').update({ phone })` that runs after `signUp` but **before email confirmation** — no session → `auth.uid()` null → the `users_update` RLS policy (`is_admin() OR auth.uid() = id`) blocks it. Silent failure. 13/15 users had no phone; after a pro pays $30 the customer's phone is empty.

### Fix (least invasive — justified)
- **Chosen:** extend the existing service-role server action `recordUserTcpaConsent` to also persist `phone` + `full_name` (bypasses RLS, same proven pattern as consent) and **return `{ ok, error }`** so the client surfaces failures. Removed the client-side `users` UPDATE.
- **Rejected Option B** (put phone in `signUp` metadata so `handle_new_user` writes it): that requires editing the DB trigger = a **migration**, which is barred (all migrations already applied to prod). Option A is app-only.
- **No more silent drops:** on failure the client `console.error`s and shows *"we could not save your phone number…"*.

### Pro path
Both customer and pro signup go through this shared block, so **`users.phone` is now persisted for pros too**. (Note for DLD-577/Task 3: pro signup also does a client-side `pros.update({ business_name })` with the same pre-session RLS exposure — flagged separately; not in scope here.)

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)