### PR TITLE
feat(analytics): wire GA4 via @next/third-parties GoogleAnalytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { Metadata, Viewport } from 'next';
 
 import { DM_Sans, Playfair_Display } from 'next/font/google';
+import { GoogleAnalytics } from '@next/third-parties/google';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { AuthProvider } from '@/lib/context/AuthContext';
@@ -79,6 +80,11 @@ export const metadata: Metadata = {
   },
 };
 
+// Boss of Clean's own GA4 property. Literal fallback keeps analytics firing
+// before the Netlify env var is set. This ID belongs to bossofclean.com only —
+// never reuse a sibling brand's measurement ID here.
+const GA_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-C50MQ6QYXF';
+
 export const viewport: Viewport = {
   themeColor: '#2563EB',
   width: 'device-width',
@@ -113,6 +119,7 @@ export default function RootLayout({
           <StickyMobileCta />
           <BocAssistantLoader />
         </AuthProvider>
+        <GoogleAnalytics gaId={GA_ID} />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@next/swc-wasm-nodejs": "13.5.1",
+        "@next/third-parties": "14.2.35",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-aspect-ratio": "^1.1.0",
@@ -477,6 +478,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.2.35.tgz",
+      "integrity": "sha512-dG1J+4uYungW1snGViN7tAVyfO0iz0zoB+sqsLMUo8kwR0NED2muLTMbOChmrliHhzOFj6ZpHfkvhy5NJjFvSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7740,6 +7754,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
     "@next/swc-wasm-nodejs": "13.5.1",
+    "@next/third-parties": "14.2.35",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-aspect-ratio": "^1.1.0",


### PR DESCRIPTION
## Wire GA4 (first analytics on Boss of Clean)

**Do NOT merge — for Daniel's review.**

### What
BOC had zero analytics. Installs GA4 the App Router way — the official `<GoogleAnalytics>` component from `@next/third-parties/google`, rendered in the root **server** layout. No manual `gtag` `<script>`/`<Head>`.

### Changes
- **`app/layout.tsx`**
  - `import { GoogleAnalytics } from '@next/third-parties/google'`
  - `const GA_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-C50MQ6QYXF'`
  - `<GoogleAnalytics gaId={GA_ID} />` inside `<body>`, after `</AuthProvider>`.
- **`package.json` / `package-lock.json`** — `@next/third-parties@14.2.35` (pinned exact; peer `next ^13.0.0 || ^14.0.0`, `react ^18.2.0` — compatible with our `next@13.5.11` / `react@18.2.0`).

### Measurement ID — BOC's own
`G-C50MQ6QYXF` is Boss of Clean's own GA4 property. **Not** SOTSVC (`G-94M7NCL7L6`) or TCE (`G-L8Y4RFB9GG`). Env override `NEXT_PUBLIC_GA_MEASUREMENT_ID` lets Netlify supply it without a code change; the literal fallback means tracking fires immediately even before that env var is set.

### Verification
- `app/layout.tsx` is a **server component** (no `'use client'`) → the GA snippet renders server-side, in the root layout — not client-injected into a random component. The `<GoogleAnalytics>` component handles the gtag script correctly.
- `npx tsc --noEmit`: the GA lines (import / `GA_ID` / component) produce **no** errors. The one error on `layout.tsx` (`'next' has no exported member 'Viewport'`, line 2) is **pre-existing** — it reproduces on `main` with this change stashed — and is unrelated to GA. Left untouched per surgical-changes rule; flagging it here. (`next build` ignores type errors anyway — `ignoreBuildErrors: true`.)
- Brand grep on touched files (`app/layout.tsx`, `package.json`, `package-lock.json`): zero hits for sotsvc / sonz / thunder / trustedcleaningexpert / sibling GA IDs.

### Netlify follow-up (post-merge, optional)
Set `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-C50MQ6QYXF` in Netlify env for explicitness; the fallback already covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)