### PR TITLE
fix(services): match pros.services by enum dbValue (DLD-603 bug 1)

### DIFF
--- a/app/services/[serviceType]/ServicePageClient.tsx
+++ b/app/services/[serviceType]/ServicePageClient.tsx
@@ -76,7 +76,6 @@ export function ServicePageClient({ serviceType }: ServicePageClientProps) {
 
     try {
       // Build query to find cleaners offering this service type
-      // Match against the shortName which is used in the services array
       const query = supabase
         .from('pros')
         .select(
@@ -91,8 +90,6 @@ export function ServicePageClient({ serviceType }: ServicePageClientProps) {
         .order('average_rating', { ascending: false })
         .limit(PAGE_SIZE);
 
-      // The services column contains display names like "House Cleaning"
-      // We need to filter by the shortName
       const { data, count, error } = await query;
 
       if (error) {
@@ -102,24 +99,13 @@ export function ServicePageClient({ serviceType }: ServicePageClientProps) {
         return;
       }
 
-      // Filter cleaners who offer this service type
-      // Services are stored as display names in the database
-      const serviceNames = [
-        serviceType.shortName.toLowerCase(),
-        serviceType.name.toLowerCase(),
-        serviceType.dbValue.replace(/_/g, ' ').toLowerCase(),
-      ];
-
-      const filteredData = (data || []).filter((cleaner: CleanerData) => {
-        if (!cleaner.services || cleaner.services.length === 0) return false;
-        return cleaner.services.some((service) =>
-          serviceNames.some(
-            (name) =>
-              service.toLowerCase().includes(name) ||
-              name.includes(service.toLowerCase())
-          )
-        );
-      });
+      // Filter cleaners who offer this service type.
+      // pros.services stores the enum dbValues (e.g. "move_in_out"), so match
+      // the dbValue exactly — display-name fuzzy matching never matched
+      // underscored values (DLD-603 bug 1).
+      const filteredData = (data || []).filter((cleaner: CleanerData) =>
+        cleaner.services?.includes(serviceType.dbValue)
+      );
 
       const mappedCleaners = filteredData.map(mapCleanerToCardProps);
       setCleaners(mappedCleaners);


### PR DESCRIPTION
## Summary
- `/services/*` landing pages showed zero pros: `pros.services` stores enum dbValues (`move_in_out`, `residential`, …) but the client filter compared display names / space-separated strings, so underscored values never matched.
- Replaced the fuzzy display-name matching with an exact `serviceType.dbValue` membership check and removed the stale comments claiming services are stored as display names.

Verified against production data: all populated `pros.services` rows contain dbValues only.

Bug 2 (the anon-RLS-dead `users!inner` join) ships separately per ticket instruction.

**Do not merge — Board review.** DLD-603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)