### PR TITLE
fix(auth): remove RLS-blocked pros writes from signup, seed ZIP server-side

### DIFF
--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -14,6 +14,7 @@ import { Loader2, Mail, CheckCircle, Eye, EyeOff } from 'lucide-react'
 import { resendVerificationEmail, canResendEmail, markEmailResent, getResendCooldownRemaining } from '@/lib/email/verification'
 import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton'
 import { recordUserTcpaConsent } from '@/lib/actions/tcpa'
+import { seedProServiceArea } from '@/lib/actions/pro-signup'
 import { normalizeToE164 } from '@/lib/phone'
 
 interface AuthFormProps {
@@ -157,10 +158,14 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
         }
 
         if (authData.user) {
-          // The handle_new_user DB trigger creates the users row automatically.
-          // Persist phone + full_name + TCPA consent via a service-role server
-          // action: the email isn't confirmed yet so the client has no session,
-          // and a direct client-side users UPDATE is blocked by RLS (DLD-576).
+          // The handle_new_user DB trigger creates the users row — and, for a
+          // 'cleaner' role, the pros row too — in the same transaction as the
+          // auth user. Persist phone + full_name + TCPA consent via a
+          // service-role server action: the email isn't confirmed yet so the
+          // client has no session, and a direct client-side users UPDATE is
+          // blocked by RLS (DLD-576).
+          let setupIssue: string | null = null
+
           const profileResult = await recordUserTcpaConsent(
             authData.user.id,
             navigator.userAgent,
@@ -169,94 +174,29 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
           if (!profileResult.ok) {
             // No more silent drops — surface it (account still exists).
             console.error('Failed to persist signup contact info', profileResult.error)
-            setError('Your account was created, but we could not save your phone number. Please add it in your profile settings.')
+            setupIssue = 'your phone number'
           }
 
-          // If cleaner, update the trigger-created cleaners profile with form data
-          if (role === 'cleaner') {
-            // Wait a moment for trigger to complete, then update with full details
-            const { data: cleanerData } = await supabase
-              .from('pros')
-              .select('id')
-              .eq('user_id', authData.user.id)
-              .single()
-
-            // Track whether the cleaner's business details / service area saved.
-            // These run after the account is created; a silent failure here means
-            // the pro won't match leads in their ZIP and never knows why.
-            let cleanerSetupFailed = false
-
-            if (cleanerData) {
-              // Update with business details from the signup form
-              const { error: bizErr } = await supabase
-                .from('pros')
-                .update({
-                  business_name: businessName || fullName || email.split('@')[0],
-                })
-                .eq('id', cleanerData.id)
-              if (bizErr) cleanerSetupFailed = true
-
-              // Seed initial service area if zip provided
-              if (zipCode) {
-                const { data: zipData } = await supabase
-                  .from('florida_zipcodes')
-                  .select('city, county')
-                  .eq('zip_code', zipCode)
-                  .single()
-
-                if (zipData) {
-                  const { error: areaErr } = await supabase
-                    .from('service_areas')
-                    .insert({
-                      cleaner_id: cleanerData.id,
-                      zip_code: zipCode,
-                      city: zipData.city,
-                      county: zipData.county,
-                      is_primary: true,
-                    })
-                  if (areaErr) cleanerSetupFailed = true
-                }
-              }
-            } else {
-              // Fallback: trigger may not have fired yet, create cleaner profile directly
-              const { data: newCleaner, error: cleanerError } = await supabase
-                .from('pros')
-                .insert({
-                  user_id: authData.user.id,
-                  business_name: businessName || fullName || email.split('@')[0],
-                  approval_status: 'pending',
-                })
-                .select('id')
-                .single()
-
-              if (cleanerError) cleanerSetupFailed = true
-
-              if (!cleanerError && newCleaner && zipCode) {
-                const { data: zipData } = await supabase
-                  .from('florida_zipcodes')
-                  .select('city, county')
-                  .eq('zip_code', zipCode)
-                  .single()
-
-                if (zipData) {
-                  const { error: areaErr } = await supabase
-                    .from('service_areas')
-                    .insert({
-                      cleaner_id: newCleaner.id,
-                      zip_code: zipCode,
-                      city: zipData.city,
-                      county: zipData.county,
-                      is_primary: true,
-                    })
-                  if (areaErr) cleanerSetupFailed = true
-                }
-              }
+          // Seed the pro's signup ZIP. The pros row and its business_name are
+          // already set by the trigger from the signUp metadata above, so there
+          // is nothing to create or re-write here — only the service area, via
+          // a service-role server action for the same no-session reason as the
+          // TCPA write. Writes pros.service_areas, the store search reads.
+          if (role === 'cleaner' && zipCode) {
+            const areaResult = await seedProServiceArea(authData.user.id, zipCode)
+            if (!areaResult.ok) {
+              // A missing service area means the pro never surfaces in a ZIP
+              // search and has no way to know why — don't let it fail silently.
+              console.error('Failed to seed pro service area', areaResult.error)
+              setupIssue = setupIssue
+                ? `${setupIssue} or your service ZIP code`
+                : 'your service ZIP code'
             }
+          }
 
-            if (cleanerSetupFailed) {
-              // Account exists; be honest that business setup didn't fully save.
-              setError('Your account was created, but we couldn\'t save all your business details. Please finish setting up your business name and service area in your profile after you verify your email.')
-            }
+          if (setupIssue) {
+            // Account exists; be honest about what didn't save.
+            setError(`Your account was created, but we could not save ${setupIssue}. You can add it in your profile after you verify your email.`)
           }
           // Notify admin of new signup (fire and forget - don't block signup flow)
           fetch('/api/admin/signup-notification', {

--- a/lib/actions/pro-signup.ts
+++ b/lib/actions/pro-signup.ts
@@ -1,0 +1,60 @@
+'use server';
+
+import { createServiceRoleClient } from '@/lib/supabase/service-role';
+
+/**
+ * Seed a pro's signup ZIP into pros.service_areas via the service role.
+ *
+ * At signup the email is not yet confirmed, so the client has no session and
+ * auth.uid() is NULL — the pros_insert / pros_update RLS policies both require
+ * auth.uid() = user_id, so any client-side write here fails. Same reason
+ * recordUserTcpaConsent exists (DLD-576).
+ *
+ * pros.service_areas (text[]) is the canonical store: it is what search reads
+ * (searchService.ts) and what onboarding writes. public.service_areas is NOT
+ * written here — see DLD-599.
+ *
+ * Appends; never overwrites. The pros row already exists (created by the
+ * handle_new_user trigger in the same transaction as the auth user).
+ */
+export async function seedProServiceArea(
+  userId: string,
+  zipCode: string
+): Promise<{ ok: boolean; error?: string }> {
+  if (!/^\d{5}$/.test(zipCode)) {
+    return { ok: false, error: 'Invalid ZIP code' };
+  }
+
+  const supabase = createServiceRoleClient();
+
+  // Only seed ZIPs we actually serve — keeps junk out of the search index.
+  const { data: zip } = await supabase
+    .from('florida_zipcodes')
+    .select('zip_code')
+    .eq('zip_code', zipCode)
+    .maybeSingle();
+
+  if (!zip) {
+    return { ok: false, error: 'ZIP code is outside our Florida service area' };
+  }
+
+  const { data: pro, error: readError } = await supabase
+    .from('pros')
+    .select('id, service_areas')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (readError) return { ok: false, error: readError.message };
+  if (!pro) return { ok: false, error: 'Pro profile not found' };
+
+  const existing: string[] = pro.service_areas ?? [];
+  if (existing.includes(zipCode)) return { ok: true };
+
+  const { error: writeError } = await supabase
+    .from('pros')
+    .update({ service_areas: [...existing, zipCode] })
+    .eq('id', pro.id);
+
+  if (writeError) return { ok: false, error: writeError.message };
+  return { ok: true };
+}


### PR DESCRIPTION
## The bug

Every email/password pro signup showed **"we couldn't save all your business details"** — on every signup, always. Three client-side writes in the signup path could never succeed.

At signup the email is unconfirmed, so the client has no session and `auth.uid()` is NULL:

1. **`pros` select** (`AuthForm.tsx:178-182`) — filtered by `pros_select`, which requires `auth.uid() = user_id` or `approval_status = 'approved'`. The trigger writes `'pending'`, so it always returned null.
2. **Fallback insert** (`:222-230`) — every signup fell into it, and `pros_insert` always rejected it for the same `auth.uid()` reason.
3. **ZIP seed** — blocked by RLS, *and* pointed at `public.service_areas`, which nothing reads.

The `business_name` update never ran either.

## Why the pros row existed anyway

`handle_new_user()` is `SECURITY DEFINER` and creates the pros row (via the `cleaners` view) in the **same transaction** as the auth user. Confirmed against production: 7 of 8 rows share `created_at` with their `auth.users` row to the microsecond. Nothing was ever missing — the client code was checking for a row it had no permission to see.

## The fix

- Deleted the blocked select, the fallback insert, and the `public.service_areas` write.
- ZIP now seeds **`pros.service_areas`** (text[]) — the store search actually reads (`searchService.ts:108,148`) and onboarding writes — via a new service-role server action, mirroring `recordUserTcpaConsent` (DLD-576). Appends, never overwrites.
- Dropped the `business_name` update: the trigger already computes the identical value from `signUp` metadata, so it was a no-op round trip.
- Consolidated the phone-failure and ZIP-failure banners. A ZIP failure used to clobber the phone-failure message and the pro never learned the phone hadn't saved. Both surface now.
- Fixed the inverted comments claiming the trigger doesn't create the pros row.

**RLS is correct and untouched.** No migration, no policy change, no trigger change. The client code was wrong, not the database.

## Scope

Net −85 lines in `AuthForm.tsx`, +59 in `lib/actions/pro-signup.ts`.

Not touched: `handle_new_user`, any RLS policy, any migration, `public.service_areas`, `match_lead_pros()`, Stripe, the webhook, tier enforcement, the locked trust bar, `Footer.tsx`.

## Verification

- `npm run build` passes
- `npx tsc --noEmit` — no errors in either changed file (note: `next.config.js` sets `ignoreBuildErrors`, so tsc was run directly)
- Branding leak check clean
- One pre-existing lint error remains at `AuthForm.tsx:534` (unescaped apostrophe). It was at :594 before; this diff only shifted it. Left alone.

**Not yet manually tested** — needs a real signup with an email round trip, and production Supabase is read-only per project rules. Suggested test plan: signup with a valid Florida ZIP → verify `pros.service_areas` contains it and no banner shows; then a non-Florida ZIP → banner names the ZIP, account still created.

## Filed separately during this work

- **DLD-599** — decide the canonical service-area store (blocks DLD-600)
- **DLD-600** — CRITICAL: broadcast lead matching is nonfunctional. `match_lead_pros()` inner-joins a 0-row table and is never called; `quote-service.ts:129,284` queries `cleaner_service_areas`, which does not exist in the DB, and both call sites swallow the error
- **DLD-601** — backfill service areas for 3 pros with none
- **DLD-602** — dead scaffolding cleanup

Backfill is explicitly **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrdHqCSwZuNzBU537FL41