### PR TITLE
feat(dashboard): honest quote status tracker (customer)

### DIFF
--- a/app/dashboard/customer/page.tsx
+++ b/app/dashboard/customer/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/context/AuthContext';
 import { ProtectedRoute } from '@/lib/auth/protected-route';
 import { createClient } from '@/lib/supabase/client';
+import { QuoteStatusTracker } from '@/components/quotes/QuoteStatusTracker';
 import {
   Settings, FileText, Clock, CheckCircle,
   XCircle, AlertCircle, Calendar, MapPin, DollarSign,
@@ -436,7 +437,12 @@ export default function CustomerDashboard() {
                                   {quote.status.charAt(0).toUpperCase() + quote.status.slice(1)}
                                 </span>
                               </div>
-                              
+
+                              <QuoteStatusTracker
+                                status={quote.status}
+                                hasResponse={!!(quote.response_message || quote.quoted_price)}
+                              />
+
                               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600">
                                 <div className="space-y-2">
                                   <div className="flex items-center gap-2">

--- a/components/quotes/QuoteStatusTracker.tsx
+++ b/components/quotes/QuoteStatusTracker.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { Check } from 'lucide-react';
+
+// Honest, live quote status — computed only from the request's own real state.
+// No invented "sent to N pros" count (that fan-out data isn't captured today),
+// and no fabricated response-time promise. Shows nothing extra when thin.
+
+export type QuoteStatus = 'pending' | 'responded' | 'accepted' | 'completed' | 'cancelled';
+
+const STEPS = ['Submitted', 'Pro responded', 'Accepted'] as const;
+
+function currentStep(status: QuoteStatus): number {
+  switch (status) {
+    case 'accepted':
+    case 'completed':
+      return 2;
+    case 'responded':
+      return 1;
+    default:
+      return 0; // pending
+  }
+}
+
+const EXPECTATION: Record<Exclude<QuoteStatus, 'cancelled'>, string> = {
+  pending: 'Your request is live with local pros. As they respond, quotes appear here and in your email.',
+  responded: 'A pro sent you a quote below — review it and accept when you’re ready.',
+  accepted: 'You accepted this quote. Arrange the work and payment directly with your pro.',
+  completed: 'This job is marked complete.',
+};
+
+export function QuoteStatusTracker({
+  status,
+  hasResponse,
+}: {
+  status: QuoteStatus;
+  /** True when at least one real pro response exists on this request. */
+  hasResponse: boolean;
+}) {
+  if (status === 'cancelled') return null;
+  const active = currentStep(status);
+
+  return (
+    <div className="mb-4 rounded-lg bg-gray-50 border border-gray-100 p-4">
+      {/* Stepper */}
+      <ol className="flex items-center">
+        {STEPS.map((label, i) => {
+          const done = i < active;
+          const isCurrent = i === active;
+          return (
+            <li key={label} className="flex items-center flex-1 last:flex-none">
+              <div className="flex flex-col items-center text-center">
+                <span
+                  className={`flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold ${
+                    done || isCurrent ? 'bg-brand-gold text-white' : 'bg-gray-200 text-gray-500'
+                  }`}
+                >
+                  {done ? <Check className="w-4 h-4" /> : i + 1}
+                </span>
+                <span
+                  className={`mt-1.5 text-xs whitespace-nowrap ${
+                    done || isCurrent ? 'text-brand-dark font-medium' : 'text-gray-400'
+                  }`}
+                >
+                  {label}
+                </span>
+              </div>
+              {i < STEPS.length - 1 && (
+                <span className={`flex-1 h-0.5 mx-2 -mt-5 ${i < active ? 'bg-brand-gold' : 'bg-gray-200'}`} />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* Factual live line */}
+      <p className="mt-3 text-sm text-gray-600">
+        {hasResponse && status !== 'pending' && (
+          <span className="font-medium text-brand-dark">1 pro responded. </span>
+        )}
+        {EXPECTATION[status]}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Part of the final-polish sprint — **PR 1 of 5** (quote status tracker).

## What
Each quote request on the customer dashboard now shows a live **status stepper** (Submitted → Pro responded → Accepted) and a **factual expectation line**, computed only from the request's own real state.

## Honest by design (data reality)
- **No "sent to N pros" count.** That fan-out data isn't captured today — `notification_logs` and `lead_distributions` are **empty** and the `notifyCleanersInArea` email step is a stub. Per your "no invented numbers; show nothing if data is thin" rule, the count is **omitted**, and it will light up automatically if fan-out logging is ever wired.
- **No fabricated response-time promise.** The pending line is neutral ("As they respond, quotes appear here and in your email") — there's only 1 responded quote in prod, too thin to state a real typical time.
- **"1 pro responded"** shows only when a real response exists on the request (the active path captures a single pro response per request).

## Files
- `components/quotes/QuoteStatusTracker.tsx` (new; renders nothing for `cancelled`)
- `app/dashboard/customer/page.tsx` — tracker added to each quote card

## Verification
- `npm run build` ✅
- Rendered across all statuses (screenshot in thread): pending / responded / accepted / completed — stepper + factual lines correct, no invented counts. (Dashboard is auth-gated, so verified via a throwaway preview harness that was removed before commit.)

No merge — cold review please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)