### PR TITLE
fix(pro-profile): friendly message on duplicate business name (slug collision)

### DIFF
--- a/app/dashboard/pro/profile/page.tsx
+++ b/app/dashboard/pro/profile/page.tsx
@@ -318,6 +318,17 @@ export default function CleanerProfilePage() {
 
       if (profileError) {
         logger.error('Error saving profile', { function: 'handleSave', error: profileError });
+        // A duplicate business name collides on the business_slug unique index
+        // (cleaners_business_slug_key) via the generate_business_slug trigger and
+        // comes back as a raw Postgres 23505. Map it to a clear, actionable
+        // message instead of leaking the constraint text to the pro.
+        const isDuplicateName =
+          profileError.code === '23505' &&
+          /business_slug/i.test(`${profileError.message ?? ''} ${profileError.details ?? ''}`);
+        if (isDuplicateName) {
+          setMessage('That business name is already taken — please choose another.');
+          return;
+        }
         saveErrors.push(`profile — ${profileError.message}`);
       }
 


### PR DESCRIPTION
Follow-up to DLD-578. **No DB, no Stripe.**

### Bug
Renaming a pro to a name whose slug already exists surfaces a **raw Postgres error** to the user: `duplicate key value violates unique constraint "cleaners_business_slug_key"`.

Root cause: the `generate_business_slug` BEFORE-UPDATE trigger de-dupes by checking the **`cleaners` view** (which is filtered — e.g. approved-only), so it misses collisions against `pros` rows excluded from that view (archived/unapproved stubs). The full unique index on `pros` then throws. (This is exactly why the SOTSVC stub had to be renamed to free the `trusted-cleaning-experts` slug.)

### Fix (client-side; schema is migration-locked)
In `handleSave`, detect the `23505`-on-`business_slug` profile error and show:

> **That business name is already taken — please choose another.**

…then stop the save so the pro can pick a different name. All other errors are unchanged, and the DLD-578 decoupling (profile vs categories) is preserved.

### Note (out of scope)
The underlying trigger de-dupe checking the filtered `cleaners` view instead of `pros` is a latent schema bug — flagged for a future migration; not touched here.

### Verify
- Typecheck clean for the touched file.
- Manual: rename a pro to an existing name → friendly message, no raw constraint text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)