### PR TITLE
fix(email): service-type-aware copy + brand palette + neutral language

### DIFF
--- a/lib/email/booking-confirmation.ts
+++ b/lib/email/booking-confirmation.ts
@@ -33,11 +33,11 @@ export interface BookingConfirmationData {
 /**
  * Generate customer confirmation email HTML
  */
-function generateCustomerConfirmationHtml(data: BookingConfirmationData): string {
+export function generateCustomerConfirmationHtml(data: BookingConfirmationData): string {
   const content = `
     <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">Booking Confirmed!</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
-      Hi ${data.customerName}, your cleaning has been scheduled with <strong>${data.businessName}</strong>.
+      Hi ${data.customerName}, your ${data.serviceType?.replace(/_/g, ' ') || 'service'} has been scheduled with <strong>${data.businessName}</strong>.
     </p>
 
     ${generateInfoBox([
@@ -69,7 +69,7 @@ function generateCustomerConfirmationHtml(data: BookingConfirmationData): string
 /**
  * Generate cleaner notification email HTML
  */
-function generateCleanerNotificationHtml(data: BookingConfirmationData): string {
+export function generateCleanerNotificationHtml(data: BookingConfirmationData): string {
   const content = `
     <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">New Booking!</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">

--- a/lib/email/dispute-notification.ts
+++ b/lib/email/dispute-notification.ts
@@ -50,12 +50,12 @@ function generateAdminAlertHtml(data: DisputeAdminAlertData): string {
   const content = `
     <h2 style="color: #dc2626; font-size: 24px; margin: 0 0 8px 0;">Stripe Dispute Alert</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
-      A payment dispute has been filed against a cleaner on the platform.
+      A payment dispute has been filed against a pro on the platform.
     </p>
 
     ${generateInfoBox([
       { label: 'Dispute ID', value: data.disputeId },
-      { label: 'Cleaner', value: `${data.cleanerName} (${data.cleanerEmail})` },
+      { label: 'Pro', value: `${data.cleanerName} (${data.cleanerEmail})` },
       { label: 'Amount', value: `$${amountFormatted} ${data.currency.toUpperCase()}` },
       { label: 'Reason', value: data.reason },
       { label: 'Charge ID', value: data.chargeId },

--- a/lib/email/new-message.ts
+++ b/lib/email/new-message.ts
@@ -32,7 +32,7 @@ export function generateNewMessageHtml(
       <strong>${data.senderName}</strong>.
     </p>
 
-    <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #2563eb;">
+    <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #FF5F1F;">
       <p style="color: #374151; font-size: 14px; margin: 0; font-style: italic;">
         "${data.messagePreview}${data.messagePreview.length >= 100 ? '...' : ''}"
       </p>

--- a/lib/email/notifications.ts
+++ b/lib/email/notifications.ts
@@ -39,15 +39,16 @@ export interface QuoteConfirmationEmailData {
 /**
  * Generate new lead email HTML
  */
-function generateNewLeadEmailHtml(data: NewLeadEmailData): string {
+export function generateNewLeadEmailHtml(data: NewLeadEmailData): string {
+  const service = data.serviceType?.replace(/_/g, ' ') || 'service';
   const content = `
     <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">New Lead Alert!</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
-      Hi ${data.businessName}, a customer in your area is looking for cleaning services!
+      Hi ${data.businessName}, a customer in your area is looking for ${service} services!
     </p>
 
     ${generateInfoBox([
-      { label: 'Service Type', value: data.serviceType.replace(/_/g, ' ') },
+      { label: 'Service Type', value: service },
       { label: 'Location', value: data.zipCode },
       { label: 'Preferred Date', value: data.preferredDate || 'Flexible' },
     ])}
@@ -56,7 +57,7 @@ function generateNewLeadEmailHtml(data: NewLeadEmailData): string {
 
     <div style="background: #fef3c7; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #f59e0b;">
       <p style="margin: 0; color: #92400e; font-size: 14px;">
-        <strong>Act fast!</strong> This lead will be available to other cleaners in your area. Respond quickly for the best chance at winning the job.
+        <strong>Act fast!</strong> This lead will be available to other pros in your area. Respond quickly for the best chance at winning the job.
       </p>
     </div>
   `;
@@ -67,11 +68,11 @@ function generateNewLeadEmailHtml(data: NewLeadEmailData): string {
 /**
  * Generate quote response email HTML
  */
-function generateQuoteResponseEmailHtml(data: QuoteResponseEmailData): string {
+export function generateQuoteResponseEmailHtml(data: QuoteResponseEmailData): string {
   const content = `
     <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">You've Received a Quote!</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
-      Hi ${data.customerName}, <strong>${data.businessName}</strong> has responded to your cleaning request.
+      Hi ${data.customerName}, <strong>${data.businessName}</strong> has responded to your quote request.
     </p>
 
     ${generateInfoBox([
@@ -80,7 +81,7 @@ function generateQuoteResponseEmailHtml(data: QuoteResponseEmailData): string {
     ])}
 
     ${data.message ? `
-      <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #2563eb;">
+      <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #FF5F1F;">
         <p style="margin: 0; font-weight: 600; color: #374151;">Message from ${data.businessName}:</p>
         <p style="margin: 8px 0 0 0; color: #4b5563; font-style: italic;">"${data.message}"</p>
       </div>
@@ -89,7 +90,7 @@ function generateQuoteResponseEmailHtml(data: QuoteResponseEmailData): string {
     ${generateButton('View Quote & Book', `${BASE_URL}/dashboard/customer`)}
 
     <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">
-      Compare quotes from multiple cleaners to find the best fit for your needs.
+      Compare quotes from multiple pros to find the best fit for your needs.
     </p>
   `;
 
@@ -99,24 +100,24 @@ function generateQuoteResponseEmailHtml(data: QuoteResponseEmailData): string {
 /**
  * Generate quote confirmation email HTML
  */
-function generateQuoteConfirmationEmailHtml(data: QuoteConfirmationEmailData): string {
+export function generateQuoteConfirmationEmailHtml(data: QuoteConfirmationEmailData): string {
   const content = `
     <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">Quote Request Submitted!</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
-      Hi ${data.customerName}, your cleaning quote request has been sent to <strong>${data.matchCount}</strong> qualified cleaners in your area.
+      Hi ${data.customerName}, your quote request has been sent to <strong>${data.matchCount}</strong> pros in your area.
     </p>
 
     <div style="background: #ecfdf5; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #10b981;">
       <p style="margin: 0; color: #065f46; font-size: 14px;">
         <strong>What happens next?</strong><br>
-        Cleaners will review your request and send you personalized quotes. You'll receive an email each time a cleaner responds.
+        Pros will review your request and send you personalized quotes. You'll receive an email each time a pro responds.
       </p>
     </div>
 
     ${generateButton('Check Quote Status', `${BASE_URL}/dashboard/customer`)}
 
     <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">
-      Most cleaners respond within 24 hours. You can view and compare all quotes from your dashboard.
+      Most pros respond within 24 hours. You can view and compare all quotes from your dashboard.
     </p>
   `;
 
@@ -142,7 +143,7 @@ export interface QuoteAcceptedCustomerEmailData {
  * Neutral-marketplace copy: BOC facilitates the introduction; the lead fee
  * unlocks contact info. No guarantees about the job.
  */
-function generateQuoteAcceptedProEmailHtml(data: QuoteAcceptedProEmailData): string {
+export function generateQuoteAcceptedProEmailHtml(data: QuoteAcceptedProEmailData): string {
   const content = `
     <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">Your quote was accepted!</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
@@ -173,7 +174,7 @@ function generateQuoteAcceptedProEmailHtml(data: QuoteAcceptedProEmailData): str
  * Neutral-marketplace copy: explains what happens next without any guarantee or
  * vetting claim.
  */
-function generateQuoteAcceptedCustomerEmailHtml(data: QuoteAcceptedCustomerEmailData): string {
+export function generateQuoteAcceptedCustomerEmailHtml(data: QuoteAcceptedCustomerEmailData): string {
   const content = `
     <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">You accepted a quote</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
@@ -181,8 +182,8 @@ function generateQuoteAcceptedCustomerEmailHtml(data: QuoteAcceptedCustomerEmail
       <strong>$${data.quoteAmount}</strong>.
     </p>
 
-    <div style="background: #eff6ff; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #2563eb;">
-      <p style="margin: 0; color: #1e40af; font-size: 14px;">
+    <div style="background: #FFF3EC; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #FF5F1F;">
+      <p style="margin: 0; color: #9A3A12; font-size: 14px;">
         <strong>What happens next?</strong><br>
         ${data.businessName} will receive your contact information and reach out to
         arrange the details directly with you. You and the pro agree on scheduling,
@@ -193,9 +194,8 @@ function generateQuoteAcceptedCustomerEmailHtml(data: QuoteAcceptedCustomerEmail
     ${generateButton('View in Your Dashboard', `${BASE_URL}/dashboard/customer`)}
 
     <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">
-      Boss of Clean connects you with independent professionals and does not vet, verify,
-      or guarantee any pro. Please confirm licensing and insurance directly with the pro
-      before work begins.
+      Boss of Clean is a marketplace that connects you with independent professionals.
+      Please confirm licensing and insurance directly with the pro before work begins.
     </p>
   `;
 
@@ -214,7 +214,7 @@ export async function sendNewLeadEmail(data: NewLeadEmailData): Promise<boolean>
 
   const result = await sendResendEmail({
     to: data.to,
-    subject: `New cleaning lead in ${data.zipCode}!`,
+    subject: `New ${data.serviceType?.replace(/_/g, ' ') || 'service'} lead in ${data.zipCode}!`,
     html: generateNewLeadEmailHtml(data),
   });
 
@@ -252,7 +252,7 @@ export async function sendQuoteConfirmationEmail(data: QuoteConfirmationEmailDat
 
   const result = await sendResendEmail({
     to: data.to,
-    subject: 'Your cleaning quote request has been submitted!',
+    subject: 'Your quote request has been submitted!',
     html: generateQuoteConfirmationEmailHtml(data),
   });
 

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -105,13 +105,14 @@ export function wrapEmailTemplate(content: string, options?: { includeUnsubscrib
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Boss of Clean</title>
+      <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     </head>
-    <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; margin: 0; padding: 0; background-color: #f3f4f6;">
+    <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; margin: 0; padding: 0; background-color: #FAF8F5;">
       <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
         <!-- Header -->
-        <div style="background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%); color: white; padding: 24px; border-radius: 12px 12px 0 0; text-align: center;">
-          <h1 style="margin: 0; font-size: 28px; font-weight: bold;">Boss of Clean</h1>
-          <p style="margin: 8px 0 0 0; opacity: 0.9; font-size: 14px;">Purrfection is our Standard</p>
+        <div style="background: linear-gradient(135deg, #0C1220 0%, #1A2332 100%); color: #FAF8F5; padding: 24px; border-radius: 12px 12px 0 0; text-align: center;">
+          <h1 style="margin: 0; font-size: 30px; font-weight: 700; font-family: 'Playfair Display', Georgia, 'Times New Roman', serif; color: #FAF8F5;">Boss of <span style="color: #FF5F1F;">Clean</span></h1>
+          <p style="margin: 8px 0 0 0; font-size: 14px; color: #C8A35F;">Purrfection is our Standard</p>
         </div>
 
         <!-- Content -->
@@ -138,7 +139,7 @@ export function wrapEmailTemplate(content: string, options?: { includeUnsubscrib
  */
 export function generateButton(text: string, url: string, color: 'primary' | 'success' | 'warning' = 'primary'): string {
   const colors = {
-    primary: '#2563eb',
+    primary: '#FF5F1F',
     success: '#16a34a',
     warning: '#ea580c',
   };
@@ -177,7 +178,7 @@ export function generateInfoBox(items: { label: string; value: string }[]): stri
     .join('');
 
   return `
-    <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #2563eb;">
+    <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 20px 0; border-left: 4px solid #FF5F1F;">
       ${rows}
     </div>
   `;

--- a/lib/email/review-request.ts
+++ b/lib/email/review-request.ts
@@ -28,14 +28,14 @@ export function generateReviewRequestHtml(
   reviewUrl: string
 ): string {
   const content = `
-    <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">How was your cleaning?</h2>
+    <h2 style="color: #111827; font-size: 24px; margin: 0 0 8px 0;">How was your service?</h2>
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
       Hi ${data.customerName}, your <strong>${data.serviceType.replace(/_/g, ' ')}</strong> with
       <strong>${data.businessName}</strong> on ${data.bookingDate} is complete.
     </p>
 
     <p style="color: #6b7280; font-size: 16px; margin-bottom: 24px;">
-      Your feedback helps other customers find great cleaners and helps
+      Your feedback helps other customers find great pros and helps
       ${data.businessName} improve their service.
     </p>
 
@@ -73,7 +73,7 @@ export async function sendReviewRequestEmail(
 
   const result = await sendResendEmail({
     to: data.customerEmail,
-    subject: `How was your cleaning with ${data.businessName}?`,
+    subject: `How was your service with ${data.businessName}?`,
     html: generateReviewRequestHtml(data, reviewUrl),
   });
 


### PR DESCRIPTION
## Summary
Audit + fix of every email template in `lib/email/`. Fixes the live bug where a **pressure washing** lead email was titled "New cleaning lead…" and said "looking for cleaning services" — cleaning-only language was hardcoded where the actual service type belongs.

`serviceType` was already passed to `sendNewLeadEmail`; the template simply ignored it. Now threaded into the subject and body (humanized `pressure_washing`→"pressure washing"), with a neutral `"service"` fallback where a type is genuinely unavailable.

## Audit table
| Template | Issues found | Fixed |
|---|---|---|
| New lead (`notifications.ts`) | Subject `New cleaning lead in {zip}!`; body `looking for cleaning services`; `other cleaners in your area`; blue accents | Subject/body use dynamic `{serviceType}` (→ "New pressure washing lead in 32801!"); `other pros`; orange accents |
| Quote response (customer) | `your cleaning request`; `multiple cleaners`; `#2563EB` accent | `your quote request`; `multiple pros`; orange accent |
| Quote confirmation (customer) | `cleaning quote request`; `qualified cleaners`; "Cleaners will review… a cleaner responds"; "Most cleaners respond" | neutral `quote request`; `pros`; "Pros will review… a pro responds"; "Most pros respond" |
| Quote accepted (pro) | (copy already neutral) | palette inherits new navy/orange wrapper |
| Quote accepted (customer) | `does not vet, verify, or guarantee`; blue info box | rephrased neutrally (marketplace connects you; confirm licensing/insurance directly); orange info box |
| New message (`new-message.ts`) | `#2563EB` accent | orange accent |
| Review request (`review-request.ts`) | `How was your cleaning?`; `find great cleaners`; subject `How was your cleaning with…` | `How was your service?`; `find great pros`; `How was your service with…` |
| Booking confirmation (`booking-confirmation.ts`) | `your cleaning has been scheduled` | `your {serviceType} has been scheduled` (neutral fallback) |
| Dispute (admin alert) | `against a cleaner`; label `Cleaner` | `against a pro`; label `Pro` |
| Shared wrapper (`resend.ts`) | Blue/purple header gradient `#1e40af/#3b82f6`; button `#2563EB`; info-box `#2563EB` | Navy gradient `#0C1220→#1A2332`, cream wordmark w/ Boss Orange accent + Playfair Display (Georgia fallback), gold tagline; buttons + info-box → Boss Orange `#FF5F1F`; page bg cream `#FAF8F5` |

## Intentional exclusions (reported, not changed)
- `document-rejection.ts` `background_check: 'Background Check'` and `certification: 'Certification'` — these are **document-type labels** (mirror a DB CHECK enum + API allowlist + admin page) naming which document the pro uploaded was rejected. Not marketing trust claims; renaming would mislabel the rejected document and break enum sync.
- `verification.ts` / `password-reset.ts` — no in-repo HTML; welcome/verification and password-reset emails are sent by Supabase Auth. Nothing to restyle here.
- In-app `notifications` table inserts (`app/api/quotes/[id]/accept`, `app/quote-request/actions.ts`, `app/api/messages/route.ts`, etc.) already use dynamic/neutral copy — no changes needed.

## Proof
Rendered each template with realistic sample data (pressure-washing new-lead) and screenshotted via the repo's Playwright. New-lead now renders subject **"New pressure washing lead in 32801!"** and body **"looking for pressure washing services!"**.

## Build
`npm run build` passes. Branding-leak grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdbyDufwshZ5uK3ydLy4Z