### PR TITLE
fix(pro-profile): make business_phone optional; kill silent save gates (DLD-581)

### DIFF
--- a/app/dashboard/pro/profile/page.tsx
+++ b/app/dashboard/pro/profile/page.tsx
@@ -263,7 +263,11 @@ export default function CleanerProfilePage() {
   };
 
   const handleSave = async () => {
-    if (!profile) return;
+    if (!profile) {
+      // Never fail silently — surface why the save didn't run (DLD-581).
+      setMessage('Profile is still loading — please wait a moment and try again.');
+      return;
+    }
 
     // Validate required address fields
     if (!profile.business_address?.trim()) {
@@ -279,9 +283,19 @@ export default function CleanerProfilePage() {
       return;
     }
 
-    const businessPhoneE164 = normalizeToE164(profile.business_phone);
-    if (!businessPhoneE164) {
-      setMessage('Please enter a valid US business phone number.');
+    // DLD-581: business_phone is OPTIONAL — messaging is a valid contact channel,
+    // so a pro can save with no phone. Only two things block the save, and both
+    // show a specific message (never a silent early-return):
+    //   1. a phone was entered but isn't a valid US number, or
+    //   2. SMS consent is checked but there's no valid number to text.
+    const hasPhoneInput = !!profile.business_phone?.trim();
+    const businessPhoneE164 = hasPhoneInput ? normalizeToE164(profile.business_phone) : null;
+    if (hasPhoneInput && !businessPhoneE164) {
+      setMessage('That business phone number isn’t a valid US number. Fix it, or clear the field to save without a phone.');
+      return;
+    }
+    if (smsConsent && !businessPhoneE164) {
+      setMessage('A valid business phone number is required to turn on SMS text alerts. Add a number, or uncheck SMS consent to save without one.');
       return;
     }
 


### PR DESCRIPTION
**DLD-581.** **PR only, not merged — for cold review.** No DB, no Stripe.

### Bug
`handleSave` early-returned whenever `business_phone` was empty:
```
const businessPhoneE164 = normalizeToE164(profile.business_phone);
if (!businessPhoneE164) { setMessage('Please enter a valid US business phone number.'); return; }
```
So a **messaging-only** pro (no phone) could never save their profile — every edit blocked before the write. Daniel hit this on his own account. Same silent-failure class as DLD-578.

### Fix
- `business_phone` is now **optional** — saves with no phone, persisted as `null`.
- Phone required **only** when the SMS-consent box is checked (can't text without a number) → specific inline message.
- Invalid-but-present phone → specific message (no silent drop).

### handleSave early-return audit (requested)
| Gate | Before | After |
|---|---|---|
| `if (!profile) return` | **silent** | now shows "Profile is still loading…" |
| address / city / zip empty | visible, specific | unchanged (already correct) |
| **phone empty/invalid** | **unconditionally required** | optional; only blocks (with a message) if invalid, or if SMS consent is on |
| duplicate name (23505) | visible friendly | unchanged |
| `saveErrors` | visible combined | unchanged |

Only the `!profile` guard and the phone gate needed changes; every other gate already surfaced a visible, specific error.

### Verify
- Typecheck clean for the touched file.
- Post-merge live check: save a pro profile with the phone field empty → persists; check the SMS-consent box with no phone → clear inline message, no save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)