### PR TITLE
fix(ux): silent-failure sweep — surface swallowed errors (signup/upload/messaging/favorites)

### DIFF
--- a/components/FavoriteButton.tsx
+++ b/components/FavoriteButton.tsx
@@ -28,6 +28,7 @@ export function FavoriteButton({
   const [isFavorited, setIsFavorited] = useState(initialFavorited);
   const [loading, setLoading] = useState(false);
   const [favoriteCount, setFavoriteCount] = useState(count);
+  const [error, setError] = useState<string | null>(null);
   const supabase = createClient();
 
   const sizeClasses = {
@@ -71,6 +72,7 @@ export function FavoriteButton({
     }
 
     setLoading(true);
+    setError(null);
 
     try {
       if (isFavorited) {
@@ -81,10 +83,9 @@ export function FavoriteButton({
           .eq('customer_id', user.id)
           .eq('cleaner_id', cleanerId);
 
-        if (!error) {
-          setIsFavorited(false);
-          setFavoriteCount((prev) => Math.max(0, prev - 1));
-        }
+        if (error) throw error;
+        setIsFavorited(false);
+        setFavoriteCount((prev) => Math.max(0, prev - 1));
       } else {
         // Add to favorites
         const { error } = await supabase.from('customer_favorites').insert({
@@ -92,13 +93,14 @@ export function FavoriteButton({
           cleaner_id: cleanerId,
         });
 
-        if (!error) {
-          setIsFavorited(true);
-          setFavoriteCount((prev) => prev + 1);
-        }
+        if (error) throw error;
+        setIsFavorited(true);
+        setFavoriteCount((prev) => prev + 1);
       }
-    } catch (error) {
-      // Error toggling favorite - silently fail for client component
+    } catch {
+      // Don't fail silently — briefly tell the user it didn't stick.
+      setError("Couldn't update favorites. Please try again.");
+      setTimeout(() => setError(null), 3000);
     } finally {
       setLoading(false);
     }
@@ -120,10 +122,19 @@ export function FavoriteButton({
         disabled:opacity-50
         disabled:cursor-not-allowed
         flex items-center gap-1
+        relative
         ${className}
       `}
-      title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+      title={error ?? (isFavorited ? 'Remove from favorites' : 'Add to favorites')}
     >
+      {error && (
+        <span
+          role="alert"
+          className="absolute bottom-full left-1/2 z-10 mb-1 -translate-x-1/2 whitespace-nowrap rounded bg-red-600 px-2 py-1 text-xs text-white shadow"
+        >
+          {error}
+        </span>
+      )}
       <Heart
         className={`
           ${sizeClasses[size]}

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -181,14 +181,20 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
               .eq('user_id', authData.user.id)
               .single()
 
+            // Track whether the cleaner's business details / service area saved.
+            // These run after the account is created; a silent failure here means
+            // the pro won't match leads in their ZIP and never knows why.
+            let cleanerSetupFailed = false
+
             if (cleanerData) {
               // Update with business details from the signup form
-              await supabase
+              const { error: bizErr } = await supabase
                 .from('pros')
                 .update({
                   business_name: businessName || fullName || email.split('@')[0],
                 })
                 .eq('id', cleanerData.id)
+              if (bizErr) cleanerSetupFailed = true
 
               // Seed initial service area if zip provided
               if (zipCode) {
@@ -199,7 +205,7 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
                   .single()
 
                 if (zipData) {
-                  await supabase
+                  const { error: areaErr } = await supabase
                     .from('service_areas')
                     .insert({
                       cleaner_id: cleanerData.id,
@@ -208,6 +214,7 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
                       county: zipData.county,
                       is_primary: true,
                     })
+                  if (areaErr) cleanerSetupFailed = true
                 }
               }
             } else {
@@ -222,6 +229,8 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
                 .select('id')
                 .single()
 
+              if (cleanerError) cleanerSetupFailed = true
+
               if (!cleanerError && newCleaner && zipCode) {
                 const { data: zipData } = await supabase
                   .from('florida_zipcodes')
@@ -230,7 +239,7 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
                   .single()
 
                 if (zipData) {
-                  await supabase
+                  const { error: areaErr } = await supabase
                     .from('service_areas')
                     .insert({
                       cleaner_id: newCleaner.id,
@@ -239,8 +248,14 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
                       county: zipData.county,
                       is_primary: true,
                     })
+                  if (areaErr) cleanerSetupFailed = true
                 }
               }
+            }
+
+            if (cleanerSetupFailed) {
+              // Account exists; be honest that business setup didn't fully save.
+              setError('Your account was created, but we couldn\'t save all your business details. Please finish setting up your business name and service area in your profile after you verify your email.')
             }
           }
           // Notify admin of new signup (fire and forget - don't block signup flow)

--- a/components/messaging/MessageInput.tsx
+++ b/components/messaging/MessageInput.tsx
@@ -14,6 +14,7 @@ interface MessageInputProps {
 export function MessageInput({ onSend, disabled, placeholder = 'Type a message...', showTemplates = true }: MessageInputProps) {
   const [content, setContent] = useState('');
   const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [showTemplatePicker, setShowTemplatePicker] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
@@ -46,12 +47,17 @@ export function MessageInput({ onSend, disabled, placeholder = 'Type a message..
     if (!trimmed || sending || disabled) return;
 
     setSending(true);
+    setError(null);
     try {
       await onSend(trimmed);
+      // Only clear the box once the send actually succeeded.
       setContent('');
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
       }
+    } catch (err) {
+      // Never fail silently — keep the typed text and tell the user.
+      setError(err instanceof Error ? err.message : 'Message failed to send. Please try again.');
     } finally {
       setSending(false);
     }
@@ -100,6 +106,12 @@ export function MessageInput({ onSend, disabled, placeholder = 'Type a message..
             );
           })}
         </div>
+      )}
+
+      {error && (
+        <p className="mb-2 text-sm text-red-600" role="alert">
+          {error}
+        </p>
       )}
 
       <div className="flex items-end gap-2">

--- a/components/onboarding/DocumentUploadForm.tsx
+++ b/components/onboarding/DocumentUploadForm.tsx
@@ -54,20 +54,10 @@ export default function DocumentUploadForm({ data, onChange, onNext, onBack, isS
         .upload(filePath, file)
 
       if (uploadError) {
-        // If bucket doesn't exist, store as base64 temporarily
-        // Storage upload error - fall back to local storage
-        // For now, just save the file info locally
-        const newDoc: DocumentUpload = {
-          document_type: type as DocumentUpload['document_type'],
-          file_name: file.name,
-          file_url: URL.createObjectURL(file),
-          file_size: file.size,
-          mime_type: file.type,
-          verification_status: 'pending'
-        }
-
-        const existingDocs = documents.filter((d) => d.document_type !== type)
-        onChange({ ...data, documents: [...existingDocs, newDoc] })
+        // Never fake success: a blob: URL dies with the tab, so the document
+        // would look "uploaded" but never actually persist (silent data loss).
+        // Surface the real failure and stop so the pro can retry.
+        setError(`We couldn't upload your ${type.replace(/_/g, ' ')}. ${uploadError.message}. Please try again.`)
         return
       }
 

--- a/components/onboarding/PhotoUploadForm.tsx
+++ b/components/onboarding/PhotoUploadForm.tsx
@@ -39,8 +39,11 @@ export default function PhotoUploadForm({ data, onChange, onNext, onBack, isSubm
       .upload(fileName, file)
 
     if (uploadError) {
-      // Fallback: use object URL for preview, store filename for later
-      return URL.createObjectURL(file)
+      // Never fake success with a blob: URL — it dies with the tab, so the photo
+      // would look uploaded but never persist. Surface the failure and return
+      // null so the caller doesn't save a dead URL.
+      setError(`We couldn't upload your photo. ${uploadError.message}. Please try again.`)
+      return null
     }
 
     const { data: urlData } = supabase.storage


### PR DESCRIPTION
Final silent-failure sweep. Audited every form/save path; 5 swallowed-error sites fixed so **every failure shows a visible, specific message**. No DB, no Stripe.

### Fixed (Table A)
| # | Path | file | Was | Now | Sev |
|---|---|---|---|---|---|
| A1 | Onboarding — document upload | `components/onboarding/DocumentUploadForm.tsx` | On upload error, faked a doc with a `blob:` URL shown as "pending" → license/insurance silently lost | Surfaces the error; no fake success | **HIGH** |
| A2 | Onboarding — profile/portfolio photos | `components/onboarding/PhotoUploadForm.tsx` | `uploadFile` returned a `blob:` URL on error → saved as `profile_image_url`/`portfolio_images` | Surfaces error, returns `null` so nothing dead is saved | **HIGH** |
| A3 | Messaging — send | `components/messaging/MessageInput.tsx` | try/finally, **no catch** → failed send showed nothing, cleared spinner | Catches, keeps typed text, shows inline error | Med |
| A4 | Cleaner signup — business details/service area | `components/auth/AuthForm.tsx` | `business_name` update + `service_areas` inserts had no error capture → pro won't match leads in their ZIP, never knows | Tracks failures, shows a "finish your profile" notice | Med |
| A5 | Favorites toggle | `components/FavoriteButton.tsx` | empty else + empty catch → zero feedback | Brief inline error | Med (low-stakes) |

### Audited & already correct (Table B) — no change
Login/signup submit, DLD-576 phone persist, resend-verification, quote request submit, quote response (pro), pro profile save (DLD-578/581), pro logo/gallery upload, settings save, customer profile save, notification-prefs toggle, pro documents dashboard upload, **payment/$30 lead unlock** (`leads/page.tsx` surfaces `data.error`), billing (upgrade/cancel/portal), review submit, conversation load/mark-read — all surface errors already.

### Reported for follow-up (out of this PR's scope — load paths + a stub, not save-path silent-data-loss)
- Load failures that leave a form/list empty with no message: `app/dashboard/customer/profile/page.tsx:63`, `app/dashboard/pro/documents/page.tsx:60`, `app/dashboard/customer/reviews/new/page.tsx:69`.
- `app/settings/page.tsx:105` `handleDeleteAccount` is a stub that only signs out (misleading "Delete Account" button) — needs a product decision.

### Verify
- Typecheck clean for all 5 touched files.
- Post-merge: previews now build (deploy-preview env gap fixed, DLD-582).

🤖 Generated with [Claude Code](https://claude.com/claude-code)