### PR TITLE
fix(compliance): replace bare Insured badges with document-on-file wording

### DIFF
--- a/app/book/[cleanerId]/page.tsx
+++ b/app/book/[cleanerId]/page.tsx
@@ -293,10 +293,16 @@ export default function BookCleanerPage() {
                 {cleaner.insurance_verified && (
                   <span className="flex items-center gap-1">
                     <Shield className="h-4 w-4 text-blue-500" />
-                    Insured
+                    Insurance doc on file
                   </span>
                 )}
               </div>
+              {/* Credentials disclaimer — BOC is a neutral marketplace and does not verify pro-provided info */}
+              {cleaner.insurance_verified && (
+                <p className="mt-3 text-xs text-gray-500 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                  Information shown is provided by the pro and is not independently verified by Boss of Clean. Please confirm licensing and insurance directly with the pro before hiring.
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/app/dashboard/customer/favorites/page.tsx
+++ b/app/dashboard/customer/favorites/page.tsx
@@ -165,7 +165,7 @@ export default function CustomerFavoritesPage() {
                       {favorite.pro.insurance_verified && (
                         <span className="bg-blue-500 text-white text-xs px-2 py-1 rounded-full flex items-center gap-1">
                           <Shield className="h-3 w-3" />
-                          Insured
+                          Insurance doc on file
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
Two customer-facing surfaces rendered a bare trust claim directly from `pros.insurance_verified`. This brings both in line with the wording already live on the pro profile and directory.

- `app/book/[cleanerId]/page.tsx:296` — label → "Insurance doc on file", plus the verbatim credentials disclaimer copied from `app/cleaner/[slug]/page.tsx:334`
- `app/dashboard/customer/favorites/page.tsx:168` — label → "Insurance doc on file"

Gates, columns (`insurance_verified` / `license_verified` / `background_check`), and visual treatment are unchanged. No schema changes, no migrations, two files touched.

### Notes for review

**No screenshots — nothing renders to photograph.** No production pro currently has `insurance_verified = true` (0 of 9, verified read-only). Neither badge renders on either surface today, so the banned word was live in code but not visibly on screen.

**Favorites uses the fallback label, not `getCleanerBadges`.** That helper emits `documents_on_file` only when `evaluateHasDocuments(insurance_verified, license_verified)` is true — it requires both flags (`lib/services/badges.ts:105-106,126`). The favorites API select (`app/api/customer/favorites/route.ts:38`) and the card's type carry only `insurance_verified`. Routing through the helper would have meant editing a third file and silently changing the gate, so the one-word label change was used instead.

**Type check:** `tsc --noEmit` reports 58 errors on `main` and 58 on this branch — identical, all pre-existing in `lib/services/*`. Zero in either edited file.

Do not merge without review — merging to `main` auto-publishes to bossofclean.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uhCVrLSd3Tac4W36zTLGk