### PR TITLE
fix(onboarding): user-scoped storage paths so uploads actually persist (root cause of blob: damage)

### DIFF
--- a/components/onboarding/DocumentUploadForm.tsx
+++ b/components/onboarding/DocumentUploadForm.tsx
@@ -43,10 +43,28 @@ export default function DocumentUploadForm({ data, onChange, onNext, onBack, isS
     setError(null)
 
     try {
+      // cleaner-documents RLS requires the first path segment to be the pro's id
+      // (pros.id for this user). Uploading under any other prefix is rejected —
+      // which is what silently pushed onboarding documents onto dead blob: URLs.
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        setError('Your session expired. Please sign in again to upload documents.')
+        return
+      }
+      const { data: pro, error: proError } = await supabase
+        .from('pros')
+        .select('id')
+        .eq('user_id', user.id)
+        .single()
+      if (proError || !pro) {
+        setError('We couldn\'t find your pro profile to attach this document to. Please refresh and try again.')
+        return
+      }
+
       // Generate unique file name
       const fileExt = file.name.split('.').pop()
       const fileName = `${type}_${Date.now()}.${fileExt}`
-      const filePath = `documents/${fileName}`
+      const filePath = `${pro.id}/${fileName}`
 
       // Upload to Supabase Storage
       const { error: uploadError } = await supabase.storage

--- a/components/onboarding/PhotoUploadForm.tsx
+++ b/components/onboarding/PhotoUploadForm.tsx
@@ -31,8 +31,17 @@ export default function PhotoUploadForm({ data, onChange, onNext, onBack, isSubm
       return null
     }
 
+    // profile-images / portfolio-photos RLS require the first path segment to be
+    // the uploader's auth uid — otherwise every INSERT is rejected (which is what
+    // silently pushed onboarding uploads onto dead blob: URLs before).
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      setError('Your session expired. Please sign in again to upload photos.')
+      return null
+    }
+
     const ext = file.name.split('.').pop()
-    const fileName = `${folder}/${Date.now()}_${Math.random().toString(36).slice(2)}.${ext}`
+    const fileName = `${user.id}/${folder}/${Date.now()}_${Math.random().toString(36).slice(2)}.${ext}`
 
     const { error: uploadError } = await supabase.storage
       .from(bucket)


### PR DESCRIPTION
Follow-up to #99 — the deeper root cause of the `blob:` data loss. **PR only, not merged.** No DB, no Stripe.

### Root cause
The onboarding uploads were **rejected by storage RLS on every attempt**, and the old code silently fell back to a `blob:` URL (#99 stopped the silent part). Storage policies require the first path segment to be the owner id:
- `profile-images` / `portfolio-photos` INSERT → `foldername(name)[1] = auth.uid()`
- `cleaner-documents` INSERT → `foldername(name)[1] = pros.id` (for this user)

But onboarding uploaded to `onboarding/…` and `documents/…` (no owner prefix) → RLS blocked → blob fallback. (The dashboard logo upload works precisely because it already uses `${user.id}/…`.)

### Fix (app-only; RLS is already correct and stays untouched)
- `PhotoUploadForm` → `${auth.uid}/${folder}/…`
- `DocumentUploadForm` → resolves the pro id and uploads to `${pro.id}/…`
- Both show a specific error if the session or pro profile can't be resolved.

With #99 + this, onboarding uploads land in storage with **real URLs**, and real failures are **visible**.

### ⚠️ Existing damage (reported separately — do not auto-fix)
3 pros already have `blob:` URLs from the old bug (2 are real pending-approval pros). Those files were never uploaded to storage and are **unrecoverable** from the DB — the pros must re-upload. Awaiting Daniel's decision.

### Verify
- Typecheck clean for both files.
- Live: as a pro, upload a document + photo in onboarding → lands in the `cleaner-documents`/`profile-images`/`portfolio-photos` bucket with a real path; forced failure shows a visible error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)