### PR TITLE
perf: remove root force-dynamic, fix underlying prerender crash

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
 
-// Force dynamic rendering for all pages — avoids experimental server actions
-// runtime null-React crash during SSG with Next.js 13.5 + experimental.serverActions.
-export const dynamic = 'force-dynamic';
 import { DM_Sans, Playfair_Display } from 'next/font/google';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';

--- a/lib/services/public-categories.ts
+++ b/lib/services/public-categories.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { createPublicClient } from '@/lib/supabase/public';
 
 /**
  * Public-facing service categories for homepage taxonomy (hero dropdown +
@@ -19,7 +19,7 @@ export interface PublicCategory {
 
 export async function getPublicCategories(): Promise<PublicCategory[]> {
   try {
-    const supabase = await createClient();
+    const supabase = createPublicClient();
     const { data, error } = await supabase
       .from('service_categories')
       .select('slug, display_name, description, supports_residential, alias_for, priority_order')

--- a/lib/supabase/public.ts
+++ b/lib/supabase/public.ts
@@ -1,0 +1,19 @@
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Cookie-free Supabase client for public, unauthenticated reads.
+ *
+ * Uses the anon key and reads no cookies/headers, so it does NOT opt the
+ * calling route into dynamic rendering. This lets pages that only read public
+ * data (e.g. the homepage taxonomy) stay statically/ISR cached. RLS still
+ * applies — only rows exposed by public "anyone reads" policies are returned.
+ */
+export function createPublicClient() {
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: { persistSession: false, autoRefreshToken: false },
+    }
+  )
+}


### PR DESCRIPTION
## Problem

`app/layout.tsx` exported `export const dynamic = 'force-dynamic'`, forcing **every** route — including the homepage — to render uncached per-request and re-run a Supabase query on each hit. This overrode `app/page.tsx`'s `export const revalidate = 3600`.

Result: server-response-time ~2,690 ms (the dominant cost), Lighthouse mobile Performance swinging **48 ↔ 91** on cold/warm serverless TTFB. TBT was only ~90 ms (JS is fine), CLS 0.002 — so this was a pure server-render/TTFB regression.

## The real crash `force-dynamic` was masking

`force-dynamic` was added in commit `e0f08b3` to work around a build-time prerender crash: **Next.js 13.5.1's `experimental.serverActions` runtime failed to initialize the React module during SSG, causing `t.useContext` to throw inside Next's internal ErrorBoundary on every page.**

Crucially, that **same commit also bumped Next.js `13.5.1 → 13.5.11`**, which fixed the underlying runtime. The `force-dynamic` was belt-and-suspenders that was never removed.

**Verified by reproduction:** removing `force-dynamic` and running `npm run build` no longer crashes — all 91 pages generate cleanly, **zero** "Error occurred prerendering page" lines. The app genuinely uses server actions (7 `'use server'` files), so `experimental.serverActions` stays on; it is no longer the problem on 13.5.11.

## Why the homepage still wasn't cacheable after just deleting the flag

Removing `force-dynamic` alone left `/` classified as `λ` (dynamic). Root cause: `getPublicCategories()` used the cookie-bound server client (`lib/supabase/server.ts` calls `cookies()`), and reading `cookies()` **opts the route into dynamic rendering**, silently voiding `revalidate = 3600`. The Footer (rendered in the root layout) calls the same helper, so this also de-dynamized layout-level rendering.

The homepage taxonomy is **public** data read under the anon RLS "anyone reads active rows" policy — it never needed a request-scoped cookie client.

## What changed

- **`app/layout.tsx`** — removed `export const dynamic = 'force-dynamic'` (and its stale comment). Never belongs on the root layout.
- **`lib/supabase/public.ts`** (new) — cookie-free anon Supabase client for public reads; reads no cookies/headers so it does not force dynamic rendering. RLS still applies.
- **`lib/services/public-categories.ts`** — use `createPublicClient()` instead of the cookie-bound server client.

Homepage now honors `revalidate = 3600` → prerendered static HTML, revalidated hourly (ISR).

## Build route-table: `/` before → after

```
BEFORE:  ┌ λ /   19 kB   132 kB      (force-dynamic — SSR every request)
AFTER:   ┌ ○ /   19 kB   132 kB      (Static/ISR, revalidate=3600)
```

Bonus: `about`, `terms`, `privacy`, `services`, `str-turnover`, and others also flipped `λ → ○` now that they no longer inherit the blanket `force-dynamic`.

## Build verification

- `npm run build` → **exit 0**, "✓ Generating static pages (91/91)".
- Grep for `Error occurred prerendering` → **0 matches** (important: `next.config.js` sets `typescript.ignoreBuildErrors` + `eslint.ignoreDuringBuilds`, so the log was inspected directly, not just the exit code).
- `/[city]` and `/services/[serviceType]` retain their own page-scoped `force-dynamic` (they read cookies) — unchanged and correct.

## Follow-up

Re-run Lighthouse on the deploy-preview (env is fully configured) — target mobile Performance **>90**, now that `/` is served as cached static HTML instead of a cold per-request SSR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdbyDufwshZ5uK3ydLy4Z