### PR TITLE
fix(copy): remove competitor fee characterizations, keep the names

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -118,8 +118,8 @@ export default function AboutPage() {
             <p className="text-gray-600 text-lg leading-relaxed">
               We&apos;re building a platform that respects the residential &amp; commercial service pros
               who keep Florida homes and businesses running — cleaners, landscapers, handymen, pool techs,
-              pressure washers, and every skilled trade in between. No predatory lead fees.
-              No hidden costs. Just a fair marketplace where your work speaks for itself.
+              pressure washers, and every skilled trade in between. Flat, published lead fees.
+              No hidden costs. Just a marketplace where your work speaks for itself.
             </p>
             <Link
               href="/signup?role=cleaner"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ import {
 export const metadata: Metadata = {
   title: "Boss of Clean \u2014 Florida's Pro Service Marketplace",
   description:
-    "Florida's fair, transparent alternative to Thumbtack, Angi, and HomeAdvisor. Find local pros for cleaning, handyman work, HVAC, plumbing, electrical, pool service, landscaping, pressure washing, and every job your home or business needs. Free quotes. Direct connections. Purrfection is our Standard.",
+    "A Florida-built alternative to Thumbtack, Angi, and HomeAdvisor. Find local pros for cleaning, handyman work, HVAC, plumbing, electrical, pool service, landscaping, pressure washing, and every job your home or business needs. Free quotes. Pros set their own prices. Purrfection is our Standard.",
   keywords:
     'Florida home services, commercial cleaning Florida, office cleaning, commercial services, pro service marketplace, Thumbtack alternative, Angi alternative, HomeAdvisor alternative, house cleaning Florida, handyman Florida, pressure washing, pool cleaning, HVAC, plumbing, electrical, pest control, landscaping, gutter cleaning, junk removal, mobile car detailing, residential & commercial pros',
   alternates: {

--- a/app/professionals/page.tsx
+++ b/app/professionals/page.tsx
@@ -495,7 +495,7 @@ export default async function ProfessionalsPage({
             </h2>
             <p className="text-lg text-gray-300 mb-8 max-w-2xl mx-auto">
               Join Boss of Clean and connect with customers across Florida.
-              Fair pricing, no predatory lead fees, and a marketplace built
+              Flat, published lead fees and a marketplace built
               for real professionals.
             </p>
             <Link

--- a/components/home/GrowthSection.tsx
+++ b/components/home/GrowthSection.tsx
@@ -140,7 +140,7 @@ export default function GrowthSection({ categoriesCount = 14 }: { categoriesCoun
             <span className="text-brand-gold">Local</span> Pro Marketplace
           </h2>
           <p className="text-gray-400 text-lg max-w-2xl mx-auto leading-relaxed">
-            We&apos;re on a mission to connect every Florida homeowner and business with local pros for any clean, fix, or service — without the middleman markup.
+            We&apos;re on a mission to connect every Florida homeowner and business with local pros for any clean, fix, or service — with pros setting their own prices and keeping the full job.
           </p>
         </div>
 

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -78,7 +78,7 @@ export default function HeroSection({ services }: { services?: string[] }) {
 
             {/* Subheadline */}
             <p className="text-lg sm:text-xl text-gray-300 max-w-2xl mx-auto lg:mx-0 mb-10 leading-relaxed">
-              Florida&apos;s fair, transparent alternative to Thumbtack, Angi, and HomeAdvisor.
+              A Florida-built alternative to Thumbtack, Angi, and HomeAdvisor.
               Local pros for cleaning, handyman, HVAC, plumbing, electrical, pool service,
               and every job your home or business needs.
             </p>

--- a/components/home/TrustSection.tsx
+++ b/components/home/TrustSection.tsx
@@ -11,8 +11,9 @@ export default function TrustSection() {
         <p className="text-gray-500 text-lg leading-relaxed mb-4 max-w-3xl mx-auto">
           Boss of Clean is Florida&apos;s full-service pro marketplace — cleaning, handyman, pressure washing,
           HVAC, plumbing, electrical, pool service, landscaping, pest control, and every skilled trade in between.
-          We connect homeowners and businesses with independent pros across all 67 counties — without
-          the inflated lead fees and middleman markup of Thumbtack, Angi, or HomeAdvisor.
+          We connect homeowners and businesses with independent pros across all 67 counties — with pros paying
+          a flat fee to unlock a customer&apos;s contact info, never a cut of the job. A Florida alternative to
+          Thumbtack, Angi, or HomeAdvisor.
         </p>
         <p className="font-display text-xl text-brand-gold italic">
           &ldquo;Purrfection is our Standard&rdquo; &mdash; your one boss for any clean, fix, or service in Florida.

--- a/components/home/ValueProposition.tsx
+++ b/components/home/ValueProposition.tsx
@@ -33,7 +33,7 @@ export default function ValueProposition() {
             Why Boss of Clean
           </p>
           <h2 className="font-display text-3xl sm:text-4xl font-bold text-brand-dark mb-4">
-            The Fair, Transparent Alternative to Thumbtack, Angi &amp; HomeAdvisor
+            A Florida-Built Alternative to Thumbtack, Angi &amp; HomeAdvisor
           </h2>
           <p className="text-gray-500 text-lg">
             Straightforward pricing and direct connections between Floridians and the pros who serve them — residential and commercial.


### PR DESCRIPTION
Marketing copy characterized Thumbtack, Angi, and HomeAdvisor's fees and practices — "inflated lead fees", "middleman markup", "predatory lead fees" — and framed Boss of Clean as the "fair, transparent alternative", which implies those three are neither. **The names stay everywhere they appeared.** What goes is any claim about what *they* charge or how they operate. Copy now states what Boss of Clean charges and lets the reader draw the comparison.

## Changes

| File | Change |
|---|---|
| `components/home/TrustSection.tsx` | Names retained; fee characterization replaced with our own terms — pros pay a flat fee to unlock contact info, never a cut of the job |
| `components/home/ValueProposition.tsx` | Heading → `A Florida-Built Alternative to Thumbtack, Angi & HomeAdvisor` |
| `components/home/GrowthSection.tsx` | Mission line rephrased positively — pros set their own prices and keep the full job — instead of "without the middleman markup" |
| `app/about/page.tsx` | "No predatory lead fees" → "Flat, published lead fees" |
| `app/professionals/page.tsx` | "Fair pricing, no predatory lead fees" → "Flat, published lead fees" |
| `app/page.tsx` | Metadata description carried the same "fair, transparent alternative" phrasing — highest-visibility instance, it is what Google renders |
| `components/home/HeroSection.tsx` | Same phrasing fixed for consistency — **see note below** |

The `GrowthSection` line was rephrased rather than deleted: the claim is true (we take no percentage of the job, matching the `0% Cut of Your Job` stat from #124) and worth stating — just not as a negation of a competitor practice.

## Scope notes

**`HeroSection.tsx` is dead code.** `app/page.tsx` renders `ScrollWorldHero`, not `HeroSection`; the latter is reachable only through the `components/home/index.ts` barrel re-export and is imported by nothing. The edit here is not user-visible. Fixed anyway for consistency, but the file is a deletion candidate — tracked separately. `ScrollWorldHero.tsx`, the hero users actually see, was checked and contains no competitor names or claim language at all.

**SEO keyword strings left intact** — `app/page.tsx:22` and `app/pricing/layout.tsx:12-14` contain `Thumbtack alternative` / `Angi alternative` / `HomeAdvisor alternative`. Names plus "alternative", no characterization of fees or practices, and load-bearing for search.

**`app/about/page.tsx:70` deliberately unchanged** — reads "transparent pricing, fair lead fees". A claim about us with no comparative framing, so it implies nothing about anyone else.

**Pricing page untouched.** `app/pricing/page.tsx:123` contains a separate issue ("locked in at signup" — forward-looking language) that is scoped to the follow-up pricing PR, not this one.

## Verification

Repo-wide sweep returns **zero hits** for `inflated lead fees`, `predatory lead fees`, `middleman markup`, `no middleman`, and `fair, transparent alternative`. All three competitor names still present. No banned trust words (vetted / verified / insured / guaranteed / bonded) and no forward-looking pricing promises in the added lines. No "no subscriptions" or "only fee" claims — the Free / Basic / Pro tiers are real. Tagline `Purrfection is our Standard` intact. Branding-leak check clean. Locked regions untouched.

Copy only — no pricing, Stripe, webhook, or tier-enforcement code, no migrations, no new imagery. `next.config.js` ignores lint and TS errors at build, so Netlify CI is the gate; all changes are string literals with no shape or import changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrdHqCSwZuNzBU537FL41