### PR TITLE
fix(ux): surface load-path failures instead of blank forms (DLD-583)

### DIFF
--- a/app/dashboard/customer/profile/page.tsx
+++ b/app/dashboard/customer/profile/page.tsx
@@ -61,7 +61,8 @@ export default function CustomerProfilePage() {
         });
       }
     } catch {
-      // silently fail for client component
+      // Don't fail silently — tell the user the profile didn't load (DLD-583).
+      setMessage('We couldn\'t load your profile. Please refresh the page and try again.');
     } finally {
       setLoading(false);
     }

--- a/app/dashboard/customer/reviews/new/page.tsx
+++ b/app/dashboard/customer/reviews/new/page.tsx
@@ -67,7 +67,8 @@ export default function NewReviewPage() {
 
       setBookings(unreviewedBookings as CompletedBooking[]);
     } catch (err) {
-      console.error('Error loading bookings:', err);
+      // Don't fail silently — tell the user the list didn't load (DLD-583).
+      setError('We couldn\'t load your completed bookings. Please refresh the page and try again.');
     } finally {
       setLoadingBookings(false);
     }

--- a/app/dashboard/pro/documents/page.tsx
+++ b/app/dashboard/pro/documents/page.tsx
@@ -61,7 +61,12 @@ export default function ProDocumentsPage() {
       if (res.ok) {
         const data = await res.json();
         setDocuments(data);
+      } else {
+        // Don't leave the list silently empty on failure (DLD-583).
+        setToast({ type: 'error', message: 'We couldn\'t load your documents. Please refresh the page.' });
       }
+    } catch {
+      setToast({ type: 'error', message: 'We couldn\'t load your documents. Please check your connection and refresh.' });
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
**DLD-583.** **PR only, not merged.** No DB, no Stripe.

Three loaders failed silently, leaving a blank form/list with no message:

| Path | file | Fix |
|---|---|---|
| Customer profile load | `app/dashboard/customer/profile/page.tsx` | empty catch → `setMessage` on failure |
| Pro documents load | `app/dashboard/pro/documents/page.tsx` | `if (res.ok)` w/ no else → `setToast('error')` on non-ok or network error |
| Customer reviews/new load | `app/dashboard/customer/reviews/new/page.tsx` | `console.error` only → `setError` shown inline |

### Flagged, intentionally NOT built (product decision)
`app/settings/page.tsx` `handleDeleteAccount` only **signs the user out** — the "Delete Account" button is misleading. Deciding what account deletion should actually do (soft-delete? purge? retention?) is yours; I did not build it.

### Verify
- Typecheck: my changed lines are clean (2 pre-existing implicit-any warnings remain on untouched `.map`/`.filter` lines in reviews/new — repo baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)