### PR TITLE
feat(pro): measured 'Usually responds within X' badge (median first-response, 3+ only)

### DIFF
--- a/app/cleaner/[slug]/page.tsx
+++ b/app/cleaner/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import Image from 'next/image';
 import {
-  Star, MapPin, Clock, Shield, Award,
+  Star, MapPin, Shield, Award,
   BadgeCheck, CheckCircle2, DollarSign, Users, Calendar,
   MessageSquare, ArrowLeft, Camera
 } from 'lucide-react';
@@ -13,6 +13,8 @@ import { PublicGallery, PortfolioPhoto } from '@/components/portfolio/PublicGall
 import type { BusinessHours } from '@/lib/types/database';
 import { getCleanerBadges } from '@/lib/services/badges';
 import { BadgeDisplay, BadgeList } from '@/components/badges/BadgeDisplay';
+import { getResponseTimeStats, MIN_RESPONSE_SAMPLES } from '@/lib/services/response-time';
+import { ResponseTimeBadge } from '@/components/pro/ResponseTimeBadge';
 
 // NOTE: business_phone, business_email, website_url intentionally omitted —
 // PII gated behind lead acceptance / payment (DLD-457, v1.1 PII wall).
@@ -186,6 +188,10 @@ export default async function CleanerProfilePage({ params }: { params: Promise<{
 
   const reviews = await getCleanerReviews(cleaner.id);
   const portfolioPhotos = await getCleanerPortfolio(cleaner.user_id);
+
+  // Measured median first-response time (shown only at MIN_RESPONSE_SAMPLES+).
+  const supabaseForStats = await createClient();
+  const responseStat = (await getResponseTimeStats(supabaseForStats, [cleaner.id])).get(cleaner.id) ?? null;
 
   // Calculate badges based on cleaner metrics
   const earnedBadges = getCleanerBadges({
@@ -524,10 +530,11 @@ export default async function CleanerProfilePage({ params }: { params: Promise<{
                   <Calendar className="h-5 w-5 text-gray-400" />
                   <span className="text-gray-600">{cleaner.total_jobs || 0} jobs completed</span>
                 </div>
-                <div className="flex items-center gap-3">
-                  <Clock className="h-5 w-5 text-gray-400" />
-                  <span className="text-gray-600">Responds in ~{cleaner.response_time_hours || 24} hours</span>
-                </div>
+                {responseStat && responseStat.sampleCount >= MIN_RESPONSE_SAMPLES && (
+                  <div className="flex items-center">
+                    <ResponseTimeBadge stat={responseStat} className="text-gray-600" iconClassName="h-5 w-5 text-gray-400" />
+                  </div>
+                )}
                 {cleaner.instant_booking && (
                   <div className="flex items-center gap-3">
                     <CheckCircle2 className="h-5 w-5 text-green-500" />

--- a/app/professionals/page.tsx
+++ b/app/professionals/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import { createClient } from '@/lib/supabase/server';
+import { getResponseTimeStats } from '@/lib/services/response-time';
+import { ResponseTimeBadge } from '@/components/pro/ResponseTimeBadge';
 import {
   Star,
   MapPin,
@@ -122,6 +124,9 @@ export default async function ProfessionalsPage({
 
   const { data: cleaners } = await query;
   const pros = (cleaners || []) as DirectoryCleaner[];
+
+  // Measured response-time stats for the listed pros (badge shows only at 3+).
+  const responseStats = await getResponseTimeStats(supabase, pros.map((p) => p.id));
 
   // Build sort URL helper
   function sortUrl(sort: string) {
@@ -400,6 +405,13 @@ export default async function ProfessionalsPage({
                           </span>
                         )}
                       </div>
+
+                      {/* Measured response time — renders only at 3+ data points */}
+                      <ResponseTimeBadge
+                        stat={responseStats.get(pro.id)}
+                        className="text-xs text-gray-500 mb-3"
+                        iconClassName="h-3.5 w-3.5 text-gray-400"
+                      />
 
                       {/* Services */}
                       {pro.services && pro.services.length > 0 && (

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -17,6 +17,7 @@ import type {
   DistanceOption,
 } from '@/components/search/SearchFilters';
 import type { ProviderCardProps } from '@/components/search/ProviderCard';
+import { getResponseTimeStats } from '@/lib/services/response-time';
 import { useSearchHistory } from '@/lib/hooks/useSearchHistory';
 import { useServiceCategories } from '@/lib/hooks/useServiceCategories';
 import { haversineDistance, type ZipCoordinates } from '@/lib/utils/distance';
@@ -261,6 +262,13 @@ export default function SearchPage() {
         }
         return props;
       });
+
+      // Attach measured response-time stats (badge shows only at 3+ points).
+      const responseStats = await getResponseTimeStats(supabase, mappedProviders.map((p) => p.id));
+      for (const p of mappedProviders) {
+        const s = responseStats.get(p.id);
+        if (s) p.responseStat = s;
+      }
 
       if (append) {
         setProviders(prev => [...prev, ...mappedProviders]);

--- a/components/pro/ResponseTimeBadge.tsx
+++ b/components/pro/ResponseTimeBadge.tsx
@@ -1,0 +1,22 @@
+import { Clock } from 'lucide-react';
+import { MIN_RESPONSE_SAMPLES, formatResponseWindow, type ResponseStat } from '@/lib/services/response-time';
+
+// "Usually responds within X" — a measured fact, shown ONLY when there are
+// enough real data points. No endorsement, no ranking, no guarantee.
+export function ResponseTimeBadge({
+  stat,
+  className = '',
+  iconClassName = 'h-4 w-4 text-gray-400',
+}: {
+  stat?: ResponseStat | null;
+  className?: string;
+  iconClassName?: string;
+}) {
+  if (!stat || stat.sampleCount < MIN_RESPONSE_SAMPLES) return null;
+  return (
+    <span className={`inline-flex items-center gap-2 ${className}`}>
+      <Clock className={iconClassName} aria-hidden="true" />
+      Usually responds within {formatResponseWindow(stat.medianSeconds)}
+    </span>
+  );
+}

--- a/components/search/ProviderCard.tsx
+++ b/components/search/ProviderCard.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { User, MapPin, ArrowRight } from 'lucide-react';
+import { ResponseTimeBadge } from '@/components/pro/ResponseTimeBadge';
+import type { ResponseStat } from '@/lib/services/response-time';
 
 export interface ProviderCardProps {
   id: string;
@@ -14,6 +16,7 @@ export interface ProviderCardProps {
   city?: string;
   state?: string;
   distance?: number;
+  responseStat?: ResponseStat;
 }
 
 export function ProviderCard({
@@ -26,6 +29,7 @@ export function ProviderCard({
   city,
   state,
   distance,
+  responseStat,
 }: ProviderCardProps) {
   const profileUrl = `/cleaner/${businessSlug || id}`;
 
@@ -70,6 +74,9 @@ export function ProviderCard({
             )}
           </div>
         )}
+
+        {/* Measured response time — renders only at 3+ data points */}
+        <ResponseTimeBadge stat={responseStat} className="text-sm text-gray-500 mb-3" iconClassName="h-3.5 w-3.5 text-gray-400" />
 
         {/* Description */}
         <p className="text-gray-600 text-sm mb-4 line-clamp-2 leading-relaxed">

--- a/lib/services/response-time.ts
+++ b/lib/services/response-time.ts
@@ -1,0 +1,57 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Measured median first-response time per pro (from real message timestamps).
+// Source: the pro_response_time_stats() SECURITY DEFINER function
+// (supabase/migrations/20260717120000_pro_response_time_stats.sql).
+
+/** Minimum data points before we display a response-time badge. */
+export const MIN_RESPONSE_SAMPLES = 3;
+
+export interface ResponseStat {
+  medianSeconds: number;
+  sampleCount: number;
+}
+
+/**
+ * Fetch measured response stats for the given pro ids. Returns an empty map on
+ * any error (RPC not yet applied, network, etc.) so callers degrade to showing
+ * no badge rather than a wrong one.
+ */
+export async function getResponseTimeStats(
+  supabase: SupabaseClient,
+  proIds: string[]
+): Promise<Map<string, ResponseStat>> {
+  const map = new Map<string, ResponseStat>();
+  const ids = proIds.filter(Boolean);
+  if (ids.length === 0) return map;
+
+  const { data, error } = await supabase.rpc('pro_response_time_stats', { p_pro_ids: ids });
+  if (error || !data) return map;
+
+  for (const row of data as Array<{ pro_id: string; median_seconds: number | string; sample_count: number }>) {
+    map.set(row.pro_id, {
+      medianSeconds: Number(row.median_seconds),
+      sampleCount: row.sample_count,
+    });
+  }
+  return map;
+}
+
+/**
+ * Humanize a median response window as an upper-bound-ish phrase for
+ * "Usually responds within X". Rounds to friendly units; never fabricates.
+ */
+export function formatResponseWindow(medianSeconds: number): string {
+  const minutes = medianSeconds / 60;
+  if (minutes < 60) {
+    const rounded = Math.max(15, Math.ceil(minutes / 15) * 15);
+    return rounded === 60 ? 'an hour' : `${rounded} minutes`;
+  }
+  const hours = minutes / 60;
+  if (hours < 24) {
+    const rounded = Math.max(1, Math.ceil(hours));
+    return rounded === 1 ? 'an hour' : `${rounded} hours`;
+  }
+  const days = Math.max(1, Math.ceil(hours / 24));
+  return days === 1 ? 'a day' : `${days} days`;
+}

--- a/supabase/migrations/20260717120000_pro_response_time_stats.sql
+++ b/supabase/migrations/20260717120000_pro_response_time_stats.sql
@@ -1,0 +1,60 @@
+-- =====================================================================
+-- pro_response_time_stats() — measured median first-response time per pro
+-- =====================================================================
+-- Computes, per pro, the MEDIAN time between a customer's first message in
+-- a conversation and that pro's first reply, from real message timestamps.
+--
+-- SECURITY DEFINER is required: messages/conversations RLS restricts row
+-- reads to the two participants (supabase/13-messaging-schema.sql:77-96), so
+-- an aggregate across all pros cannot be computed by an anon/other-user
+-- client. This function returns ONLY the safe aggregate (median seconds +
+-- sample count) — never message content or counterparties.
+--
+-- The UI only renders "Usually responds within X" when sample_count >= 3
+-- (see lib/services/response-time.ts MIN_RESPONSE_SAMPLES), so thin pros
+-- show nothing.
+--
+-- DRAFT — apply by hand (this repo never auto-applies migrations).
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION public.pro_response_time_stats(p_pro_ids uuid[] DEFAULT NULL)
+RETURNS TABLE (pro_id uuid, median_seconds numeric, sample_count integer)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH per_conv AS (
+    SELECT
+      c.cleaner_id AS pro_id,
+      min(m.created_at) FILTER (WHERE m.sender_role = 'customer') AS t0,
+      min(m.created_at) FILTER (WHERE m.sender_role = 'cleaner')  AS t1
+    FROM conversations c
+    JOIN messages m ON m.conversation_id = c.id
+    WHERE p_pro_ids IS NULL OR c.cleaner_id = ANY(p_pro_ids)
+    GROUP BY c.id, c.cleaner_id
+  ),
+  deltas AS (
+    -- Only conversations where the customer messaged first AND the pro later
+    -- replied count as a data point.
+    SELECT pro_id, EXTRACT(EPOCH FROM (t1 - t0)) AS secs
+    FROM per_conv
+    WHERE t0 IS NOT NULL AND t1 IS NOT NULL AND t1 > t0
+  )
+  SELECT
+    pro_id,
+    percentile_cont(0.5) WITHIN GROUP (ORDER BY secs) AS median_seconds,
+    count(*)::int AS sample_count
+  FROM deltas
+  GROUP BY pro_id;
+$$;
+
+-- Aggregate-only, no PII — safe to expose to public marketplace surfaces.
+GRANT EXECUTE ON FUNCTION public.pro_response_time_stats(uuid[]) TO anon, authenticated;
+
+-- =====================================================================
+-- Verify after apply:
+--   SELECT * FROM public.pro_response_time_stats();
+--   -- returns (pro_id, median_seconds, sample_count) for pros with >=1
+--   -- customer-first/pro-reply conversation. UI shows the badge at >=3.
+-- =====================================================================


### PR DESCRIPTION
Part of the final-polish sprint — **PR 2 of 5** (response-time badge).

## What
Each pro's **median** time from a customer's first message to that pro's first reply, computed from **real message timestamps**, shown as **"Usually responds within X"** — and only when there are **≥3 data points**. Pure measured fact: no ranking, endorsement, or guarantee.

## Architecture (why a DB function)
`messages`/`conversations` RLS restricts row reads to the two participants, so an aggregate across all pros **cannot** be computed by an anon/other-user client. A **`SECURITY DEFINER` function** `pro_response_time_stats(p_pro_ids uuid[])` returns **only** the safe aggregate — `(pro_id, median_seconds, sample_count)`, never message content or counterparties.

## ⚠️ Migration is a DRAFT — apply by hand
`supabase/migrations/20260717120000_pro_response_time_stats.sql`. I did **not** apply it. Until it's applied, `getResponseTimeStats()` degrades to an empty map (no badge shown). SQL:

```sql
CREATE OR REPLACE FUNCTION public.pro_response_time_stats(p_pro_ids uuid[] DEFAULT NULL)
RETURNS TABLE (pro_id uuid, median_seconds numeric, sample_count integer)
LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
  WITH per_conv AS (
    SELECT c.cleaner_id AS pro_id,
      min(m.created_at) FILTER (WHERE m.sender_role='customer') AS t0,
      min(m.created_at) FILTER (WHERE m.sender_role='cleaner')  AS t1
    FROM conversations c JOIN messages m ON m.conversation_id=c.id
    WHERE p_pro_ids IS NULL OR c.cleaner_id = ANY(p_pro_ids)
    GROUP BY c.id, c.cleaner_id
  ),
  deltas AS (
    SELECT pro_id, EXTRACT(EPOCH FROM (t1-t0)) AS secs
    FROM per_conv WHERE t0 IS NOT NULL AND t1 IS NOT NULL AND t1>t0
  )
  SELECT pro_id, percentile_cont(0.5) WITHIN GROUP (ORDER BY secs) AS median_seconds,
         count(*)::int AS sample_count
  FROM deltas GROUP BY pro_id;
$$;
GRANT EXECUTE ON FUNCTION public.pro_response_time_stats(uuid[]) TO anon, authenticated;
```

## Surfaces wired
- **Pro profile** (`/cleaner/[slug]`) — replaces the old **invented** "Responds in ~24 hours" default line; now shows nothing unless measured.
- **Professionals directory** cards.
- **Search result** cards (`ProviderCard`).

## Data reality (dormant by design)
Prod has **2 conversations total; 0 pros with 3+ data points**, so the badge displays for **nobody today** — correct per the "measured, 3+ only" rule. It lights up as data grows. Verified the query computes correctly on the real data (two pros at sample_count=1 → correctly hidden).

## Verification
- `npm run build` ✅ (no type errors)
- Rendered the badge with sample data (screenshot in thread): "within 15 minutes / an hour / 2 hours / 24 hours / 2 days"; a 2-point sample correctly renders nothing.

No merge — cold review please. Apply the migration when you're ready for it to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)