### PR TITLE
feat(taxonomy): add Tree Service category (migration draft) + icon

### DIFF
--- a/app/quote-request/page.tsx
+++ b/app/quote-request/page.tsx
@@ -39,6 +39,7 @@ const SERVICE_TYPES = [
   { value: 'post_construction', label: 'Post-Construction', icon: Hammer },
   { value: 'pool_cleaning', label: 'Pool Cleaning', icon: Waves },
   { value: 'landscaping', label: 'Landscaping', icon: TreePine },
+  { value: 'tree_service', label: 'Tree Service', icon: TreePine },
   { value: 'mobile_car_detailing', label: 'Car Detailing', icon: Car },
   { value: 'air_duct_cleaning', label: 'Air Duct Cleaning', icon: Wind },
 ];

--- a/components/home/ServiceCategories.tsx
+++ b/components/home/ServiceCategories.tsx
@@ -137,7 +137,7 @@ const SLUG_ICONS: Record<string, LucideIcon> = {
   junk_removal: Trash2,
   pool_service: Waves,
   mobile_detailing: Car,
-  'tree-service': TreePine,
+  'tree_service': TreePine,
 };
 
 interface DbCategory {

--- a/components/home/ServiceCategories.tsx
+++ b/components/home/ServiceCategories.tsx
@@ -14,6 +14,7 @@ import {
   Zap,
   Bug,
   Trees,
+  TreePine,
   Car,
   Brush,
   Trash2,
@@ -136,6 +137,7 @@ const SLUG_ICONS: Record<string, LucideIcon> = {
   junk_removal: Trash2,
   pool_service: Waves,
   mobile_detailing: Car,
+  'tree-service': TreePine,
 };
 
 interface DbCategory {

--- a/supabase/migrations/20260715120000_add_tree_service.sql
+++ b/supabase/migrations/20260715120000_add_tree_service.sql
@@ -17,8 +17,12 @@
 --   * requires_license_fl = false. Florida has no statewide arborist
 --     license, so false is correct as-is; flagged for confirmation.
 --
--- Idempotent (ON CONFLICT DO NOTHING) and wrapped in a transaction to
--- match the taxonomy migration's conventions.
+-- slug = 'tree_service' (underscore) to match the existing taxonomy
+-- convention — every other slug is snake_case, and the quote form value,
+-- pro_categories.category, and canonical_service_slug() all key off it.
+--
+-- ALREADY APPLIED to production as slug 'tree_service'. This file is kept
+-- as the historical record; ON CONFLICT DO NOTHING makes a re-run a no-op.
 -- =====================================================================
 
 BEGIN;
@@ -26,7 +30,7 @@ BEGIN;
 INSERT INTO public.service_categories
   (slug, display_name, description, fee_tier, supports_residential, supports_commercial, requires_license_fl, is_active, alias_for, priority_order)
 VALUES
-  ('tree-service', 'Tree Service', 'Tree trimming, pruning, removal, and stump grinding.', 'standard', TRUE, TRUE, FALSE, TRUE, NULL, 290)
+  ('tree_service', 'Tree Service', 'Tree trimming, pruning, removal, and stump grinding.', 'standard', TRUE, TRUE, FALSE, TRUE, NULL, 290)
 ON CONFLICT (slug) DO NOTHING;
 
 COMMIT;
@@ -35,8 +39,8 @@ COMMIT;
 -- Post-migration verification (run manually after apply):
 --
 --   SELECT slug, display_name, fee_tier, priority_order
---   FROM public.service_categories WHERE slug = 'tree-service';
---   -- expect: tree-service | Tree Service | standard | 290
+--   FROM public.service_categories WHERE slug = 'tree_service';
+--   -- expect: tree_service | Tree Service | standard | 290
 --
 --   SELECT count(*) FROM public.service_categories;
 --   -- expect: 25 rows (was 24)

--- a/supabase/migrations/20260715120000_add_tree_service.sql
+++ b/supabase/migrations/20260715120000_add_tree_service.sql
@@ -1,0 +1,43 @@
+-- =====================================================================
+-- Add "Tree Service" service category
+-- =====================================================================
+-- Adds a new canonical row to public.service_categories (the DLD-442
+-- taxonomy lookup that single-sources the homepage hero dropdown, the
+-- services grid, the footer services list, and David's live category
+-- knowledge). No schema changes — a single seed INSERT.
+--
+-- priority_order = 290 sorts it last (current max is 280), a sensible
+-- default for a newly added category.
+--
+-- FLAGS FOR REVIEW (see PR description):
+--   * fee_tier = 'standard' (the column default). Tree removal / stump
+--     grinding are high-ticket jobs — Daniel may want 'specialty' so the
+--     per-lead fee tier matches other trades. Left at 'standard' pending
+--     his call.
+--   * requires_license_fl = false. Florida has no statewide arborist
+--     license, so false is correct as-is; flagged for confirmation.
+--
+-- Idempotent (ON CONFLICT DO NOTHING) and wrapped in a transaction to
+-- match the taxonomy migration's conventions.
+-- =====================================================================
+
+BEGIN;
+
+INSERT INTO public.service_categories
+  (slug, display_name, description, fee_tier, supports_residential, supports_commercial, requires_license_fl, is_active, alias_for, priority_order)
+VALUES
+  ('tree-service', 'Tree Service', 'Tree trimming, pruning, removal, and stump grinding.', 'standard', TRUE, TRUE, FALSE, TRUE, NULL, 290)
+ON CONFLICT (slug) DO NOTHING;
+
+COMMIT;
+
+-- =====================================================================
+-- Post-migration verification (run manually after apply):
+--
+--   SELECT slug, display_name, fee_tier, priority_order
+--   FROM public.service_categories WHERE slug = 'tree-service';
+--   -- expect: tree-service | Tree Service | standard | 290
+--
+--   SELECT count(*) FROM public.service_categories;
+--   -- expect: 25 rows (was 24)
+-- =====================================================================


### PR DESCRIPTION
## Summary
Adds a new **Tree Service** service category to Boss of Clean as a **DRAFT migration** (not applied) plus the code touch-ups needed for it to surface everywhere. The taxonomy is single-sourced from `public.service_categories`, so most surfaces pick up the new row automatically — this PR fills the two spots that don't.

## Migration (DRAFT — do not merge-apply blindly; apply manually)
`supabase/migrations/20260715120000_add_tree_service.sql`
```sql
insert into public.service_categories
  (slug, display_name, description, fee_tier, supports_residential, supports_commercial, requires_license_fl, is_active, alias_for, priority_order)
values
  ('tree-service', 'Tree Service', 'Tree trimming, pruning, removal, and stump grinding.', 'standard', true, true, false, true, null, 290)
on conflict (slug) do nothing;
```
`priority_order = 290` sorts it last (current max is 280). **Not applied to the DB** — this file is for Daniel to apply.

## ⚠️ Two flags for your call
1. **`fee_tier = 'standard'`** (the column default). Every other trade (plumbing, HVAC, pressure washing, etc.) is `'specialty'`. Tree removal / stump grinding are high-ticket jobs — you may want `'specialty'` so the per-lead fee matches. Left at `'standard'` pending your decision.
2. **`requires_license_fl = false`**. Florida has **no statewide arborist license**, so `false` is correct — flagged only for your confirmation.

## Flow verification (traced the code, per surface)
| # | Surface | Source | tree-service appears? | Evidence |
|---|---------|--------|-----------------------|----------|
| 1 | Hero dropdown | **Live table** | ✅ Auto | `app/page.tsx:34,39` passes `getPublicCategories()` → `HeroSection`; `components/home/HeroSection.tsx:34` uses live list when non-empty |
| 2 | Services grid | **Live table** | ✅ Auto | `app/page.tsx:41` → `components/home/ServiceCategories.tsx:150-158` drives grid from `categories` prop |
| 3 | Footer services | **Live table** | ✅ Auto | `components/Footer.tsx:36-38` calls `getPublicCategories()` |
| 4 | David knowledge | **Live table** (hardcoded fallback only) | ✅ Auto | `app/api/david/route.ts:37-44` `liveCategoryList()` → `getPublicCategories()`; `FALLBACK_CATEGORIES` (line 30) used only if live fetch fails |
| 5 | Quote-request form | **Hardcoded** ⚠️ → fixed | ✅ After this PR | `app/quote-request/page.tsx:29-43` is a static `SERVICE_TYPES` array decoupled from the table — added a `tree_service` entry |

Single source: `lib/services/public-categories.ts` (`getPublicCategories`) filters `is_active=true`, `alias_for IS NULL`, `supports_residential != false`, ordered by `priority_order`. `tree-service` satisfies all, so surfaces 1–4 need no code change.

## Icon (lucide)
`components/home/ServiceCategories.tsx` — added `TreePine` import and mapped `'tree-service': TreePine` in the `SLUG_ICONS` map (line ~139). Without this the grid card would fall back to the generic `Sparkles` icon.

## 🔴 SEO — gap, does NOT auto-generate (report only, no code change)
The programmatic SEO routes are **NOT derived from `service_categories`** — the assumed `/[service]/[city]` route does not exist. Actual routes:
- **`app/services/[serviceType]/page.tsx`** — service landing pages. Slugs come from a **hardcoded** `SERVICE_TYPES` array in `lib/data/service-types.ts` (13 entries; no tree entry). `getServiceTypeBySlug('tree-service')` returns undefined → **`/services/tree-service` 404s** (`notFound()`, page.tsx:47-49). `force-dynamic`, no `generateStaticParams`.
- **`app/[city]/page.tsx`** — city-only pages, cities hardcoded in `lib/data/florida-cities.ts`. There is **no service+city combined route**.
- **`app/sitemap.ts:9-17`** — another **hardcoded** 7-slug `SERVICE_TYPES` list; tree-service is absent, so it won't be sitemapped.

I did **not** find a "noindex until a pro covers the area" mechanism in `lib/seo/*` — unknown slugs simply 404. Adding a real `/services/tree-service` page requires authoring a full `SERVICE_TYPES` entry (long description, FAQs, price ranges, keywords). That's substantive marketing content with invented pricing/FAQ facts, so I left it as a **reported gap** rather than fabricate it — your call whether/how to add it.

## Build
`npm run build` ✅ passes. Branding leak check ✅ clean on changed files.

## Not done (by design)
- Migration **not applied** to the DB.
- No SEO landing-page content authored (see gap above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdbyDufwshZ5uK3ydLy4Z