### PR TITLE
fix(quote-request): match broadcast leads against pros.service_areas [DLD-600]

### DIFF
--- a/app/quote-request/actions.ts
+++ b/app/quote-request/actions.ts
@@ -145,39 +145,42 @@ export async function submitQuoteRequest(
     // ============================================
     // STEP 2: Find matching approved pros
     // ============================================
-    // Match by: approved cleaners whose service_areas include this zip code
-    // Fallback: if no service_areas match, try cleaners whose user zip matches
+    // Match by: approved pros whose pros.service_areas array covers this zip.
+    // DLD-599: pros.service_areas text[] is the canonical store. The former
+    // public.service_areas table is retired — it never had a writer, so this
+    // query always returned zero rows and every broadcast silently fell
+    // through to the all-approved fallback below.
     let matchedPros: { cleaner_id: string; user_id: string; email: string; business_name: string; business_phone: string | null }[] = [];
+    let matchStrategy: 'geo' | 'fallback' = 'geo';
 
     try {
-      // Primary match: service_areas table (service-role: cross-customer read)
+      // Primary match: pros.service_areas (service-role: cross-customer read).
+      // Uses the idx_cleaners_service_areas_gin GIN index on pros.service_areas.
       const { data: areaMatches } = await adminSupabase
-        .from('service_areas')
-        .select('cleaner_id, cleaner:pros!inner(id, business_name, user_id, approval_status, business_phone, user:users!inner(email))')
-        .eq('zip_code', data.zip_code);
+        .from('pros')
+        .select('id, business_name, user_id, business_phone, user:users!inner(email)')
+        .contains('service_areas', [data.zip_code])
+        .eq('approval_status', 'approved');
 
       if (areaMatches && areaMatches.length > 0) {
-        matchedPros = areaMatches
-          .filter((m) => {
-            const cleaner = m.cleaner as Record<string, unknown>;
-            return cleaner?.approval_status === 'approved';
-          })
-          .map((m) => {
-            const cleaner = m.cleaner as Record<string, unknown>;
-            const user = cleaner.user as Record<string, unknown>;
-            return {
-              cleaner_id: cleaner.id as string,
-              user_id: cleaner.user_id as string,
-              email: user.email as string,
-              business_name: cleaner.business_name as string,
-              business_phone: (cleaner.business_phone as string) ?? null,
-            };
-          });
+        matchedPros = areaMatches.map((c) => {
+          const user = c.user as Record<string, unknown>;
+          return {
+            cleaner_id: c.id as string,
+            user_id: c.user_id as string,
+            email: user.email as string,
+            business_name: c.business_name as string,
+            business_phone: (c.business_phone as string) ?? null,
+          };
+        });
       }
 
-      // Fallback: if no service_areas match, find all approved cleaners
-      // (early stage — not many pros have set up service areas yet)
+      // Fallback: no pro covers this zip — broadcast to all approved pros.
+      // (early stage — coverage is sparse, so a geo miss must not mean the
+      // customer hears from nobody). Retire this once the geo/fallback ratio
+      // logged below shows coverage is dense enough.
       if (matchedPros.length === 0) {
+        matchStrategy = 'fallback';
         const { data: allApproved } = await adminSupabase
           .from('pros')
           .select('id, business_name, user_id, business_phone, user:users!inner(email)')
@@ -197,8 +200,12 @@ export async function submitQuoteRequest(
         }
       }
 
+      // matchStrategy distinguishes a real geo match from a blind all-approved
+      // broadcast. Track the ratio to decide when the fallback can be retired.
       logger.info('Pro matching complete', {
         function: 'submitQuoteRequest',
+        matchStrategy,
+        zipCode: data.zip_code,
         matchCount: matchedPros.length,
         quoteId: quote.id,
       });

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -14,6 +14,7 @@ import { Loader2, Mail, CheckCircle, Eye, EyeOff } from 'lucide-react'
 import { resendVerificationEmail, canResendEmail, markEmailResent, getResendCooldownRemaining } from '@/lib/email/verification'
 import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton'
 import { recordUserTcpaConsent } from '@/lib/actions/tcpa'
+import { seedProServiceArea } from '@/lib/actions/pro-signup'
 import { normalizeToE164 } from '@/lib/phone'
 
 interface AuthFormProps {
@@ -157,10 +158,14 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
         }
 
         if (authData.user) {
-          // The handle_new_user DB trigger creates the users row automatically.
-          // Persist phone + full_name + TCPA consent via a service-role server
-          // action: the email isn't confirmed yet so the client has no session,
-          // and a direct client-side users UPDATE is blocked by RLS (DLD-576).
+          // The handle_new_user DB trigger creates the users row — and, for a
+          // 'cleaner' role, the pros row too — in the same transaction as the
+          // auth user. Persist phone + full_name + TCPA consent via a
+          // service-role server action: the email isn't confirmed yet so the
+          // client has no session, and a direct client-side users UPDATE is
+          // blocked by RLS (DLD-576).
+          let setupIssue: string | null = null
+
           const profileResult = await recordUserTcpaConsent(
             authData.user.id,
             navigator.userAgent,
@@ -169,94 +174,29 @@ export function AuthForm({ mode, role = 'customer' }: AuthFormProps) {
           if (!profileResult.ok) {
             // No more silent drops — surface it (account still exists).
             console.error('Failed to persist signup contact info', profileResult.error)
-            setError('Your account was created, but we could not save your phone number. Please add it in your profile settings.')
+            setupIssue = 'your phone number'
           }
 
-          // If cleaner, update the trigger-created cleaners profile with form data
-          if (role === 'cleaner') {
-            // Wait a moment for trigger to complete, then update with full details
-            const { data: cleanerData } = await supabase
-              .from('pros')
-              .select('id')
-              .eq('user_id', authData.user.id)
-              .single()
-
-            // Track whether the cleaner's business details / service area saved.
-            // These run after the account is created; a silent failure here means
-            // the pro won't match leads in their ZIP and never knows why.
-            let cleanerSetupFailed = false
-
-            if (cleanerData) {
-              // Update with business details from the signup form
-              const { error: bizErr } = await supabase
-                .from('pros')
-                .update({
-                  business_name: businessName || fullName || email.split('@')[0],
-                })
-                .eq('id', cleanerData.id)
-              if (bizErr) cleanerSetupFailed = true
-
-              // Seed initial service area if zip provided
-              if (zipCode) {
-                const { data: zipData } = await supabase
-                  .from('florida_zipcodes')
-                  .select('city, county')
-                  .eq('zip_code', zipCode)
-                  .single()
-
-                if (zipData) {
-                  const { error: areaErr } = await supabase
-                    .from('service_areas')
-                    .insert({
-                      cleaner_id: cleanerData.id,
-                      zip_code: zipCode,
-                      city: zipData.city,
-                      county: zipData.county,
-                      is_primary: true,
-                    })
-                  if (areaErr) cleanerSetupFailed = true
-                }
-              }
-            } else {
-              // Fallback: trigger may not have fired yet, create cleaner profile directly
-              const { data: newCleaner, error: cleanerError } = await supabase
-                .from('pros')
-                .insert({
-                  user_id: authData.user.id,
-                  business_name: businessName || fullName || email.split('@')[0],
-                  approval_status: 'pending',
-                })
-                .select('id')
-                .single()
-
-              if (cleanerError) cleanerSetupFailed = true
-
-              if (!cleanerError && newCleaner && zipCode) {
-                const { data: zipData } = await supabase
-                  .from('florida_zipcodes')
-                  .select('city, county')
-                  .eq('zip_code', zipCode)
-                  .single()
-
-                if (zipData) {
-                  const { error: areaErr } = await supabase
-                    .from('service_areas')
-                    .insert({
-                      cleaner_id: newCleaner.id,
-                      zip_code: zipCode,
-                      city: zipData.city,
-                      county: zipData.county,
-                      is_primary: true,
-                    })
-                  if (areaErr) cleanerSetupFailed = true
-                }
-              }
+          // Seed the pro's signup ZIP. The pros row and its business_name are
+          // already set by the trigger from the signUp metadata above, so there
+          // is nothing to create or re-write here — only the service area, via
+          // a service-role server action for the same no-session reason as the
+          // TCPA write. Writes pros.service_areas, the store search reads.
+          if (role === 'cleaner' && zipCode) {
+            const areaResult = await seedProServiceArea(authData.user.id, zipCode)
+            if (!areaResult.ok) {
+              // A missing service area means the pro never surfaces in a ZIP
+              // search and has no way to know why — don't let it fail silently.
+              console.error('Failed to seed pro service area', areaResult.error)
+              setupIssue = setupIssue
+                ? `${setupIssue} or your service ZIP code`
+                : 'your service ZIP code'
             }
+          }
 
-            if (cleanerSetupFailed) {
-              // Account exists; be honest that business setup didn't fully save.
-              setError('Your account was created, but we couldn\'t save all your business details. Please finish setting up your business name and service area in your profile after you verify your email.')
-            }
+          if (setupIssue) {
+            // Account exists; be honest about what didn't save.
+            setError(`Your account was created, but we could not save ${setupIssue}. You can add it in your profile after you verify your email.`)
           }
           // Notify admin of new signup (fire and forget - don't block signup flow)
           fetch('/api/admin/signup-notification', {

--- a/lib/actions/pro-signup.ts
+++ b/lib/actions/pro-signup.ts
@@ -1,0 +1,60 @@
+'use server';
+
+import { createServiceRoleClient } from '@/lib/supabase/service-role';
+
+/**
+ * Seed a pro's signup ZIP into pros.service_areas via the service role.
+ *
+ * At signup the email is not yet confirmed, so the client has no session and
+ * auth.uid() is NULL — the pros_insert / pros_update RLS policies both require
+ * auth.uid() = user_id, so any client-side write here fails. Same reason
+ * recordUserTcpaConsent exists (DLD-576).
+ *
+ * pros.service_areas (text[]) is the canonical store: it is what search reads
+ * (searchService.ts) and what onboarding writes. public.service_areas is NOT
+ * written here — see DLD-599.
+ *
+ * Appends; never overwrites. The pros row already exists (created by the
+ * handle_new_user trigger in the same transaction as the auth user).
+ */
+export async function seedProServiceArea(
+  userId: string,
+  zipCode: string
+): Promise<{ ok: boolean; error?: string }> {
+  if (!/^\d{5}$/.test(zipCode)) {
+    return { ok: false, error: 'Invalid ZIP code' };
+  }
+
+  const supabase = createServiceRoleClient();
+
+  // Only seed ZIPs we actually serve — keeps junk out of the search index.
+  const { data: zip } = await supabase
+    .from('florida_zipcodes')
+    .select('zip_code')
+    .eq('zip_code', zipCode)
+    .maybeSingle();
+
+  if (!zip) {
+    return { ok: false, error: 'ZIP code is outside our Florida service area' };
+  }
+
+  const { data: pro, error: readError } = await supabase
+    .from('pros')
+    .select('id, service_areas')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (readError) return { ok: false, error: readError.message };
+  if (!pro) return { ok: false, error: 'Pro profile not found' };
+
+  const existing: string[] = pro.service_areas ?? [];
+  if (existing.includes(zipCode)) return { ok: true };
+
+  const { error: writeError } = await supabase
+    .from('pros')
+    .update({ service_areas: [...existing, zipCode] })
+    .eq('id', pro.id);
+
+  if (writeError) return { ok: false, error: writeError.message };
+  return { ok: true };
+}

--- a/lib/services/searchService.ts
+++ b/lib/services/searchService.ts
@@ -351,8 +351,7 @@ export class SearchService {
       .from('pros')
       .select(`
         *,
-        users!inner(full_name, phone, email, city, zip_code),
-        service_areas!left(zip_code, city, county, travel_fee)
+        users!inner(full_name, phone, email, city, zip_code)
       `)
       .eq('approval_status', 'approved')
       .eq('insurance_verified', true)
@@ -377,8 +376,7 @@ export class SearchService {
       .from('pros')
       .select(`
         *,
-        users!inner(full_name, phone, email, city, zip_code),
-        service_areas!left(zip_code, city, county, travel_fee)
+        users!inner(full_name, phone, email, city, zip_code)
       `)
       .eq('approval_status', 'approved')
       .eq('insurance_verified', true)


### PR DESCRIPTION
Supersedes #122, which GitHub auto-closed when its base branch (fix/signup-pros-rls-and-service-areas, PR #121) was deleted on merge.

DLD-599 resolved: pros.service_areas text[] is canonical. public.service_areas is retired (0 rows, no writer).

The broadcast matcher in app/quote-request/actions.ts queried the empty public.service_areas table, always returned zero rows, and silently fell through to broadcasting to every approved pro regardless of geography. This replaces that query with a .contains() against pros.service_areas.

- Primary match: pros.service_areas contains the ZIP, approval_status = approved
- All-approved fallback KEPT deliberately (coverage is sparse; a geo miss must not mean the customer hears from nobody)
- Added matchStrategy log field (geo vs fallback) so the ratio can be tracked to decide when the fallback can retire
- Removed two dead service_areas!left embeds in searchService.ts

Follow-ups filed separately: DLD-601 (backfill 3 pros with empty service_areas), DLD-603 (drop public.service_areas + match_lead_pros), DLD-604 (delete dead quote-service.ts), DLD-605 (travel fees discarded on save).