### PR TITLE
fix(home): align homepage copy with real gated lead flow

### DIFF
--- a/components/home/ForProfessionals.tsx
+++ b/components/home/ForProfessionals.tsx
@@ -5,7 +5,7 @@ const benefits = [
   { icon: UserPlus, text: 'Reach residential and commercial customers in your area' },
   { icon: FileCheck, text: 'Create your professional profile' },
   { icon: DollarSign, text: 'Set your own rates and availability' },
-  { icon: Calendar, text: 'No long-term contracts. No inflated lead fees.' },
+  { icon: Calendar, text: 'Choose a monthly membership or pay per lead you unlock' },
 ];
 
 export default function ForProfessionals() {

--- a/components/home/GrowthSection.tsx
+++ b/components/home/GrowthSection.tsx
@@ -105,8 +105,7 @@ export default function GrowthSection({ categoriesCount = 14 }: { categoriesCoun
   const stats = [
     { value: 67, suffix: '', label: 'Florida Counties Served', icon: MapPin },
     { value: categoriesCount, suffix: '+', label: 'Pro Service Categories', icon: TrendingUp },
-    // "0" is the whole point here — phrased so it reads as the benefit it is.
-    { value: 0, suffix: '%', label: 'Lead Fee Markup — pros keep what they earn', icon: Building2 },
+    { value: 0, suffix: '%', label: 'Cut of Your Job — pros set their own price', icon: Building2 },
   ];
 
   // Dot positions along the curve (approximate x,y for key points)

--- a/components/home/HowItWorks.tsx
+++ b/components/home/HowItWorks.tsx
@@ -10,14 +10,14 @@ const steps = [
   {
     number: '02',
     icon: Users,
-    title: 'Browse Local Pros',
-    description: 'See Florida pros in your area with profiles, services, and contact details.',
+    title: 'Get Quotes From Local Pros',
+    description: 'Florida pros serving your ZIP send you quotes. Comparing them is free for customers.',
   },
   {
     number: '03',
     icon: MessageCircle,
-    title: 'Connect Directly',
-    description: 'Reach out to the pro you choose. No middleman markup. No inflated lead fees.',
+    title: 'Choose Your Pro',
+    description: 'Accept the quote that fits. Your pro then gets your details and reaches out to schedule.',
   },
 ];
 

--- a/components/home/ValueProposition.tsx
+++ b/components/home/ValueProposition.tsx
@@ -18,8 +18,8 @@ const values = [
   },
   {
     icon: Handshake,
-    title: 'Direct, No Markup',
-    description: 'Connect directly with pros. No middleman markup. No inflated lead fees.',
+    title: 'Quotes Direct From Pros',
+    description: 'Pros quote you directly. You compare and choose who to work with.',
   },
 ];
 
@@ -36,7 +36,7 @@ export default function ValueProposition() {
             The Fair, Transparent Alternative to Thumbtack, Angi &amp; HomeAdvisor
           </h2>
           <p className="text-gray-500 text-lg">
-            No inflated lead fees. No middleman markup. Just direct connections between Floridians and the pros who serve them — residential and commercial.
+            Straightforward pricing and direct connections between Floridians and the pros who serve them — residential and commercial.
           </p>
         </div>
 


### PR DESCRIPTION
Homepage copy described a browse-and-contact-directly model. The real flow is: customer requests a quote → pros quote for free → customer accepts one quote → that pro pays a flat $30 to unlock the customer's contact info. Contact details are gated, so the old copy promised something the product does not do.

## Changes

**`components/home/HowItWorks.tsx`** — steps 02 and 03 rewritten.
- 02 `Browse Local Pros` → `Get Quotes From Local Pros`; no longer promises contact details.
- 03 `Connect Directly` → `Choose Your Pro`; no longer tells the customer to reach out to the pro. Object shape, icons, and number strings unchanged.

**`components/home/GrowthSection.tsx`** — third stat now reads `0% Cut of Your Job — pros set their own price`. The fee is flat regardless of job value, so Boss of Clean takes no percentage. Matches `app/how-pricing-works/page.tsx:42` and `app/terms/page.tsx:99`. `value` stays `0` so the count-up animation still works. Stats 1–2 and the floating-label array untouched.

**`components/home/ValueProposition.tsx`** — card title `Direct, No Markup` → `Quotes Direct From Pros`, and the subhead above the cards drops the same "no inflated lead fees / no middleman markup" framing so the section reads consistently.

**`components/home/ForProfessionals.tsx`** — benefit now names the real options: monthly membership or pay per lead unlocked.

## Scope notes

- The competitor claim on `ValueProposition.tsx:36` is intentionally **not** touched here — it belongs to the follow-up competitor-claims branch, which will rebase on main after this merges.
- Copy only. No pricing, Stripe, webhook, or tier-enforcement code touched. No migrations, no new imagery.

## Compliance

No banned trust words (vetted / verified / insured / guaranteed / bonded). No forward-looking pricing promises. No "no subscriptions" or "$30 is our only fee" claim — the three tiers are real. Claims describe the marketplace, not what pros are. Tagline untouched. Locked regions (`app/how-it-works/page.tsx:175-195`, `components/Footer.tsx`, `lib/stripe/*`, the webhook, `lib/seo/city-pages.ts`, `app/help/page.tsx:49`) untouched.

## Verification

`next.config.js` sets `eslint.ignoreDuringBuilds` and `typescript.ignoreBuildErrors`, so a local `npm run build` would not catch type or lint errors here — Netlify CI is the gate. Changes are string literals inside existing arrays; no shape or import changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrdHqCSwZuNzBU537FL41