### PR TITLE
feat(pwa): dedicated /install page with browser+OS-aware steps

### DIFF
--- a/app/install/page.tsx
+++ b/app/install/page.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { generatePageMetadata } from '@/lib/seo/metadata';
+import InstallGuide from '@/components/pwa/InstallGuide';
+
+export const metadata = generatePageMetadata({
+  title: 'Install the App',
+  description:
+    'Add Boss of Clean to your phone home screen. Step-by-step install help for iPhone (Safari) and Android (Chrome), tailored to your browser.',
+  path: '/install',
+  keywords: ['install app', 'add to home screen', 'Boss of Clean app', 'PWA install'],
+});
+
+export default function InstallPage() {
+  return (
+    <div className="min-h-screen bg-brand-warm">
+      {/* Hero */}
+      <section className="relative overflow-hidden bg-brand-dark">
+        <div className="absolute inset-0 bg-gradient-to-br from-brand-dark via-brand-navy to-brand-dark" />
+        <div className="absolute top-1/4 right-1/4 w-96 h-96 bg-brand-gold/5 rounded-full blur-3xl" />
+        <div className="relative max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 pb-12 text-center">
+          <p className="inline-block text-brand-gold text-sm font-semibold tracking-[0.2em] uppercase mb-5 border border-brand-gold/30 rounded-full px-5 py-1.5">
+            Get the App
+          </p>
+          <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-[1.1] mb-4">
+            Install <span className="text-brand-gold">Boss of Clean</span>
+          </h1>
+          <p className="text-gray-300 text-base sm:text-lg">
+            One tap from your home screen. We&rsquo;ll show you the exact steps for your phone.
+          </p>
+        </div>
+      </section>
+
+      {/* Guide — detection runs client-side */}
+      <section className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-14">
+        <InstallGuide />
+
+        <p className="mt-8 text-center text-sm text-gray-500">
+          Installing adds a home-screen icon and full-screen app — no App Store, no download size.
+        </p>
+
+        <div className="mt-8 text-center">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-brand-dark font-semibold hover:text-brand-gold transition-colors"
+          >
+            Back to Boss of Clean
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -22,6 +22,7 @@ const quickLinks = [
   { label: 'Home', href: '/' },
   { label: 'Search', href: '/search' },
   { label: 'How It Works', href: '/how-it-works' },
+  { label: 'Install App', href: '/install' },
   { label: 'Pricing', href: '/pricing' },
   { label: 'About', href: '/about' },
   { label: 'Contact', href: '/contact' },

--- a/components/pwa/InstallGuide.tsx
+++ b/components/pwa/InstallGuide.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  EllipsisVertical,
+  SquarePlus,
+  Download,
+  Smartphone,
+  MonitorSmartphone,
+  Compass,
+  CircleAlert,
+  Check,
+  Link2,
+} from 'lucide-react';
+import {
+  detectPlatform,
+  getDeferredPrompt,
+  subscribeInstall,
+  triggerInstall,
+  type Platform,
+} from '@/lib/pwa/install';
+
+const SITE_URL = 'bossofclean.com';
+
+// Accurate iOS "Share" glyph (up arrow rising out of an open box).
+function IosShareIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12 15V3" />
+      <path d="m8 7 4-4 4 4" />
+      <path d="M8 11H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-2" />
+    </svg>
+  );
+}
+
+type StepIcon = React.ComponentType<{ className?: string }>;
+interface Step {
+  icon: StepIcon;
+  body: React.ReactNode;
+}
+
+function StepList({ steps }: { steps: Step[] }) {
+  return (
+    <ol className="space-y-4">
+      {steps.map((s, i) => (
+        <li key={i} className="flex items-start gap-4">
+          <span className="shrink-0 flex items-center justify-center w-10 h-10 rounded-xl bg-brand-gold/10 text-brand-gold">
+            <s.icon className="w-5 h-5" />
+          </span>
+          <div className="flex-1 pt-1.5 text-brand-dark leading-relaxed">
+            <span className="mr-2 inline-flex items-center justify-center w-5 h-5 rounded-full bg-brand-dark text-white text-xs font-bold align-middle">
+              {i + 1}
+            </span>
+            {s.body}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function CopyLinkButton() {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(`https://${SITE_URL}/install`);
+          setCopied(true);
+        } catch {
+          /* clipboard blocked — the URL is shown on screen anyway */
+        }
+      }}
+      className="inline-flex items-center gap-2 rounded-xl border border-brand-gold/40 px-4 py-2.5 text-sm font-semibold text-brand-dark hover:bg-brand-gold/10 transition-colors"
+    >
+      <Link2 className="w-4 h-4" />
+      {copied ? 'Link copied!' : `Copy ${SITE_URL}/install`}
+    </button>
+  );
+}
+
+function Card({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-2xl p-6 sm:p-8 shadow-sm">
+      <h2 className="font-display text-xl sm:text-2xl font-bold text-brand-dark mb-1">{title}</h2>
+      {subtitle && <p className="text-gray-500 text-sm mb-6">{subtitle}</p>}
+      {!subtitle && <div className="mb-6" />}
+      {children}
+    </div>
+  );
+}
+
+const inAppName: Record<'facebook' | 'instagram' | 'other', string> = {
+  facebook: 'Facebook',
+  instagram: 'Instagram',
+  other: 'in-app',
+};
+
+export default function InstallGuide() {
+  const [platform, setPlatform] = useState<Platform | null>(null);
+  const [canPrompt, setCanPrompt] = useState(false);
+  const [installOutcome, setInstallOutcome] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPlatform(detectPlatform());
+    const sync = () => setCanPrompt(getDeferredPrompt() !== null);
+    sync();
+    return subscribeInstall(sync);
+  }, []);
+
+  // Pre-hydration / detecting
+  if (!platform) {
+    return (
+      <div className="bg-white border border-gray-200 rounded-2xl p-8 text-center text-gray-400">
+        Detecting your device…
+      </div>
+    );
+  }
+
+  const install = async () => {
+    const outcome = await triggerInstall();
+    if (outcome === 'accepted') setInstallOutcome('Installing — check your home screen!');
+    else if (outcome === 'dismissed') setInstallOutcome('No problem — you can install any time.');
+  };
+
+  const RealInstallButton = (
+    <button
+      type="button"
+      onClick={install}
+      className="inline-flex items-center gap-2 bg-brand-gold text-white px-6 py-3.5 rounded-xl font-semibold hover:bg-brand-gold-light transition-colors shadow-lg"
+    >
+      <Download className="w-5 h-5" />
+      Install Boss of Clean
+    </button>
+  );
+
+  // 1. Already installed
+  if (platform.isStandalone) {
+    return (
+      <Card title="You're all set" subtitle="Boss of Clean is already installed on this device.">
+        <div className="flex items-center gap-3 text-brand-dark">
+          <span className="flex items-center justify-center w-10 h-10 rounded-xl bg-green-100 text-green-700">
+            <Check className="w-5 h-5" />
+          </span>
+          <p>Open it any time from your home screen.</p>
+        </div>
+      </Card>
+    );
+  }
+
+  // 2. In-app webview (Instagram / Facebook / etc.)
+  if (platform.inApp) {
+    const realBrowser = platform.os === 'ios' ? 'Safari' : 'Chrome';
+    return (
+      <Card
+        title={`Open in ${realBrowser} first`}
+        subtitle={`You're viewing this inside the ${inAppName[platform.inApp]} browser, which can't install apps.`}
+      >
+        <StepList
+          steps={[
+            {
+              icon: EllipsisVertical,
+              body: (
+                <>
+                  Tap the <strong>⋯ menu</strong> in the corner of the {inAppName[platform.inApp]} browser.
+                </>
+              ),
+            },
+            {
+              icon: Compass,
+              body: (
+                <>
+                  Choose <strong>Open in {realBrowser}</strong> (or &ldquo;Open in browser&rdquo;).
+                </>
+              ),
+            },
+            {
+              icon: Download,
+              body: (
+                <>
+                  On this page in {realBrowser}, follow the install steps that appear.
+                </>
+              ),
+            },
+          ]}
+        />
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <CopyLinkButton />
+          <span className="text-sm text-gray-400">so you can paste it into {realBrowser}</span>
+        </div>
+      </Card>
+    );
+  }
+
+  // 3. iOS Safari
+  if (platform.os === 'ios' && platform.browser === 'safari') {
+    return (
+      <Card title="Add to your iPhone home screen" subtitle="Safari · iOS">
+        <StepList
+          steps={[
+            {
+              icon: IosShareIcon,
+              body: (
+                <>
+                  Tap the <strong>Share</strong> button at the bottom of Safari.
+                </>
+              ),
+            },
+            {
+              icon: SquarePlus,
+              body: (
+                <>
+                  Scroll down and tap <strong>Add to Home Screen</strong>.
+                </>
+              ),
+            },
+            {
+              icon: Check,
+              body: (
+                <>
+                  Tap <strong>Add</strong> — the Boss of Clean cat lands on your home screen.
+                </>
+              ),
+            },
+          ]}
+        />
+      </Card>
+    );
+  }
+
+  // 4. iOS Firefox — genuinely no Add to Home Screen
+  if (platform.os === 'ios' && platform.browser === 'firefox') {
+    return (
+      <Card
+        title="Open in Safari to install"
+        subtitle="Firefox on iPhone can't add apps to the home screen."
+      >
+        <StepList
+          steps={[
+            {
+              icon: Compass,
+              body: (
+                <>
+                  Open <strong>{SITE_URL}</strong> in <strong>Safari</strong>.
+                </>
+              ),
+            },
+            {
+              icon: IosShareIcon,
+              body: (
+                <>
+                  Tap the <strong>Share</strong> button at the bottom.
+                </>
+              ),
+            },
+            {
+              icon: SquarePlus,
+              body: (
+                <>
+                  Tap <strong>Add to Home Screen</strong>, then <strong>Add</strong>.
+                </>
+              ),
+            },
+          ]}
+        />
+        <div className="mt-6">
+          <CopyLinkButton />
+        </div>
+      </Card>
+    );
+  }
+
+  // 5. iOS Chrome / Edge / Opera — WebKit, Share lives elsewhere
+  if (platform.os === 'ios') {
+    const label = platform.browser.charAt(0).toUpperCase() + platform.browser.slice(1);
+    return (
+      <Card title="Add to your iPhone home screen" subtitle={`${label} · iOS`}>
+        <StepList
+          steps={[
+            {
+              icon: IosShareIcon,
+              body: (
+                <>
+                  Tap the <strong>Share</strong> button — in {label} it&rsquo;s in the address bar or
+                  the <strong>⋯</strong> menu (top or bottom right).
+                </>
+              ),
+            },
+            {
+              icon: SquarePlus,
+              body: (
+                <>
+                  Choose <strong>Add to Home Screen</strong>.
+                </>
+              ),
+            },
+            {
+              icon: Check,
+              body: (
+                <>
+                  Tap <strong>Add</strong>.
+                </>
+              ),
+            },
+          ]}
+        />
+        <div className="mt-6 flex items-start gap-3 rounded-xl bg-brand-cream border border-brand-gold/20 p-4">
+          <CircleAlert className="w-5 h-5 text-brand-gold shrink-0 mt-0.5" />
+          <p className="text-sm text-brand-dark">
+            Don&rsquo;t see <strong>Add to Home Screen</strong>? Open{' '}
+            <strong>{SITE_URL}</strong> in <strong>Safari</strong> — it always works there.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  // 6. Android (Chrome / Samsung / Edge / Firefox / other)
+  if (platform.os === 'android') {
+    const chromium = platform.browser === 'chrome' || platform.browser === 'samsung' || platform.browser === 'edge';
+    const label =
+      platform.browser === 'other'
+        ? 'your browser'
+        : platform.browser.charAt(0).toUpperCase() + platform.browser.slice(1);
+    return (
+      <Card title="Install on your Android phone" subtitle={`${label} · Android`}>
+        {chromium && canPrompt && (
+          <div className="mb-6">
+            {RealInstallButton}
+            {installOutcome && <p className="mt-3 text-sm text-gray-500">{installOutcome}</p>}
+            <p className="mt-3 text-sm text-gray-400">Or install it manually:</p>
+          </div>
+        )}
+        <StepList
+          steps={[
+            {
+              icon: EllipsisVertical,
+              body: (
+                <>
+                  Tap the <strong>⋮ menu</strong> in the top-right of {label}.
+                </>
+              ),
+            },
+            {
+              icon: Download,
+              body: (
+                <>
+                  Tap <strong>Install app</strong> {chromium ? '(or ' : '(shown as '}
+                  <strong>Add to Home screen</strong>).
+                </>
+              ),
+            },
+            {
+              icon: Check,
+              body: (
+                <>
+                  Confirm <strong>Install</strong> — done.
+                </>
+              ),
+            },
+          ]}
+        />
+      </Card>
+    );
+  }
+
+  // 7. Desktop
+  return (
+    <Card title="Install is built for phones" subtitle="Desktop">
+      <div className="flex items-start gap-3 mb-6">
+        <span className="flex items-center justify-center w-10 h-10 rounded-xl bg-brand-gold/10 text-brand-gold shrink-0">
+          <Smartphone className="w-5 h-5" />
+        </span>
+        <p className="text-brand-dark leading-relaxed">
+          Open <strong>{SITE_URL}</strong> on your phone&rsquo;s browser to add Boss of Clean to your
+          home screen. On iPhone use Safari&rsquo;s Share → Add to Home Screen; on Android tap the
+          ⋮ menu → Install app.
+        </p>
+      </div>
+      {canPrompt && (
+        <div className="border-t border-gray-100 pt-6">
+          <p className="text-sm text-gray-400 mb-3 flex items-center gap-2">
+            <MonitorSmartphone className="w-4 h-4" /> You can also install it on this computer:
+          </p>
+          {RealInstallButton}
+          {installOutcome && <p className="mt-3 text-sm text-gray-500">{installOutcome}</p>}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/components/pwa/InstallPrompt.tsx
+++ b/components/pwa/InstallPrompt.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { detectPlatform, getDeferredPrompt, subscribeInstall } from '@/lib/pwa/install';
 
 // z-index stack (documented so future widgets stay clear):
 //   - David chat launcher/panel: z-50, fixed bottom-right
@@ -8,14 +10,13 @@ import { useEffect, useState } from 'react';
 //   - InstallPrompt (this):      z-[60], fixed TOP banner
 // A top banner never shares vertical space with the two bottom-fixed
 // widgets, so both remain fully tappable.
+//
+// The banner is now a thin entry point: it links to /install, where the
+// browser/OS-specific steps live (iOS forbids programmatic install in every
+// browser, so cramming steps into a banner never worked well).
 
 const DISMISS_KEY = 'boc_pwa_install_dismissed';
 const DISMISS_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-
-type BeforeInstallPromptEvent = Event & {
-  prompt: () => Promise<void>;
-  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
-};
 
 function recentlyDismissed(): boolean {
   try {
@@ -29,62 +30,24 @@ function recentlyDismissed(): boolean {
   }
 }
 
-function isStandalone(): boolean {
-  if (typeof window === 'undefined') return false;
-  const displayStandalone = window.matchMedia?.('(display-mode: standalone)').matches;
-  // iOS Safari exposes navigator.standalone
-  const iosStandalone = (window.navigator as unknown as { standalone?: boolean }).standalone === true;
-  return Boolean(displayStandalone || iosStandalone);
-}
-
-function isIos(): boolean {
-  if (typeof navigator === 'undefined') return false;
-  const ua = navigator.userAgent;
-  // No browser on iOS (Safari, Chrome/CriOS, Firefox/FxiOS, Edge) supports
-  // beforeinstallprompt — they all run WebKit. So treat ALL iOS as the
-  // manual "Add to Home Screen" case, regardless of which browser.
-  return (
-    /iphone|ipad|ipod/i.test(ua) ||
-    // iPadOS 13+ reports as "MacIntel"; distinguish from a real Mac via touch.
-    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
-  );
-}
-
 export default function InstallPrompt() {
-  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
-  const [showIosBanner, setShowIosBanner] = useState(false);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    if (isStandalone() || recentlyDismissed()) return;
-
-    const onBeforeInstall = (e: Event) => {
-      e.preventDefault();
-      setDeferredPrompt(e as BeforeInstallPromptEvent);
-      setVisible(true);
+    const evaluate = () => {
+      const p = detectPlatform();
+      if (p.isStandalone || recentlyDismissed()) {
+        setVisible(false);
+        return;
+      }
+      // Install matters on phones; on desktop only show if a real prompt exists.
+      const isPhone = p.os === 'ios' || p.os === 'android';
+      setVisible(isPhone || getDeferredPrompt() !== null);
     };
 
-    const onInstalled = () => {
-      setVisible(false);
-      setShowIosBanner(false);
-      setDeferredPrompt(null);
-    };
-
-    // iOS never fires beforeinstallprompt (any browser) — show manual steps
-    // and DON'T register the prompt listener (the Install button must never
-    // appear on iOS). Non-iOS: listen for the real event to drive the button.
-    if (isIos()) {
-      setShowIosBanner(true);
-      setVisible(true);
-    } else {
-      window.addEventListener('beforeinstallprompt', onBeforeInstall);
-    }
-    window.addEventListener('appinstalled', onInstalled);
-
-    return () => {
-      window.removeEventListener('beforeinstallprompt', onBeforeInstall);
-      window.removeEventListener('appinstalled', onInstalled);
-    };
+    evaluate();
+    // A late-firing beforeinstallprompt can bring a desktop user into scope.
+    return subscribeInstall(evaluate);
   }, []);
 
   const dismiss = () => {
@@ -93,14 +56,6 @@ export default function InstallPrompt() {
     } catch {
       /* ignore */
     }
-    setVisible(false);
-  };
-
-  const install = async () => {
-    if (!deferredPrompt) return;
-    await deferredPrompt.prompt();
-    await deferredPrompt.userChoice;
-    setDeferredPrompt(null);
     setVisible(false);
   };
 
@@ -114,27 +69,16 @@ export default function InstallPrompt() {
       style={{ paddingTop: 'calc(0.625rem + env(safe-area-inset-top))' }}
     >
       <span className="text-2xl leading-none" aria-hidden="true">🐱</span>
-      <div className="flex-1 min-w-0 text-sm">
-        {showIosBanner ? (
-          <p className="leading-snug">
-            <span className="font-semibold">Install Boss of Clean:</span>{' '}
-            tap the Share button{' '}
-            <span aria-hidden="true">⎋</span>, then &lsquo;Add to Home Screen&rsquo;.
-          </p>
-        ) : (
-          <p className="font-semibold leading-snug">Install the Boss of Clean app</p>
-        )}
-      </div>
+      <p className="flex-1 min-w-0 text-sm font-semibold leading-snug">
+        <span aria-hidden="true">📱</span> Install our app
+      </p>
 
-      {!showIosBanner && deferredPrompt && (
-        <button
-          type="button"
-          onClick={install}
-          className="shrink-0 bg-white text-[#2563EB] font-semibold text-sm px-4 py-2 min-h-[40px] rounded-lg hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-white"
-        >
-          Install App
-        </button>
-      )}
+      <Link
+        href="/install"
+        className="shrink-0 bg-white text-[#2563EB] font-semibold text-sm px-4 py-2 min-h-[40px] flex items-center rounded-lg hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-white"
+      >
+        How?
+      </Link>
 
       <button
         type="button"

--- a/lib/pwa/install.ts
+++ b/lib/pwa/install.ts
@@ -1,0 +1,131 @@
+'use client';
+
+// PWA install helpers — platform detection + a shared beforeinstallprompt
+// store. iOS forbids programmatic install in EVERY browser (Safari, Chrome,
+// Firefox, Edge on iOS are all WebKit — manual Share → Add to Home Screen is
+// the only path). Only Chromium browsers (Android Chrome/Samsung/Edge, and
+// desktop Chrome/Edge) fire `beforeinstallprompt` for a real install button.
+
+export type OS = 'ios' | 'android' | 'desktop';
+export type Browser = 'safari' | 'chrome' | 'firefox' | 'edge' | 'samsung' | 'opera' | 'other';
+export type InApp = 'facebook' | 'instagram' | 'other' | null;
+
+export interface Platform {
+  os: OS;
+  browser: Browser;
+  /** Non-null when we're inside an in-app webview with no install path. */
+  inApp: InApp;
+  isStandalone: boolean;
+}
+
+export function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  const displayStandalone = window.matchMedia?.('(display-mode: standalone)').matches;
+  // iOS Safari exposes navigator.standalone
+  const iosStandalone = (window.navigator as unknown as { standalone?: boolean }).standalone === true;
+  return Boolean(displayStandalone || iosStandalone);
+}
+
+export function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') {
+    return { os: 'desktop', browser: 'other', inApp: null, isStandalone: false };
+  }
+  const ua = navigator.userAgent || '';
+
+  const isIos =
+    /iphone|ipad|ipod/i.test(ua) ||
+    // iPadOS 13+ reports as "MacIntel"; a real Mac has no touch points.
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+  const isAndroid = /android/i.test(ua);
+  const os: OS = isIos ? 'ios' : isAndroid ? 'android' : 'desktop';
+
+  // In-app webviews (Instagram/Facebook/etc.) can't add to the home screen —
+  // detect the common ones so we can route the user to a real browser.
+  let inApp: InApp = null;
+  if (/FBAN|FBAV|FB_IAB|FBIOS/i.test(ua)) inApp = 'facebook';
+  else if (/Instagram/i.test(ua)) inApp = 'instagram';
+  else if (/Line\/|Twitter|TikTok|Snapchat|Pinterest|LinkedInApp|WhatsApp/i.test(ua)) inApp = 'other';
+  // Generic Android WebView marker used by many in-app browsers.
+  else if (isAndroid && /;\s*wv\)/i.test(ua)) inApp = 'other';
+
+  let browser: Browser;
+  if (isIos) {
+    // Every iOS browser is WebKit; the token just tells us where the Share
+    // button lives. Order matters (CriOS/FxiOS/EdgiOS all also contain Safari).
+    if (/CriOS/i.test(ua)) browser = 'chrome';
+    else if (/FxiOS/i.test(ua)) browser = 'firefox';
+    else if (/EdgiOS/i.test(ua)) browser = 'edge';
+    else if (/OPiOS|OPT\//i.test(ua)) browser = 'opera';
+    else browser = 'safari';
+  } else if (isAndroid) {
+    if (/SamsungBrowser/i.test(ua)) browser = 'samsung';
+    else if (/EdgA/i.test(ua)) browser = 'edge';
+    else if (/Firefox/i.test(ua)) browser = 'firefox';
+    else if (/OPR|Opera/i.test(ua)) browser = 'opera';
+    else if (/Chrome/i.test(ua)) browser = 'chrome';
+    else browser = 'other';
+  } else {
+    if (/Edg\//i.test(ua)) browser = 'edge';
+    else if (/Firefox/i.test(ua)) browser = 'firefox';
+    else if (/OPR/i.test(ua)) browser = 'opera';
+    else if (/Chrome/i.test(ua)) browser = 'chrome';
+    else if (/Safari/i.test(ua)) browser = 'safari';
+    else browser = 'other';
+  }
+
+  return { os, browser, inApp, isStandalone: isStandalone() };
+}
+
+// ---------------------------------------------------------------------------
+// Shared beforeinstallprompt store
+// ---------------------------------------------------------------------------
+// The event fires once per eligible page load. We capture it at module load
+// (imported by the always-mounted banner) and stash it so a later visit to
+// /install can fire the real prompt. The root layout persists across client
+// navigations, so this singleton survives route changes.
+
+export type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+};
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const subscribers = new Set<() => void>();
+
+function emit() {
+  subscribers.forEach((cb) => cb());
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeinstallprompt', (e) => {
+    // Suppress Chrome's mini-infobar; we drive install from our own UI.
+    e.preventDefault();
+    deferredPrompt = e as BeforeInstallPromptEvent;
+    emit();
+  });
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    emit();
+  });
+}
+
+export function getDeferredPrompt(): BeforeInstallPromptEvent | null {
+  return deferredPrompt;
+}
+
+export async function triggerInstall(): Promise<'accepted' | 'dismissed' | 'unavailable'> {
+  if (!deferredPrompt) return 'unavailable';
+  await deferredPrompt.prompt();
+  const { outcome } = await deferredPrompt.userChoice;
+  deferredPrompt = null;
+  emit();
+  return outcome;
+}
+
+/** Subscribe to prompt availability changes. Returns an unsubscribe fn. */
+export function subscribeInstall(cb: () => void): () => void {
+  subscribers.add(cb);
+  return () => {
+    subscribers.delete(cb);
+  };
+}


### PR DESCRIPTION
## What

Rework PWA install UX around the reality that **iOS forbids programmatic install in every browser** (Safari, Chrome, Firefox, Edge on iOS are all WebKit — manual **Share → Add to Home Screen** only), while **Android Chromium** fires a real install button. Instead of cramming steps into the top banner, add a dedicated **`/install`** page that detects the user's OS + browser and shows **only** the relevant steps with simple visuals.

## Changes

- **`lib/pwa/install.ts`** — platform detection + a shared `beforeinstallprompt` store:
  - iOS (incl. **iPadOS-as-Mac** via `MacIntel` + touch points), Android, desktop
  - per-browser Share-button location (Safari vs CriOS/EdgiOS/FxiOS)
  - **in-app webview** detection (Instagram, Facebook, and generic Android `wv`)
  - singleton store so the real Android install button can fire from `/install` (root layout persists across client navigations)
- **`app/install/page.tsx` + `components/pwa/InstallGuide.tsx`** — per-platform guides:
  - **iOS Safari** — accurate Share glyph → Add to Home Screen steps
  - **iOS Chrome/Edge** — Share is in the address bar / ⋯ menu, plus a "don't see it? open in Safari" fallback
  - **iOS Firefox** — open in Safari (genuinely no Add-to-Home-Screen)
  - **Android Chromium** — real **Install** button when `beforeinstallprompt` is available, plus manual ⋮-menu steps
  - **Android Firefox / other** — manual ⋮-menu steps
  - **Desktop** — "install is for phones" (+ optional install on Chromium desktop)
  - **In-app webview** — open in real browser + copy-link
  - **Already installed** — success state
- **`components/pwa/InstallPrompt.tsx`** — banner CTA is now **"📱 Install our app → How?"** linking to `/install` (no more inline steps). Shows on phones, or on desktop only if a real prompt exists. Dismiss (30-day), standalone, and safe-area behavior preserved.
- **`components/Footer.tsx`** — add **Install App** quick link.

## Verification

- `npm run build` ✅ passes (`/install` is a static route, 4.94 kB)
- Branding-leak check ✅ clean
- **Live at 375px** (built app served locally), screenshotted across three UAs — each shows the correct platform's steps:

| UA | Heading | Steps |
|---|---|---|
| iOS Safari | Add to your iPhone home screen · Safari · iOS | Share → scroll → Add to Home Screen |
| iOS Chrome | Chrome · iOS | Share (address bar/⋯) → Add to Home Screen + "open in Safari" fallback |
| Android Chrome | Install on your Android phone · Chrome · Android | ⋮ menu → Install app → Confirm |

**Note:** the real Android install button is gated on `beforeinstallprompt`, which headless Chromium can't synthesize — the manual fallback (verified) always renders, and the real button appears above it on a genuine installable device (PR #105's production deploy already reported PWA installable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)