### PR TITLE
feat(seo): enhance service + city landing pages (meta, FAQ/JSON-LD, noindex, sitemap fix)

### DIFF
--- a/app/[city]/page.tsx
+++ b/app/[city]/page.tsx
@@ -13,6 +13,8 @@ import {
   generateCityMetadata,
   generateCityJsonLd,
   generateBreadcrumbJsonLd,
+  generateCityFaqs,
+  generateCityFaqJsonLd,
   SERVICE_DESCRIPTIONS,
   getRegionDisplayName,
 } from '@/lib/seo/city-pages';
@@ -161,6 +163,8 @@ export default async function CityPage({ params }: CityPageProps) {
     topServices,
   });
   const breadcrumbJsonLd = generateBreadcrumbJsonLd(city);
+  const faqs = generateCityFaqs(city);
+  const faqJsonLd = generateCityFaqJsonLd(city);
 
   return (
     <>
@@ -171,6 +175,10 @@ export default async function CityPage({ params }: CityPageProps) {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c') }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd).replace(/</g, '\\u003c') }}
       />
 
       <div className="min-h-screen bg-gray-50">
@@ -195,20 +203,28 @@ export default async function CityPage({ params }: CityPageProps) {
                 <h1 className="text-4xl lg:text-5xl font-bold mb-6">
                   Professional Cleaning Services in {city.name}, FL
                 </h1>
-                <p className="text-xl text-blue-100 mb-8">{city.description}</p>
+                <p className="text-xl text-blue-100 mb-3">{city.description}</p>
+                <p className="text-blue-100/90 mb-8">
+                  Request quotes free from local pros — no subscription, and a pro pays a flat $30
+                  only when you accept.
+                </p>
 
                 {/* Stats */}
                 <div className="flex flex-wrap gap-6 mb-8">
-                  <div className="flex items-center gap-2">
-                    <Users className="h-6 w-6" />
-                    <span className="text-2xl font-bold">{cleanerCount}+</span>
-                    <span className="text-blue-200">Cleaners</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Star className="h-6 w-6 fill-yellow-400 text-yellow-400" />
-                    <span className="text-2xl font-bold">{avgRating.toFixed(1)}</span>
-                    <span className="text-blue-200">Avg Rating</span>
-                  </div>
+                  {cleanerCount > 0 && (
+                    <>
+                      <div className="flex items-center gap-2">
+                        <Users className="h-6 w-6" />
+                        <span className="text-2xl font-bold">{cleanerCount}</span>
+                        <span className="text-blue-200">Pro{cleanerCount === 1 ? '' : 's'}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Star className="h-6 w-6 fill-yellow-400 text-yellow-400" />
+                        <span className="text-2xl font-bold">{avgRating.toFixed(1)}</span>
+                        <span className="text-blue-200">Avg Rating</span>
+                      </div>
+                    </>
+                  )}
                   <div className="flex items-center gap-2">
                     <MapPin className="h-6 w-6" />
                     <span className="text-blue-200">{city.county} County</span>
@@ -427,6 +443,23 @@ export default async function CityPage({ params }: CityPageProps) {
             </div>
           </section>
         )}
+
+        {/* FAQ — visible content backing the FAQPage JSON-LD */}
+        <section className="py-16 bg-white">
+          <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 className="text-3xl font-bold text-gray-900 mb-8 text-center">
+              Home Services in {city.name} — FAQ
+            </h2>
+            <div className="space-y-6">
+              {faqs.map((faq) => (
+                <div key={faq.question} className="border-b border-gray-100 pb-6 last:border-0">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">{faq.question}</h3>
+                  <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
 
         {/* Nearby Cities */}
         {nearbyCities.length > 0 && (

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,114 +1,47 @@
 import { MetadataRoute } from 'next';
 import { createClient } from '@/lib/supabase/server';
 import { createLogger } from '@/lib/utils/logger';
+import { getAllServiceTypeSlugs } from '@/lib/data/service-types';
+import { getAllCitySlugs } from '@/lib/data/florida-cities';
 
 const logger = createLogger({ file: 'app/sitemap' });
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://bossofclean.com';
 
-// Service types for dynamic pages
-const SERVICE_TYPES = [
-  'residential',
-  // COMMERCIAL_DISABLED: 'commercial',
-  'deep-cleaning',
-  'move-in-out',
-  'pressure-washing',
-  'carpet-cleaning',
-  'window-cleaning',
-  'post-construction',
-];
-
-// Florida counties for landing pages
-const FLORIDA_COUNTIES = [
-  'miami-dade',
-  'broward',
-  'palm-beach',
-  'hillsborough',
-  'orange',
-  'duval',
-  'pinellas',
-  'lee',
-  'polk',
-  'brevard',
-  'volusia',
-  'pasco',
-  'seminole',
-  'sarasota',
-  'manatee',
-  'collier',
-  'marion',
-  'lake',
-  'osceola',
-  'escambia',
-];
-
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const supabase = await createClient();
+  const now = new Date();
 
-  // Static pages with their priorities
+  // Static pages
   const staticPages: MetadataRoute.Sitemap = [
-    {
-      url: BASE_URL,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 1.0,
-    },
-    {
-      url: `${BASE_URL}/search`,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/about`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/contact`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
-    {
-      url: `${BASE_URL}/pricing`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/quote-request`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/professionals`,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.9,
-    },
-  ];
+    { url: BASE_URL, changeFrequency: 'daily' as const, priority: 1.0 },
+    { url: `${BASE_URL}/search`, changeFrequency: 'daily' as const, priority: 0.9 },
+    { url: `${BASE_URL}/professionals`, changeFrequency: 'daily' as const, priority: 0.9 },
+    { url: `${BASE_URL}/pricing`, changeFrequency: 'weekly' as const, priority: 0.8 },
+    { url: `${BASE_URL}/how-pricing-works`, changeFrequency: 'monthly' as const, priority: 0.7 },
+    { url: `${BASE_URL}/how-it-works`, changeFrequency: 'monthly' as const, priority: 0.7 },
+    { url: `${BASE_URL}/quote-request`, changeFrequency: 'monthly' as const, priority: 0.7 },
+    { url: `${BASE_URL}/about`, changeFrequency: 'monthly' as const, priority: 0.6 },
+    { url: `${BASE_URL}/contact`, changeFrequency: 'monthly' as const, priority: 0.5 },
+  ].map((p) => ({ ...p, lastModified: now }));
 
-  // Service type pages
-  const servicePages: MetadataRoute.Sitemap = SERVICE_TYPES.map((service) => ({
-    url: `${BASE_URL}/services/${service}`,
-    lastModified: new Date(),
+  // Service landing pages — real slugs (/services/{slug})
+  const servicePages: MetadataRoute.Sitemap = getAllServiceTypeSlugs().map((slug) => ({
+    url: `${BASE_URL}/services/${slug}`,
+    lastModified: now,
     changeFrequency: 'weekly' as const,
     priority: 0.8,
   }));
 
-  // County landing pages
-  const countyPages: MetadataRoute.Sitemap = FLORIDA_COUNTIES.map((county) => ({
-    url: `${BASE_URL}/cleaners/${county}`,
-    lastModified: new Date(),
+  // City landing pages — root-level (/{slug})
+  const cityPages: MetadataRoute.Sitemap = getAllCitySlugs().map((slug) => ({
+    url: `${BASE_URL}/${slug}`,
+    lastModified: now,
     changeFrequency: 'weekly' as const,
-    priority: 0.8,
+    priority: 0.7,
   }));
 
-  // Dynamic cleaner profile pages
+  // Cleaner profile pages — real route is /cleaner/{business_slug} (singular)
   let cleanerPages: MetadataRoute.Sitemap = [];
-
   try {
     const { data: cleaners } = await supabase
       .from('pros')
@@ -118,8 +51,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     if (cleaners) {
       cleanerPages = cleaners.map((cleaner) => ({
-        url: `${BASE_URL}/cleaners/${cleaner.business_slug}`,
-        lastModified: cleaner.updated_at ? new Date(cleaner.updated_at) : new Date(),
+        url: `${BASE_URL}/cleaner/${cleaner.business_slug}`,
+        lastModified: cleaner.updated_at ? new Date(cleaner.updated_at) : now,
         changeFrequency: 'weekly' as const,
         priority: 0.6,
       }));
@@ -128,41 +61,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     logger.error('Error fetching cleaners for sitemap', { function: 'sitemap' }, error);
   }
 
-  // Dynamic city pages based on service areas
-  let cityPages: MetadataRoute.Sitemap = [];
-
-  try {
-    const { data: cities } = await supabase
-      .from('service_areas')
-      .select('city, county')
-      .not('city', 'is', null);
-
-    if (cities) {
-      // Get unique city slugs
-      const uniqueCities = new Map<string, { city: string; county: string | null }>();
-      cities.forEach((area) => {
-        const slug = area.city.toLowerCase().replace(/\s+/g, '-');
-        if (!uniqueCities.has(slug)) {
-          uniqueCities.set(slug, area);
-        }
-      });
-
-      cityPages = Array.from(uniqueCities.entries()).map(([slug]) => ({
-        url: `${BASE_URL}/cleaners/city/${slug}`,
-        lastModified: new Date(),
-        changeFrequency: 'weekly' as const,
-        priority: 0.7,
-      }));
-    }
-  } catch (error) {
-    logger.error('Error fetching cities for sitemap', { function: 'sitemap' }, error);
-  }
-
-  return [
-    ...staticPages,
-    ...servicePages,
-    ...countyPages,
-    ...cleanerPages,
-    ...cityPages,
-  ];
+  return [...staticPages, ...servicePages, ...cityPages, ...cleanerPages];
 }

--- a/lib/seo/city-pages.ts
+++ b/lib/seo/city-pages.ts
@@ -16,12 +16,15 @@ export interface CityPageData {
 export function generateCityMetadata(data: CityPageData): Metadata {
   const { city, cleanerCount, averageRating } = data;
 
-  const title = `House Cleaning Services in ${city.name}, FL | Boss of Clean`;
-  const description = `Find home service professionals in ${city.name}, Florida. Residential cleaning, deep cleaning, move-in/out cleaning, pressure washing and more. Browse and connect with local pros.`;
+  const title = `Home Services in ${city.name}, FL | Boss of Clean`;
+  const description = `Find home service pros in ${city.name}, Florida — cleaning, handyman, pressure washing, landscaping and more. Free to request quotes. No subscriptions. Pros pay $30 flat only when you accept.`;
 
   return {
     title,
     description,
+    // Thin/zero-coverage cities are kept out of the index until a pro serves
+    // the area (still crawlable so the recruitment CTA can be discovered).
+    robots: cleanerCount === 0 ? { index: false, follow: true } : undefined,
     keywords: [
       `cleaning services ${city.name}`,
       `house cleaning ${city.name} FL`,
@@ -123,6 +126,53 @@ export function generateBreadcrumbJsonLd(city: FloridaCity): object {
         item: `${SITE_URL}/${city.slug}`,
       },
     ],
+  };
+}
+
+export interface CityFaq {
+  question: string;
+  answer: string;
+}
+
+/**
+ * Shared 4-question FAQ template for city pages. Honest, neutral-marketplace:
+ * general cost framing (never a Boss of Clean price promise), the free/$30
+ * model, how it works, and the independent-pro disclaimer.
+ */
+export function generateCityFaqs(city: FloridaCity): CityFaq[] {
+  return [
+    {
+      question: `How much do home services cost in ${city.name}?`,
+      answer: `Prices vary by the job, your property, and the pro you choose. Boss of Clean isn't a service company and doesn't set prices — each pro quotes their own. Requesting quotes is free, so you can compare a few before you decide.`,
+    },
+    {
+      question: `Is Boss of Clean free for customers in ${city.name}?`,
+      answer: `Yes. Requesting quotes is always free and there's no subscription. Pros pay a flat $30 only after you accept their quote.`,
+    },
+    {
+      question: `How does Boss of Clean work in ${city.name}?`,
+      answer: `Tell us what you need, local ${city.name} pros respond with quotes, and you choose who to hire and pay them directly.`,
+    },
+    {
+      question: `Are the pros on Boss of Clean independent?`,
+      answer: `Yes. Boss of Clean is a neutral marketplace of independent home service pros. We don't employ, supervise, or control them — hiring decisions are yours.`,
+    },
+  ];
+}
+
+/**
+ * FAQPage JSON-LD for city pages, built from the shared template.
+ */
+export function generateCityFaqJsonLd(city: FloridaCity): object {
+  const faqs = generateCityFaqs(city);
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((f) => ({
+      '@type': 'Question',
+      name: f.question,
+      acceptedAnswer: { '@type': 'Answer', text: f.answer },
+    })),
   };
 }
 

--- a/lib/seo/service-pages.ts
+++ b/lib/seo/service-pages.ts
@@ -8,7 +8,7 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bossofclean.com';
  */
 export function generateServicePageMetadata(serviceType: ServiceType): Metadata {
   const title = `${serviceType.name} in Florida | Boss of Clean`;
-  const description = `Find professional ${serviceType.name.toLowerCase()} in Florida. ${serviceType.description} Compare home service professionals, read reviews, and get free quotes.`;
+  const description = `Find ${serviceType.name.toLowerCase()} pros in Florida. ${serviceType.description} Free to request quotes. No subscriptions. Pros pay $30 flat only when you accept.`;
 
   return {
     title,


### PR DESCRIPTION
Part of the final-polish sprint — **PR 4 of 5** (SEO pass).

## Scope note
Item #4's example H1 ("Pressure Washing in Winter Garden, FL") is a **service×city** page — that combined route **doesn't exist** today (only `/services/[serviceType]` statewide + `/[city]`). Per our discussion this PR **enhances the existing pages now**; the new combined service×city surface is a **separate follow-up** you can greenlight later.

## Changes
- **Meta descriptions** (service + city generators) now include the exact line: *"Free to request quotes. No subscriptions. Pros pay $30 flat only when you accept."* City title/desc broadened from cleaning-only → home services.
- **City FAQ + FAQPage JSON-LD** (city pages had neither): a shared 4-question template — honest **general cost framing** (never a BOC price promise), the free/$30 model, how-it-works, and the independent-pro disclaimer — rendered visibly and as `FAQPage` structured data. Plus a short honest intro line in the hero.
- **noindex for zero-coverage city pages** (still `follow`, so the recruitment CTA stays discoverable) — pairs with PR #3.
- **Honesty fix:** the city hero no longer shows "0+ Cleaners" or a fabricated **4.5** rating when there are no pros — those stats render only with real coverage (the JSON-LD already gated `aggregateRating`).
- **Sitemap fix (real bug):** `app/sitemap.ts` pointed at a non-existent `/cleaners/*` tree (county/city/profile) and used wrong service slugs — mostly **404s**. Now emits real routes: `/services/{slug}` (13 real slugs), `/{city}` (34), `/cleaner/{slug}` (singular), plus `/how-pricing-works` and `/how-it-works`.

## Neutral-marketplace
No vetted/verified/guarantee/endorsement language (audited).

## Verification (screenshot in thread)
- `npm run build` ✅ (92 pages)
- `/sitemap.xml`: real routes present, **zero** `/cleaners/*` entries.
- **Orlando** (covered): meta line present, `FAQPage` JSON-LD present, FAQ section renders, indexable (no `noindex`).
- **Naples** (0 pros): `noindex` present, "0+ Cleaners"/fake rating **absent**.

No merge — cold review please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)