### PR TITLE
fix(pwa): iOS banner shows Share→Add-to-Home-Screen steps, no phantom install button

### DIFF
--- a/components/pwa/InstallPrompt.tsx
+++ b/components/pwa/InstallPrompt.tsx
@@ -37,14 +37,17 @@ function isStandalone(): boolean {
   return Boolean(displayStandalone || iosStandalone);
 }
 
-function isIosSafari(): boolean {
+function isIos(): boolean {
   if (typeof navigator === 'undefined') return false;
   const ua = navigator.userAgent;
-  const isIos = /iphone|ipad|ipod/i.test(ua) ||
-    // iPadOS 13+ reports as Mac; detect via touch
-    (/Macintosh/i.test(ua) && typeof document !== 'undefined' && 'ontouchend' in document);
-  const isSafari = /safari/i.test(ua) && !/crios|fxios|edgios|chrome|android/i.test(ua);
-  return isIos && isSafari;
+  // No browser on iOS (Safari, Chrome/CriOS, Firefox/FxiOS, Edge) supports
+  // beforeinstallprompt — they all run WebKit. So treat ALL iOS as the
+  // manual "Add to Home Screen" case, regardless of which browser.
+  return (
+    /iphone|ipad|ipod/i.test(ua) ||
+    // iPadOS 13+ reports as "MacIntel"; distinguish from a real Mac via touch.
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  );
 }
 
 export default function InstallPrompt() {
@@ -67,14 +70,16 @@ export default function InstallPrompt() {
       setDeferredPrompt(null);
     };
 
-    window.addEventListener('beforeinstallprompt', onBeforeInstall);
-    window.addEventListener('appinstalled', onInstalled);
-
-    // iOS Safari has no beforeinstallprompt — show manual instructions.
-    if (isIosSafari()) {
+    // iOS never fires beforeinstallprompt (any browser) — show manual steps
+    // and DON'T register the prompt listener (the Install button must never
+    // appear on iOS). Non-iOS: listen for the real event to drive the button.
+    if (isIos()) {
       setShowIosBanner(true);
       setVisible(true);
+    } else {
+      window.addEventListener('beforeinstallprompt', onBeforeInstall);
     }
+    window.addEventListener('appinstalled', onInstalled);
 
     return () => {
       window.removeEventListener('beforeinstallprompt', onBeforeInstall);
@@ -121,7 +126,7 @@ export default function InstallPrompt() {
         )}
       </div>
 
-      {!showIosBanner && (
+      {!showIosBanner && deferredPrompt && (
         <button
           type="button"
           onClick={install}


### PR DESCRIPTION
## Bug
On iOS, the PWA install banner rendered a heading plus a non-functional **Install App** button. Two root causes:

1. **Button gated on the wrong condition.** The "Install App" button's visibility was tied to `!showIosBanner` rather than to a captured `beforeinstallprompt` event. Since iOS never fires `beforeinstallprompt` (all iOS browsers run WebKit), the button appeared but had no deferred prompt to call — a dead button.
2. **iOS detection too strict.** Detection required a Safari UA and used `ontouchend`, which missed iPadOS 13+ (reports as `MacIntel`) and non-Safari iOS WebKit browsers (Chrome/CriOS, Firefox/FxiOS, Edge).

## Fix
- iOS detection now uses `/iphone|ipad|ipod/i.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)`, covering iPadOS-13-as-Mac and all iOS WebKit browsers.
- On iOS the banner shows ONLY the manual text — "Install Boss of Clean: tap the Share button ⎋, then 'Add to Home Screen'." — with a × dismiss and no install button. The `beforeinstallprompt` listener is not even registered on iOS.
- On non-iOS, the **Install App** button renders only when a real `beforeinstallprompt` event was captured (`deferredPrompt` truthy), and clicking it calls `prompt()`.

## Verification
- `npm run build` passes.
- Playwright screenshots at 375px:
  - iOS (WebKit / iPhone 13): banner shows the Share → Add to Home Screen steps, no Install App button.
  - Android (Chromium / Pixel 5, synthetic `beforeinstallprompt`): Install App button renders and is wired to `prompt()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdbyDufwshZ5uK3ydLy4Z
