### PR TITLE
fix(quote-request): match broadcast leads against pros.service_areas [DLD-600]

### DIFF
--- a/app/quote-request/actions.ts
+++ b/app/quote-request/actions.ts
@@ -145,39 +145,42 @@ export async function submitQuoteRequest(
     // ============================================
     // STEP 2: Find matching approved pros
     // ============================================
-    // Match by: approved cleaners whose service_areas include this zip code
-    // Fallback: if no service_areas match, try cleaners whose user zip matches
+    // Match by: approved pros whose pros.service_areas array covers this zip.
+    // DLD-599: pros.service_areas text[] is the canonical store. The former
+    // public.service_areas table is retired — it never had a writer, so this
+    // query always returned zero rows and every broadcast silently fell
+    // through to the all-approved fallback below.
     let matchedPros: { cleaner_id: string; user_id: string; email: string; business_name: string; business_phone: string | null }[] = [];
+    let matchStrategy: 'geo' | 'fallback' = 'geo';
 
     try {
-      // Primary match: service_areas table (service-role: cross-customer read)
+      // Primary match: pros.service_areas (service-role: cross-customer read).
+      // Uses the idx_cleaners_service_areas_gin GIN index on pros.service_areas.
       const { data: areaMatches } = await adminSupabase
-        .from('service_areas')
-        .select('cleaner_id, cleaner:pros!inner(id, business_name, user_id, approval_status, business_phone, user:users!inner(email))')
-        .eq('zip_code', data.zip_code);
+        .from('pros')
+        .select('id, business_name, user_id, business_phone, user:users!inner(email)')
+        .contains('service_areas', [data.zip_code])
+        .eq('approval_status', 'approved');
 
       if (areaMatches && areaMatches.length > 0) {
-        matchedPros = areaMatches
-          .filter((m) => {
-            const cleaner = m.cleaner as Record<string, unknown>;
-            return cleaner?.approval_status === 'approved';
-          })
-          .map((m) => {
-            const cleaner = m.cleaner as Record<string, unknown>;
-            const user = cleaner.user as Record<string, unknown>;
-            return {
-              cleaner_id: cleaner.id as string,
-              user_id: cleaner.user_id as string,
-              email: user.email as string,
-              business_name: cleaner.business_name as string,
-              business_phone: (cleaner.business_phone as string) ?? null,
-            };
-          });
+        matchedPros = areaMatches.map((c) => {
+          const user = c.user as Record<string, unknown>;
+          return {
+            cleaner_id: c.id as string,
+            user_id: c.user_id as string,
+            email: user.email as string,
+            business_name: c.business_name as string,
+            business_phone: (c.business_phone as string) ?? null,
+          };
+        });
       }
 
-      // Fallback: if no service_areas match, find all approved cleaners
-      // (early stage — not many pros have set up service areas yet)
+      // Fallback: no pro covers this zip — broadcast to all approved pros.
+      // (early stage — coverage is sparse, so a geo miss must not mean the
+      // customer hears from nobody). Retire this once the geo/fallback ratio
+      // logged below shows coverage is dense enough.
       if (matchedPros.length === 0) {
+        matchStrategy = 'fallback';
         const { data: allApproved } = await adminSupabase
           .from('pros')
           .select('id, business_name, user_id, business_phone, user:users!inner(email)')
@@ -197,8 +200,12 @@ export async function submitQuoteRequest(
         }
       }
 
+      // matchStrategy distinguishes a real geo match from a blind all-approved
+      // broadcast. Track the ratio to decide when the fallback can be retired.
       logger.info('Pro matching complete', {
         function: 'submitQuoteRequest',
+        matchStrategy,
+        zipCode: data.zip_code,
         matchCount: matchedPros.length,
         quoteId: quote.id,
       });

--- a/lib/services/searchService.ts
+++ b/lib/services/searchService.ts
@@ -351,8 +351,7 @@ export class SearchService {
       .from('pros')
       .select(`
         *,
-        users!inner(full_name, phone, email, city, zip_code),
-        service_areas!left(zip_code, city, county, travel_fee)
+        users!inner(full_name, phone, email, city, zip_code)
       `)
       .eq('approval_status', 'approved')
       .eq('insurance_verified', true)
@@ -377,8 +376,7 @@ export class SearchService {
       .from('pros')
       .select(`
         *,
-        users!inner(full_name, phone, email, city, zip_code),
-        service_areas!left(zip_code, city, county, travel_fee)
+        users!inner(full_name, phone, email, city, zip_code)
       `)
       .eq('approval_status', 'approved')
       .eq('insurance_verified', true)


### PR DESCRIPTION
## ⚠️ Stacks on #121 — merge AFTER it

This PR is **based on `fix/signup-pros-rls-and-service-areas` (#121)**, not `main`. #121 touches `lib/actions/pro-signup.ts`, which writes the same store this PR reads.

**Do not merge this before #121.** Once #121 lands, this retargets to `main` cleanly.

---

## What was broken

Broadcast lead matching queried `public.service_areas` — a table with **0 rows and no writer anywhere in the codebase**. The query always returned nothing, so *every* broadcast silently fell through to the all-approved fallback and notified every approved pro regardless of geography.

This was not a dormant feature. `submitQuoteRequest` is live and wired to `app/quote-request/page.tsx:132`; production shows 4 broadcast quotes and 22 `new_lead` notifications already sent — all of them by the blind fallback.

## What changed

Per the DLD-599 decision, `pros.service_areas text[]` is canonical.

1. **`app/quote-request/actions.ts`** — primary matcher now queries `pros` with `.contains('service_areas', [zip])` and filters `approval_status` in SQL rather than post-hoc in JS. Downstream `matchedPros` shape is unchanged.
2. **Fallback retained by design.** Coverage is sparse (2 approved pros, 5 ZIPs); a geo miss must not mean the customer hears from nobody.
3. **Observability** — logs `matchStrategy` (`geo` | `fallback`) and `zipCode` alongside `matchCount`, so the geo/fallback ratio is measurable and the fallback can be retired on evidence.
4. **`lib/services/searchService.ts`** — removed two `service_areas!left(...)` embeds reading the same empty table (returned `[]` per pro).

## Index

`idx_cleaners_service_areas_gin` (`ON public.pros USING gin (service_areas)`) **exists** — it survived the `cleaners`→`pros` rename under a `_gin` suffix, so the drop at `23-fix-indexes.sql:11` (which targeted the old un-suffixed name) missed it. `.contains()` → `@>` is served by it. No migration needed.

Caveat: at 8 rows the planner will seqscan regardless. Index is present and correct, but not yet exercised under load.

## Verification

| gate | result |
|---|---|
| `npm run build` | ✅ passes |
| `tsc --noEmit` | 64 → **62** errors repo-wide, no new error class |
| branding / compliance scan | ✅ clean |

Behavior against production data (read-only):

| ZIP | geo matches | path taken |
|---|---|---|
| 32801, 32803, 32714 | 1 | `geo` |
| 32703, 33606, 34741 | 0 | `fallback` |

33606 correctly misses — a pro covers it but is `pending`, not `approved`.

The two remaining TS casts at L167/L191 are the pre-existing `as Record<string, unknown>` pattern used throughout this file; the rewrite removed one of the original three. Left as-is intentionally to match surrounding style.

## Deliberately out of scope

No migration. `public.service_areas`, `match_lead_pros()`, and the dead `lib/services/quote-service.ts` are all left in place — filed as **DLD-603** (drop empty table + `match_lead_pros`) and **DLD-604** (delete dead `quote-service.ts`).

Separately filed: **DLD-605** — `app/dashboard/pro/service-areas/page.tsx:128` discards per-ZIP travel fees on save while confirming success. Pre-existing, user-visible data loss, untouched here.

Untouched: `lib/stripe/*`, webhook, tier enforcement, `how-it-works` trust bar, `Footer.tsx`, `AuthForm.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrdHqCSwZuNzBU537FL41
