### PR TITLE
feat(recruitment): pro 'claim this area' CTA on empty search + zero-coverage city pages

### DIFF
--- a/app/[city]/page.tsx
+++ b/app/[city]/page.tsx
@@ -428,6 +428,28 @@ export default async function CityPage({ params }: CityPageProps) {
           </section>
         )}
 
+        {/* Zero-coverage recruitment CTA — honest empty state for cities with no listed pros yet */}
+        {(!cleaners || cleaners.length === 0) && (
+          <section className="py-16 bg-gray-50">
+            <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+              <h2 className="text-3xl font-bold text-gray-900 mb-4">
+                Are you a pro serving {city.name}?
+              </h2>
+              <p className="text-gray-600 mb-8 max-w-xl mx-auto">
+                Boss of Clean is expanding in {city.name}. Claim your service area and start
+                receiving exclusive leads from local customers — free to join.
+              </p>
+              <Link
+                href="/signup?role=cleaner"
+                className="inline-flex items-center gap-2 bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-blue-700 transition"
+              >
+                Claim {city.name} — free to join
+                <ArrowRight className="h-5 w-5" />
+              </Link>
+            </div>
+          </section>
+        )}
+
         {/* Nearby Cities */}
         {nearbyCities.length > 0 && (
           <section className="py-16 bg-white">

--- a/components/search/EmptySearchState.tsx
+++ b/components/search/EmptySearchState.tsx
@@ -82,16 +82,17 @@ export function EmptySearchState({ searchLocation, searchService }: EmptySearchS
             <Sparkles className="h-5 w-5 text-brand-gold" />
           </div>
           <h3 className="font-display text-lg font-bold text-brand-dark mb-2">
-            Are You a Pro?
+            Are you a pro?
           </h3>
           <p className="text-gray-600 text-sm mb-4">
-            Join Boss of Clean and connect with customers looking for your services.
+            Boss of Clean is expanding {searchLocation ? `in ${searchLocation}` : 'across Florida'}.
+            Claim your service area and start receiving exclusive leads.
           </p>
           <Link
             href="/signup?role=cleaner"
             className="inline-flex items-center gap-2 text-brand-gold font-semibold text-sm hover:gap-3 transition-all duration-200"
           >
-            List Your Business
+            Claim this area — free to join
             <ArrowRight className="h-4 w-4" />
           </Link>
         </div>


### PR DESCRIPTION
Part of the final-polish sprint — **PR 3 of 5** (empty-state recruitment flip).

## What
Turns zero-result dead ends into pro recruitment, without overpromising to customers.

- **Empty search** (`EmptySearchState.tsx`): the pro card is now **"Are you a pro?"** → **"Claim this area — free to join"** (`/signup?role=cleaner`), with the searched location woven into the copy. The warm customer headline and the "Get Notified" card are unchanged.
- **Zero-coverage city pages** (`app/[city]/page.tsx`): when a city has **no listed pros**, an honest **"Are you a pro serving {City}?"** section renders with a **"Claim {City} — free to join"** CTA, in the page's existing style.

## Neutral-marketplace compliance
No vetted/verified/guarantee/endorsement language. Only factual marketplace framing ("exclusive leads", "free to join") already used elsewhere on the site.

## Verification (screenshots in thread)
- `npm run build` ✅
- Live-rendered locally: empty search for "Tree Service in Naples" shows the claim CTA; the Naples city page (0 pros) shows "Are you a pro serving Naples? … Claim Naples — free to join".

## Note
Item #3 mentions "noindex city pages" — the **noindex-for-thin-coverage** logic itself lands in the SEO PR (#4), since no city is noindexed today. This PR adds the recruitment CTA that those pages will carry.

No merge — cold review please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)