### PR TITLE
fix(compliance): propagate credentials disclaimer to remaining credential surfaces

### DIFF
--- a/app/dashboard/admin/components/approval-queue.tsx
+++ b/app/dashboard/admin/components/approval-queue.tsx
@@ -219,7 +219,7 @@ export function ApprovalQueue({ applications, onViewDetails }: ApprovalQueueProp
                     {cleaner.insurance_verified && (
                       <Badge variant="outline" className="text-green-600">
                         <CheckCircle className="h-3 w-3 mr-1" />
-                        Insurance Verified
+                        Insurance doc on file
                       </Badge>
                     )}
                     {cleaner.background_check && (

--- a/app/dashboard/customer/favorites/page.tsx
+++ b/app/dashboard/customer/favorites/page.tsx
@@ -122,6 +122,13 @@ export default function CustomerFavoritesPage() {
               </Link>
             </div>
           ) : (
+            <>
+            {/* Credentials disclaimer — shown only when a saved pro renders a credential label */}
+            {favorites.some((favorite) => favorite.pro.insurance_verified) && (
+              <p className="mb-6 text-xs text-gray-500 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                Information shown is provided by the pro and is not independently verified by Boss of Clean. Please confirm licensing and insurance directly with the pro before hiring.
+              </p>
+            )}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {favorites.map((favorite) => (
                 <div
@@ -238,6 +245,7 @@ export default function CustomerFavoritesPage() {
                 </div>
               ))}
             </div>
+            </>
           )}
         </div>
       </div>

--- a/app/professionals/page.tsx
+++ b/app/professionals/page.tsx
@@ -291,6 +291,13 @@ export default async function ProfessionalsPage({
             </div>
           </div>
 
+          {/* Credentials disclaimer — shown only when a listed pro renders a credential label */}
+          {pros.some((pro) => pro.insurance_verified) && (
+            <p className="mb-6 text-xs text-gray-500 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+              Information shown is provided by the pro and is not independently verified by Boss of Clean. Please confirm licensing and insurance directly with the pro before hiring.
+            </p>
+          )}
+
           {/* Pro Grid */}
           {pros.length > 0 ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/components/seo/ServiceTypeContent.tsx
+++ b/components/seo/ServiceTypeContent.tsx
@@ -154,6 +154,20 @@ export function ServiceTypeContent({
             </div>
           ) : cleaners.length > 0 ? (
             <>
+              {/* Credentials disclaimer — shown only when a listed card renders a credential
+                  label, via either the documents-on-file badge or the per-document list. */}
+              {cleaners.some(
+                (cleaner) =>
+                  (cleaner.insuranceVerified && cleaner.licenseVerified) ||
+                  (!cleaner.isCertified &&
+                    (cleaner.insuranceVerified ||
+                      cleaner.licenseVerified ||
+                      cleaner.backgroundCheckVerified))
+              ) && (
+                <p className="mb-6 text-xs text-gray-500 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                  Information shown is provided by the pro and is not independently verified by Boss of Clean. Please confirm licensing and insurance directly with the pro before hiring.
+                </p>
+              )}
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {cleaners.map((cleaner) => (
                   <CleanerCard


### PR DESCRIPTION
Labels were already compliant everywhere; the disclaimer that gives them context existed only on the pro profile. This adds it to the remaining surfaces that render a credential label, plus a one-word admin fix.

Disclaimer text is byte-identical to `app/cleaner/[slug]/page.tsx:334` on all four surfaces (verified by exact-string grep).

### Files touched

| File | Change |
|---|---|
| `app/professionals/page.tsx` | Disclaimer above the results grid, gated on `pros.some(p => p.insurance_verified)` |
| `app/dashboard/customer/favorites/page.tsx` | Disclaimer above the grid, gated on `favorites.some(f => f.pro.insurance_verified)` |
| `components/seo/ServiceTypeContent.tsx` | Disclaimer above the CleanerCard grid, gated on whether any card renders a credential label |
| `app/dashboard/admin/components/approval-queue.tsx:222` | Literal `Insurance Verified` → `Insurance doc on file` (admin-only; last rendered banned word in the codebase) |

Rendered once per page, never per card, and suppressed entirely on an empty or credential-free result set.

### Where CleanerCard actually renders — correction to the earlier sweep

`components/search/CleanerCard.tsx` renders on **exactly one surface**: service pages (`/services/[serviceType]`), via `app/services/[serviceType]/ServicePageClient.tsx:159` → `components/seo/ServiceTypeContent.tsx:159`. Putting the disclaimer in `ServiceTypeContent` covers every CleanerCard consumer in one place.

My earlier report claimed search results and city pages also render CleanerCard. That was wrong:

- **`/search`** renders `ProviderCard` via `SearchResultsGrid`, not `CleanerCard`. `ProviderCard` renders no credential labels at all — no disclaimer needed.
- **`/[city]`** renders its own inline card markup. It selects `insurance_verified` at line 124 but never renders it (dead select) — no credential label, no disclaimer needed.

So three pages needed the disclaimer, not five.

### Gate for the service-pages disclaimer

A CleanerCard can show a credential label through two independent paths, so the condition covers both:

- `CompactBadgeDisplay` renders the `documents_on_file` badge whenever `insuranceVerified && licenseVerified`, regardless of `isCertified`
- the per-document list at lines 197-213 renders only when `!isCertified`, on any single flag

Condition: `(ins && lic) || (!isCertified && (ins || lic || bg))`.

### Out of scope, deliberately untouched

`CleanerCard.tsx:197-213` hand-rolled badge block, `lib/services/badges.ts`, `evaluateHasDocuments`, all gate logic, `app/how-it-works/page.tsx`, and any schema. Collapsing the hand-rolled block into `getCleanerBadges` would change the gate from independent flags to requiring both `insurance_verified` AND `license_verified`, hiding badges from insurance-only pros — a product decision, not this PR.

### Verification

- `npm run build` passes
- `tsc --noEmit`: 58 errors on `main`, 58 on this branch — identical, all pre-existing in `lib/services/*`, zero in any touched file
- Banned-word scan across all four files: clean

Do not merge without review — merging to `main` auto-publishes to bossofclean.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uhCVrLSd3Tac4W36zTLGk