### PR TITLE
fix(privacy): remove personal cell from all public surfaces → admin@ email

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -107,9 +107,9 @@ export async function POST(request: NextRequest) {
               </div>
               <div style="border-top: 1px solid #e5e7eb; padding-top: 20px; margin-top: 24px;">
                 <p style="color: #4b5563; font-size: 14px; margin: 0 0 4px 0;">
-                  If you need immediate assistance, call us at
+                  If you need anything else, just reply to this email or reach us at
                 </p>
-                <a href="tel:407-461-6039" style="color: #FF5F1F; font-size: 18px; font-weight: 700; text-decoration: none;">407-461-6039</a>
+                <a href="mailto:admin@bossofclean.com" style="color: #FF5F1F; font-size: 18px; font-weight: 700; text-decoration: none;">admin@bossofclean.com</a>
               </div>
             </div>
             <div style="text-align: center; padding: 24px; color: #9ca3af; font-size: 12px;">

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -320,7 +320,7 @@ export async function POST(request: NextRequest) {
 
     // A6 (DLD-514): cumulative rolling-window scrubber. filterPII catches PII in
     // this single message; filterPIIWithWindow also catches a phone/email split
-    // across the sender's recent messages (e.g. "407" / "461" / "6039"). We only
+    // across the sender's recent messages (e.g. "555" / "123" / "4567"). We only
     // pay for the extra read when the conversation is still locked.
     let piiResult: ReturnType<typeof filterPII> = filterPII(content.trim(), isUnlocked)
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Mail, Phone, MapPin, ArrowRight, CheckCircle2, Loader2 } from 'lucide-react';
+import { Mail, MapPin, ArrowRight, CheckCircle2, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import Image from 'next/image';
 
@@ -182,19 +182,6 @@ export default function ContactPage() {
                 Contact Information
               </h2>
               <div className="space-y-5">
-                <a
-                  href="tel:407-461-6039"
-                  className="flex items-center gap-4 text-gray-700 hover:text-brand-gold transition-colors group"
-                >
-                  <div className="w-10 h-10 rounded-full bg-brand-gold/10 flex items-center justify-center flex-shrink-0 group-hover:bg-brand-gold/20 transition-colors">
-                    <Phone className="h-5 w-5 text-brand-gold" />
-                  </div>
-                  <div>
-                    <p className="font-semibold text-brand-dark">Phone</p>
-                    <p className="text-sm">407-461-6039</p>
-                  </div>
-                </a>
-
                 <a
                   href="mailto:admin@bossofclean.com"
                   className="flex items-center gap-4 text-gray-700 hover:text-brand-gold transition-colors group"

--- a/app/dashboard/customer/help/page.tsx
+++ b/app/dashboard/customer/help/page.tsx
@@ -6,7 +6,7 @@ import { ProtectedRoute } from '@/lib/auth/protected-route';
 import { createClient } from '@/lib/supabase/client';
 import {
   HelpCircle, ChevronDown, Mail, MessageSquare, CheckCircle, XCircle,
-  Loader2, Phone, Send, Clock
+  Loader2, Send, Clock
 } from 'lucide-react';
 
 interface ContactSubmission {
@@ -172,11 +172,11 @@ export default function CustomerHelpPage() {
                 <h1 className="text-xl font-semibold text-gray-900">Help & Support</h1>
               </div>
               <a
-                href="tel:407-461-6039"
+                href="mailto:admin@bossofclean.com"
                 className="hidden sm:flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
               >
-                <Phone className="h-4 w-4" />
-                407-461-6039
+                <Mail className="h-4 w-4" />
+                admin@bossofclean.com
               </a>
             </div>
           </div>

--- a/app/qa/quote-demo/page.tsx
+++ b/app/qa/quote-demo/page.tsx
@@ -203,7 +203,7 @@ export default function QuoteDemoPage() {
                   type="tel"
                   value={customerPhone}
                   onChange={(e) => setCustomerPhone(e.target.value)}
-                  placeholder="407-461-6039"
+                  placeholder="555-123-4567"
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 />
               </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { Phone, Mail } from 'lucide-react';
+import { Mail } from 'lucide-react';
 import { getPublicCategories } from '@/lib/services/public-categories';
 
 // Fallback only — the live list comes from service_categories (same helper
@@ -63,14 +63,6 @@ export default async function Footer() {
               Florida&apos;s Pro Service Marketplace — plumbing, handyman, landscaping, cleaning, and more.
             </p>
             <address className="space-y-3 not-italic text-sm">
-              <a
-                href="tel:407-461-6039"
-                className="flex items-center gap-2.5 text-gray-400 hover:text-brand-gold transition-colors"
-                aria-label="Call us at 407-461-6039"
-              >
-                <Phone className="h-4 w-4 text-brand-gold flex-shrink-0" aria-hidden="true" />
-                407-461-6039
-              </a>
               <a
                 href="mailto:admin@bossofclean.com"
                 className="flex items-center gap-2.5 text-gray-400 hover:text-brand-gold transition-colors"

--- a/lib/pii-filter.ts
+++ b/lib/pii-filter.ts
@@ -129,14 +129,14 @@ export async function hashContent(content: string): Promise<string> {
  *
  * filterPII() catches PII inside a SINGLE message. But a determined sender can
  * split a phone number across several messages, each individually under any
- * threshold: "my number" / "is 407" / "461" / "6039". filterPIIWithWindow()
+ * threshold: "my number" / "is 555" / "123" / "4567". filterPIIWithWindow()
  * closes that gap by concatenating the sender's recent messages in this
  * conversation with the new one and re-checking the combined text — including
  * a cumulative digit count that catches an assembled phone number.
  *
- * It also normalizes spelled-out digits ("four zero seven") and strips spacing
- * tricks before counting, so "4 0 7 4 6 1 6 0 3 9" and "four oh seven..." are
- * caught the same as "4074616039".
+ * It also normalizes spelled-out digits ("five five five") and strips spacing
+ * tricks before counting, so "5 5 5 1 2 3 4 5 6 7" and "five five five..." are
+ * caught the same as "5551234567".
  *
  * Returns blocked:false immediately when isUnlocked is true.
  */


### PR DESCRIPTION
## What

Daniel's personal cell (`407-461-6039`) was exposed sitewide. This removes **every** occurrence and routes all contact to the **monitored `admin@bossofclean.com`** inbox.

## Which email — confirmed `admin@`, not `support@`
- The contact form already delivers submissions to `admin@bossofclean.com` (`app/api/contact/route.ts`).
- Every legal page (terms/privacy/refund) already uses `admin@bossofclean.com`.
- `support@bossofclean.com` is **not** a configured recipient anywhere in the codebase.

So `admin@` is the verified, monitored, consistent choice. (Say the word if you want `support@` instead and have confirmed it's monitored.)

## Key finding
The number was **not** hardcoded on the homepage/about/terms/privacy/refund pages — it reached them through the shared **Footer**. Fixing the footer clears it from all of them. The legal pages already carried `admin@` as their contact method, so they keep a contact method with no change.

## Changes (every one)
| File | Change |
|---|---|
| `components/Footer.tsx` | Removed the phone link (global footer); kept existing `admin@` email. Dropped now-unused `Phone` import. |
| `app/contact/page.tsx` | Removed the Phone contact block; kept `admin@` email. Dropped unused `Phone` import. |
| `app/api/contact/route.ts` | Contact **auto-reply email** now points to `admin@` ("reply to this email or reach us at…") instead of "call us at \<cell\>". |
| `app/dashboard/customer/help/page.tsx` | Logged-in help header now links `admin@` email (Phone→Mail icon). |
| `app/qa/quote-demo/page.tsx` | QA form placeholder → neutral `555-123-4567`. |
| `lib/pii-filter.ts` | PII-scrubber doc comment used the real number as its example → neutralized to generic `555…`. **This is a public repo, so the literal in source was itself exposure.** |
| `app/api/messages/route.ts` | Same PII-scrubber comment fragments → generic `555…`. |

## Preserved / untouched
- Contact form + David widget remain the primary contact paths.
- Legal pages keep a contact method (`admin@`, unchanged).
- **Twilio platform number `833-853-4612` untouched** (it's runtime config, not in tracked source).
- No name exposure — `daniel`/`alvarez` appear nowhere in source, and none was added.

## Verification
- `git grep 6039 / 4074616039` → **0 matches** after changes.
- No orphaned `Phone` imports in edited files.
- `npm run build` ✅ passes. Branding-leak check ✅ clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)