### PR TITLE
fix(seo): replace fabricated city-page LocalBusiness schema with Service

### DIFF
--- a/lib/seo/city-pages.ts
+++ b/lib/seo/city-pages.ts
@@ -63,18 +63,31 @@ export function generateCityMetadata(data: CityPageData): Metadata {
 }
 
 /**
- * Generate JSON-LD structured data for a city page
+ * Generate JSON-LD structured data for a city page.
+ *
+ * Boss of Clean is a neutral marketplace, not a LocalBusiness operating in each
+ * city, so a city page is modeled as a `Service` (home services scoped to the
+ * city) provided by the Organization — mirroring generateServiceSchema in
+ * lib/seo/json-ld.ts. No AggregateRating is emitted here: the only rating data
+ * that belongs in structured markup is a real per-pro review count, which lives
+ * on individual pro profiles (generateCleanerSchema), never a city-level count.
  */
 export function generateCityJsonLd(data: CityPageData): object {
-  const { city, cleanerCount, averageRating, topServices } = data;
+  const { city, topServices } = data;
 
   return {
     '@context': 'https://schema.org',
-    '@type': 'LocalBusiness',
-    '@id': `${SITE_URL}/${city.slug}`,
-    name: `Boss of Clean - ${city.name}`,
-    description: `Professional home services in ${city.name}, ${city.county} County, Florida. ${cleanerCount}+ home service professionals available.`,
+    '@type': 'Service',
+    '@id': `${SITE_URL}/${city.slug}#service`,
+    name: `Home Services in ${city.name}, Florida`,
+    description: `Connect with independent home service professionals in ${city.name}, ${city.county} County, Florida — cleaning, pressure washing, landscaping, pool care and more.`,
     url: `${SITE_URL}/${city.slug}`,
+    serviceType: topServices,
+    provider: {
+      '@type': 'Organization',
+      '@id': `${SITE_URL}/#organization`,
+      name: 'Boss of Clean',
+    },
     areaServed: {
       '@type': 'City',
       name: city.name,
@@ -87,15 +100,6 @@ export function generateCityJsonLd(data: CityPageData): object {
         },
       },
     },
-    aggregateRating: cleanerCount > 0 ? {
-      '@type': 'AggregateRating',
-      ratingValue: averageRating.toFixed(1),
-      reviewCount: cleanerCount,
-      bestRating: '5',
-      worstRating: '1',
-    } : undefined,
-    serviceType: topServices,
-    priceRange: '$$',
   };
 }
 


### PR DESCRIPTION
## P0 — Remove fabricated city-page review markup

**Do NOT merge — for Daniel's review.**

### Problem
`lib/seo/city-pages.ts → generateCityJsonLd()` emitted, for every one of 39 city pages:
- `@type: "LocalBusiness"` named `Boss of Clean - {City}` — a neutral marketplace is not a LocalBusiness operating in each city.
- an `AggregateRating` whose `reviewCount` was the **pro count** (`cleanerCount`), not real reviews, with `ratingValue` = averaged pro rating.

On a pre-launch, dummy-data site that is **fabricated `AggregateRating` markup** — a textbook Google structured-data manual-action trigger — and it contradicted the correct Organization/Service pattern already used in `lib/seo/json-ld.ts`.

### Fix
Return a `Service` scoped to the city, `provider` referencing the Organization `@id` (`/#organization`), `areaServed` = the City. **No `AggregateRating` at the city level.** Mirrors the existing `generateServiceSchema` pattern — no new pattern invented.

### Before
```jsonc
{ "@type": "LocalBusiness",
  "name": "Boss of Clean - Orlando",
  "aggregateRating": { "@type": "AggregateRating",
    "ratingValue": "4.8", "reviewCount": 12 /* = pro count, fabricated */ },
  "priceRange": "$$" }
```
### After
```jsonc
{ "@type": "Service",
  "@id": ".../orlando#service",
  "name": "Home Services in Orlando, Florida",
  "serviceType": ["House Cleaning", ...],
  "provider": { "@type": "Organization", "@id": ".../#organization" },
  "areaServed": { "@type": "City", "name": "Orlando", ... } }
```

### Scope note
The audit also flagged `generateCleanerListSchema` (json-ld.ts). On close read it — like `generateCleanerSchema` and `app/professionals/page.tsx` — derives `reviewCount` from real `cleaner.total_reviews`, guarded by truthiness. Those are **legitimate** and left intact. The city function was the only fabricated rating in the repo.

### Verification
- `grep AggregateRating` across `lib/seo` + `app/professionals`: 3 remaining, all fed by real `total_reviews`.
- `npx tsc --noEmit`: no errors in touched files. (`next build` ignores type errors — `ignoreBuildErrors: true`.)
- Callsite `app/[city]/page.tsx` unchanged; `CityPageData` interface unchanged.
- Brand-leak grep over `lib/seo`: clean.

Files changed: `lib/seo/city-pages.ts` (1 file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)