### PR TITLE
fix(csp): allow GA4 in Content-Security-Policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,14 +15,14 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://www.googletagmanager.com",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "font-src 'self' https://fonts.gstatic.com",
-      "img-src 'self' data: blob: https://*.supabase.co https://*.supabase.in https://boc-scroll-assets.netlify.app",
+      "img-src 'self' data: blob: https://*.supabase.co https://*.supabase.in https://boc-scroll-assets.netlify.app https://www.google-analytics.com https://www.googletagmanager.com",
       // Scroll-world hero clips are served from a dedicated Netlify assets CDN
       // (kept out of the repo). Byte-range 206 verified.
       "media-src 'self' https://boc-scroll-assets.netlify.app",
-      "connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://api.stripe.com",
+      "connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://api.stripe.com https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com",
       "frame-src https://js.stripe.com https://hooks.stripe.com",
       "object-src 'none'",
       "base-uri 'self'",


### PR DESCRIPTION
## P0 — CSP was blocking GA4 (the only thing stopping analytics)

**Do NOT merge — for Daniel's review.**

### Root cause
GA4 wiring (PR #117) loads but sends nothing. `gtag.js` from `www.googletagmanager.com` was blocked by `script-src`, and GA's collection endpoints were absent from `connect-src` — so `config` queued in `dataLayer` and GA4 Realtime showed **0**. CSP is defined in `next.config.js` (`securityHeaders`), applied to `/(.*)`.

### Fix — extend 3 existing directives, drop nothing
| Directive | Added |
|---|---|
| `script-src` | `https://www.googletagmanager.com` |
| `connect-src` | `https://www.google-analytics.com` `https://region1.google-analytics.com` `https://www.googletagmanager.com` |
| `img-src` | `https://www.google-analytics.com` `https://www.googletagmanager.com` (pixel fallback) |

Every prior source is preserved — `'self'`, `'unsafe-inline'`, `'unsafe-eval'`, `https://js.stripe.com`, all Supabase hosts, `wss://`, `https://api.stripe.com`, `boc-scroll-assets.netlify.app`. No directive narrowed.

### Before → After (`script-src` / `connect-src` / `img-src`)
```
- script-src  'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com
+ script-src  'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://www.googletagmanager.com

- connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://api.stripe.com
+ connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://api.stripe.com https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com

- img-src     'self' data: blob: https://*.supabase.co https://*.supabase.in https://boc-scroll-assets.netlify.app
+ img-src     'self' data: blob: https://*.supabase.co https://*.supabase.in https://boc-scroll-assets.netlify.app https://www.google-analytics.com https://www.googletagmanager.com
```

### Verification
- `npx tsc --noEmit`: no errors in `next.config.js`.
- Before/after diffed against `origin/main`: Stripe + Supabase + scroll-assets sources all survive; only additions, no removals.
- Brand grep on touched file: zero hits.

Files changed: `next.config.js` (1 file). After merge + Netlify deploy, GA4 Realtime should register hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)